### PR TITLE
[SPIRV] Remove unecessary ELF text output from assembly output

### DIFF
--- a/llvm/lib/Target/SPIRV/MCTargetDesc/CMakeLists.txt
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_llvm_component_library(LLVMSPIRVDesc
   SPIRVMCTargetDesc.cpp
+  SPIRVTargetStreamer.cpp
   SPIRVAsmBackend.cpp
   SPIRVMCCodeEmitter.cpp
   SPIRVObjectTargetWriter.cpp

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCTargetDesc.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCTargetDesc.cpp
@@ -14,9 +14,8 @@
 
 #include "MCTargetDesc/SPIRVMCAsmInfo.h"
 #include "MCTargetDesc/SPIRVMCTargetDesc.h"
-
 #include "InstPrinter/SPIRVInstPrinter.h"
-
+#include "SPIRVTargetStreamer.h"
 #include "llvm/MC/MCInstrAnalysis.h"
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCRegisterInfo.h"
@@ -58,6 +57,12 @@ createSPIRVMCStreamer(const Triple &T, MCContext &Ctx,
                       std::unique_ptr<MCCodeEmitter> &&Emitter, bool RelaxAll) {
   return createSPIRVStreamer(Ctx, std::move(MAB), std::move(OW),
                              std::move(Emitter), RelaxAll);
+}
+
+static MCTargetStreamer *createTargetAsmStreamer(MCStreamer &S,
+                                                 formatted_raw_ostream &,
+                                                 MCInstPrinter *, bool) {
+  return new SPIRVTargetStreamer(S);
 }
 
 static MCInstPrinter *createSPIRVMCInstPrinter(const Triple &T,
@@ -113,5 +118,8 @@ extern "C" void LLVMInitializeSPIRVTargetMC() {
 
     // Register the ASM Backend
     TargetRegistry::RegisterMCAsmBackend(*T, createSPIRVAsmBackend);
+
+    // Register the AsmTargetStreamer
+    TargetRegistry::RegisterAsmTargetStreamer(*T, createTargetAsmStreamer);
   }
 }

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVTargetStreamer.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVTargetStreamer.cpp
@@ -1,0 +1,17 @@
+//=====- SPIRVTargetStreamer.cpp - SPIRVTargetStreamer class ------------=====//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file implements the SPIRVTargetStreamer class.
+//
+//===----------------------------------------------------------------------===//
+
+#include "SPIRVTargetStreamer.h"
+
+using namespace llvm;
+SPIRVTargetStreamer::SPIRVTargetStreamer(MCStreamer &S) : MCTargetStreamer(S) {}
+SPIRVTargetStreamer::~SPIRVTargetStreamer() = default;

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVTargetStreamer.h
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVTargetStreamer.h
@@ -1,0 +1,26 @@
+//=====-- SPIRVTargetStreamer.h - SPIRVTargetStreamer Target Streamer ------*- C++ -*--=====//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LIB_TARGET_SPIRV_MCTARGETDESC_SPIRVTARGETSTREAMER_H
+#define LIB_TARGET_SPIRV_MCTARGETDESC_SPIRVTARGETSTREAMER_H
+
+#include "llvm/MC/MCStreamer.h"
+namespace llvm {
+class MCSection;
+class SPIRVTargetStreamer : public MCTargetStreamer{
+public:
+  SPIRVTargetStreamer(MCStreamer &S);
+  ~SPIRVTargetStreamer() override;
+
+  void changeSection(const MCSection *CurSection, MCSection *Section,
+                       const MCExpr *SubSection, raw_ostream &OS) override{};
+
+};
+}
+
+#endif /* LIB_TARGET_SPIRV_MCTARGETDESC_SPIRVTARGETSTREAMER_H_ */

--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -12,6 +12,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "InstPrinter/SPIRVInstPrinter.h"
+#include "llvm/CodeGen/TargetLoweringObjectFileImpl.h"
 #include "SPIRV.h"
 #include "SPIRVInstrInfo.h"
 #include "SPIRVMCInstLower.h"
@@ -48,14 +49,20 @@ public:
   void emitInstruction(const MachineInstr *MI) override;
 
   // TODO: consider if these are necessary
-  // void emitFunctionHeader() override {}
   void emitFunctionEntryLabel() override {};
+  void emitFunctionHeader() override;
+  void emitFunctionBodyStart() override {};
   void emitBasicBlockStart(const MachineBasicBlock &MBB) override {}
   void emitBasicBlockEnd(const MachineBasicBlock &MBB) override {}
-  // void emitGlobalVariable(const GlobalVariable *GV) override {}
+  void emitGlobalVariable(const GlobalVariable *GV) override {}
 };
 } // namespace
 
+void SPIRVAsmPrinter::emitFunctionHeader() {
+  const Function &F = MF->getFunction();
+  auto section = getObjFileLowering().SectionForGlobal(&F, TM);
+  MF->setSection(section);
+}
 
 void SPIRVAsmPrinter::printOperand(const MachineInstr *MI, int OpNum,
                                    raw_ostream &O) {


### PR DESCRIPTION
SPIRV doesn't require flags like .text and .functionName in the assembly
format. This patch introduces measures to suppress that output.