### PR TITLE
[SPIR-V] fix error in OpBranch insertion

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVBlockLabeler.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBlockLabeler.cpp
@@ -130,7 +130,8 @@ bool SPIRVBlockLabeler::runOnMachineFunction(MachineFunction &MF) {
     }
 
     // Add an unconditional branch if the block has no explicit terminator
-    if (!MBB.getLastNonDebugInstr()->isTerminator()) {
+    // and is not the last one.
+    if (!MBB.getLastNonDebugInstr()->isTerminator() && MBB.getNextNode()) {
       MIRBuilder.setMBB(MBB); // Insert at end of block
       auto MIB = MIRBuilder.buildInstr(OpBranch).addMBB(MBB.getNextNode());
       branches.push_back(MIB);


### PR DESCRIPTION
Small fix in SPIRVBlockLabeler.cpp. The last block does not always have a terminator instruction.