### PR TITLE
[SPIR-V] add processing of global unreferenced variables

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVAddRequirementsPass.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAddRequirementsPass.cpp
@@ -50,9 +50,9 @@ public:
 } // namespace
 
 // Add the all the requirements needed for the given instruction.
-static void addInstrRequirements(const MachineInstr &MI,
-                                 SPIRVRequirementHandler &reqs,
-                                 const SPIRVSubtarget &ST);
+void addInstrRequirements(const MachineInstr &MI,
+                          SPIRVRequirementHandler &reqs,
+                          const SPIRVSubtarget &ST);
 
 // Insert a deduplicated list of all OpCapability and OpExtension instructions
 // required for MF.
@@ -172,9 +172,9 @@ static void addOpTypeImageReqs(const MachineInstr &MI,
   }
 }
 
-static void addInstrRequirements(const MachineInstr &MI,
-                                 SPIRVRequirementHandler &reqs,
-                                 const SPIRVSubtarget &ST) {
+void addInstrRequirements(const MachineInstr &MI,
+                          SPIRVRequirementHandler &reqs,
+                          const SPIRVSubtarget &ST) {
   using namespace Capability;
   switch (MI.getOpcode()) {
   case SPIRV::OpMemoryModel: {

--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
@@ -194,10 +194,11 @@ private:
   SPIRVType *generateSPIRVOpaqueType(const StructType *Ty,
                                      MachineIRBuilder &MIRBuilder,
                                      AQ::AccessQualifier aq = AQ::ReadWrite);
-
-  Register buildConstantI32(uint32_t val, MachineIRBuilder &MIRBuilder,
-                            SPIRVTypeRegistry *TR);
 public:
+  Register buildConstantInt(uint64_t val, MachineIRBuilder &MIRBuilder,
+                            SPIRVType *spvType = nullptr);
+  Register buildConstantFP(APFloat val, MachineIRBuilder &MIRBuilder,
+                           SPIRVType *spvType = nullptr);
   // convenient helpers for getting types
   // w/ check for duplicates
   SPIRVType *getOrCreateSPIRVIntegerType(unsigned BitWidth,


### PR DESCRIPTION
This patch add some processing of global unreferenced variables that were just skipped before. Now types, constants, OpDecorates, OpNames and OpVariables are created for them. The patch partly fixes #34, 4 tests are expected to pass.