### PR TITLE
[SPIR-V] fix regression on image_decl_func_arg.ll

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
@@ -471,20 +471,22 @@ SPIRVType *SPIRVTypeRegistry::getOpTypeByOpcode(MachineIRBuilder &MIRBuilder,
 }
 
 SPIRVType *SPIRVTypeRegistry::checkBuiltinTypeMap(SPIRVType *newType) {
-  auto t = BuiltinTypeMap.find(newType->getOpcode());
+  auto t = BuiltinTypeMap.find(newType->getMF());
   if (t != BuiltinTypeMap.end()) {
-    SmallVector<SPIRVType*> types = t->second;
-    for (auto type : types) {
-      if (type->isIdenticalTo(*newType,
-                              MachineInstr::MICheckType::IgnoreDefs)) {
-        if (newType->getMF() == type->getMF())
+    auto tt = t->second.find(newType->getOpcode());
+    if (tt != t->second.end()) {
+      SmallVector<SPIRVType*> types = tt->second;
+      for (auto type : types) {
+        if (type->isIdenticalTo(*newType,
+                                MachineInstr::MICheckType::IgnoreDefs)) {
           const_cast<llvm::MachineInstr*>(newType)->eraseFromParent();
-        return type;
+          return type;
+        }
       }
     }
   }
   // It's new builtin type, insert it to the map.
-  BuiltinTypeMap[newType->getOpcode()].push_back(newType);
+  BuiltinTypeMap[newType->getMF()][newType->getOpcode()].push_back(newType);
   return newType;
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
@@ -477,7 +477,8 @@ SPIRVType *SPIRVTypeRegistry::checkBuiltinTypeMap(SPIRVType *newType) {
     for (auto type : types) {
       if (type->isIdenticalTo(*newType,
                               MachineInstr::MICheckType::IgnoreDefs)) {
-        const_cast<llvm::MachineInstr*>(newType)->eraseFromParent();
+        if (newType->getMF() == type->getMF())
+          const_cast<llvm::MachineInstr*>(newType)->eraseFromParent();
         return type;
       }
     }

--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
@@ -47,7 +47,8 @@ class SPIRVTypeRegistry {
   // pairs so check any builtin type for existance in the map before emitting
   // it to SPIR-V. The map contains a vector of SPIR-V builtin types already
   // emitted for a given type opcode.
-  DenseMap<unsigned int, SmallVector<SPIRVType*>> BuiltinTypeMap;
+  DenseMap<const MachineFunction *,
+           DenseMap<unsigned int, SmallVector<SPIRVType*>>> BuiltinTypeMap;
 
   // Look for an equivalent of the newType in the map. Return the equivalent
   // if it's found, otherwise insert newType to the map and return the type.


### PR DESCRIPTION
The patch fixes the regression on image_decl_func_arg.ll test after de30720620e4f04385aa32fba516c9a45f51552a.