### PR TITLE
[SPIR-V] Update to add_llvm_component_library

### DIFF
--- a/llvm/lib/Target/SPIRV/MCTargetDesc/CMakeLists.txt
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_llvm_library(LLVMSPIRVDesc
+add_llvm_component_library(LLVMSPIRVDesc
   SPIRVMCTargetDesc.cpp
   SPIRVAsmBackend.cpp
   SPIRVMCCodeEmitter.cpp

--- a/llvm/lib/Target/SPIRV/TargetInfo/CMakeLists.txt
+++ b/llvm/lib/Target/SPIRV/TargetInfo/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_llvm_library(LLVMSPIRVInfo
+add_llvm_component_library(LLVMSPIRVInfo
   SPIRVTargetInfo.cpp
   )


### PR DESCRIPTION
This fixes shared library builds after rebasing onto `ab411801b827
("[cmake] Explicitly mark libraries defined in lib/ as "Component
Libraries"", 2019-11-21).`