### PR TITLE
[SPIR-V] add isNoopAddrSpaceCast, fix typo in literal-struct.ll test

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.h
@@ -38,6 +38,10 @@ public:
   TargetLoweringObjectFile *getObjFileLowering() const override {
     return TLOF.get();
   }
+
+  bool isNoopAddrSpaceCast(unsigned SrcAS, unsigned DestAS) const override {
+    return true;
+  }
 };
 } // namespace llvm
 

--- a/llvm/test/CodeGen/SPIRV/literal-struct.ll
+++ b/llvm/test/CodeGen/SPIRV/literal-struct.ll
@@ -14,7 +14,7 @@
 ; RUN: llc -O0 -global-isel %s -o - | FileCheck %s
 
 ; CHECK: %[[Int:[0-9]+]] = OpTypeInt 32 0
-; CHECK: %[[Int8:[0-9]+]] = TypeInt 8 0
+; CHECK: %[[Int8:[0-9]+]] = OpTypeInt 8 0
 ; CHECK: %[[Int8Ptr:[0-9]+]] = OpTypePointer Generic %[[Int8]]
 ; CHECK: %[[StructType:[0-9]+]] = OpTypeStruct %[[Int]] %[[Int]] %[[Int8Ptr]]
 


### PR DESCRIPTION
llc failed on literal-struct.ll with the following message: `Unsupported expression in static initializer: addrspacecast (i8* bitcast (void (i8 addrspace(4)*)* @__foo_block_invoke to i8*) to i8 addrspace(4)*)` . Adding isNoopAddrSpaceCast() implementation in  SPIRVTargetMachine fixes it and generate asm similar to trabslator's one.

Also a small typo was fixed in literal-struct.ll test.

After the fix, the test fails with missed OpConstantComposite:
```
literal-struct.ll:27:10: error: CHECK: expected string not found in input
; CHECK: OpConstantComposite %[[StructType]]
```
