### PR TITLE
[SPIR-V] support buffer dim and arrayed in OpecnCL builtin image type…

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
@@ -479,10 +479,15 @@ SPIRVType *SPIRVTypeRegistry::generateOpenCLOpaqueType(const StructType *Ty,
     char dimC = TypeName[strlen("image")];
     if (dimC >= '1' && dimC <= '3') {
       auto dim = dimC == '1' ? DIM_1D : dimC == '2' ? DIM_2D : DIM_3D;
+      unsigned int arrayed = 0;
+      if (TypeName.contains("buffer"))
+        dim = DIM_Buffer;
+      if (TypeName.contains("array"))
+        arrayed = 1;
       auto *VoidTy = getOrCreateSPIRVType(
           Type::getVoidTy(MIRBuilder.getMF().getFunction().getContext()),
           MIRBuilder);
-      return getOpTypeImage(MIRBuilder, VoidTy, dim, 0, 0, 0, 0,
+      return getOpTypeImage(MIRBuilder, VoidTy, dim, 0, arrayed, 0, 0,
                             ImageFormat::Unknown, accessQual);
     }
   } else if (TypeName.startswith("sampler_t")) {

--- a/llvm/test/CodeGen/SPIRV/transcoding/cl-types.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/cl-types.ll
@@ -23,8 +23,8 @@
 ; CHECK-SPIRV-DAG: OpCapability Sampled1D
 ; CHECK-SPIRV-DAG: OpCapability SampledBuffer
 ; CHECK-SPIRV-DAG: %[[VOID:[0-9]+]] = OpTypeVoid
-; CHECK-SPIRV-DAG: %[[PIPE_RD:[0-9]+]] = OpTypePipe 0
-; CHECK-SPIRV-DAG: %[[PIPE_WR:[0-9]+]] = OpTypePipe 1
+; CHECK-SPIRV-DAG: %[[PIPE_RD:[0-9]+]] = OpTypePipe ReadOnly
+; CHECK-SPIRV-DAG: %[[PIPE_WR:[0-9]+]] = OpTypePipe WriteOnly
 ; CHECK-SPIRV-DAG: %[[IMG1D_RD:[0-9]+]] = OpTypeImage %[[VOID]] 1D 0 0 0 0 Unknown ReadOnly
 ; CHECK-SPIRV-DAG: %[[IMG2D_RD:[0-9]+]] = OpTypeImage %[[VOID]] 2D 0 0 0 0 Unknown ReadOnly
 ; CHECK-SPIRV-DAG: %[[IMG3D_RD:[0-9]+]] = OpTypeImage %[[VOID]] 3D 0 0 0 0 Unknown ReadOnly
@@ -35,7 +35,7 @@
 ; CHECK-SPIRV-DAG: %[[SAMP:[0-9]+]] = OpTypeSampler
 ; CHECK-SPIRV-DAG: %[[SAMPIMG:[0-9]+]] = OpTypeSampledImage %[[IMG2D_RD]]
 
-; CHECK-SPIRV: %[[SAMP_CONST:[0-9]+]] = OpConstantSampler %[[SAMP]] 0 0 1
+; CHECK-SPIRV: %[[SAMP_CONST:[0-9]+]] = OpConstantSampler %[[SAMP]] None 0 Linear
 
 ; ModuleID = 'cl-types.cl'
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"


### PR DESCRIPTION
The patch adds buffer dim and arrayed literal support for OpecnCL builtin image type. This fixes llc wrong output on image_dim.ll and partly on transcoding/cl-types.ll.

Also it fixes errors in transcoding/cl-types.ll.