### PR TITLE
[SPIR-V] support SPIR-V builtin types

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
@@ -256,7 +256,7 @@ static void hoistGlobalOps(MachineIRBuilder &MetaBuilder,
   for (auto *MI : ToRemove)
     // If we have two builtin IR types that correspond to the same SPIR-V type,
     // current MI may be already erased, so check it before the erase.
-    if (MI->getParent())
+    if (MI && MI->getParent())
       MI->eraseFromParent();
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
@@ -254,7 +254,10 @@ static void hoistGlobalOps(MachineIRBuilder &MetaBuilder,
   }
 
   for (auto *MI : ToRemove)
-    MI->eraseFromParent();
+    // If we have two builtin IR types that correspond to the same SPIR-V type,
+    // current MI may be already erased, so check it before the erase.
+    if (MI->getParent())
+      MI->eraseFromParent();
 }
 
 // we need this specialization as

--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
@@ -42,6 +42,17 @@ class SPIRVTypeRegistry {
 
   DenseMap<SPIRVType *, const Type *> SPIRVToLLVMType;
 
+  // Builtin types may be represented in two ways while translating to SPIR-V:
+  // in OpenCL form and in SPIR-V form. We have to keep only one type for such
+  // pairs so check any builtin type for existance in the map before emitting
+  // it to SPIR-V. The map contains a vector of SPIR-V builtin types already
+  // emitted for a given type opcode.
+  DenseMap<unsigned int, SmallVector<SPIRVType*>> BuiltinTypeMap;
+
+  // Look for an equivalent of the newType in the map. Return the equivalent
+  // if it's found, otherwise insert newType to the map and return the type.
+  SPIRVType *checkBuiltinTypeMap(SPIRVType *newType);
+
   // Number of bits pointers and size_t integers require.
   const unsigned int pointerSize;
 
@@ -174,6 +185,14 @@ private:
   SPIRVType *generateOpenCLOpaqueType(const StructType *Ty,
                                       MachineIRBuilder &MIRBuilder,
                                       AQ::AccessQualifier aq = AQ::ReadWrite);
+
+  SPIRVType *handleSPIRVBuiltin(const StructType *Ty,
+                                MachineIRBuilder &MIRBuilder,
+                                AQ::AccessQualifier aq);
+
+  SPIRVType *generateSPIRVOpaqueType(const StructType *Ty,
+                                     MachineIRBuilder &MIRBuilder,
+                                     AQ::AccessQualifier aq = AQ::ReadWrite);
 
   Register buildConstantI32(uint32_t val, MachineIRBuilder &MIRBuilder,
                             SPIRVTypeRegistry *TR);


### PR DESCRIPTION
This patch adds basic support for SPIR-V builtin types. This also adds the technique of operating with two IR types that should correspond to one SPIR-V type.

The first thing fixes spirv.Queue.ll test, the second avoids image_store.ll degradation.