### PR TITLE
[SPIR-V] add missed OpBitReverse support

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -147,6 +147,9 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
   // getActionDefinitionsBuilder({G_AND, G_OR, G_XOR})
   //     .legalFor(allScalarsAndVectors);
 
+  getActionDefinitionsBuilder(G_BITREVERSE)
+      .legalFor(allFloatScalarsAndVectors);
+
   getActionDefinitionsBuilder(G_FMA)
       .legalFor(allFloatScalarsAndVectors);
 


### PR DESCRIPTION
This patch adds missed OpBitReverse support and partly fixes #11 (fails on G_BITREVERSE).