### PR TITLE
[SPIR-V] add missed Int64Atomics capability

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
@@ -173,7 +173,7 @@ void SPIRVSubtarget::initAvailableCapabilities(const Triple &TT) {
     addCaps(availableCaps,
             {Addresses, Float16Buffer, Int16, Int8, Kernel, Linkage, Vector16});
     if (openCLFullProfile) {
-      addCaps(availableCaps, {Int64});
+      addCaps(availableCaps, {Int64, Int64Atomics});
     }
     if (openCLImageSupport) {
       addCaps(availableCaps, {ImageBasic, LiteralSampler, Image1D,


### PR DESCRIPTION
Missed OpCapability Int64Atomics was added. Two tests (capability-Int64Atomics.ll, capability-Int64Atomics-store.ll) passed with this patch.