### PR TITLE
[SPIR-V] fix G_STORE/G_LOAD legalization

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -130,11 +130,8 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
   getActionDefinitionsBuilder(G_ADDRSPACE_CAST)
       .legalForCartesianProduct(allPtrs, allPtrs);
 
-  getActionDefinitionsBuilder(G_LOAD)
-      .legalForCartesianProduct(allValues, allPtrs);
-
-  getActionDefinitionsBuilder(G_STORE)
-      .legalForCartesianProduct(allValues, allPtrs);
+  getActionDefinitionsBuilder({G_LOAD, G_STORE})
+      .legalIf(typeInSet(1, allPtrs));
 
   // getActionDefinitionsBuilder(
   //     {G_ADD, G_SUB, G_MUL, G_SDIV, G_UDIV, G_SREM, G_UREM})


### PR DESCRIPTION
llc compilation failed on transcoding/extract_insert_value.ll with "unable to legalize instruction: G_STORE" (see #11, G_LOAD also crashed the test) since the instructions was not legal for composite types. This patch fixes it. 