### PR TITLE
[SPIR-V] implement atomic_cmpxchg, atomic_work_item_fence, atomic_load_explicit builtins

### DIFF
--- a/llvm/test/CodeGen/SPIRV/transcoding/OpenCL/atomic_cmpxchg.cl
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpenCL/atomic_cmpxchg.cl
@@ -22,19 +22,19 @@ __kernel void test_atomic_cmpxchg(__global int *p, int cmp, int val) {
 // translator applies some default memory order for it and therefore, constants
 // below include a bit more information than original source
 //
-// 0x1 Device
-// CHECK-SPIRV-DAG: %[[DEVICE_SCOPE:[0-9]+]] = OpConstant %[[UINT]] 1
+// 0x2 Workgroup
+// CHECK-SPIRV-DAG: %[[SCOPE:[0-9]+]] = OpConstant %[[UINT]] 2
 //
-// 0x10 SequentiallyConsistent
+// 0x0 Relaxed
 // TODO: do we need CrossWorkgroupMemory here as well?
-// CHECK-SPIRV-DAG: %[[SEQ_CST:[0-9]+]] = OpConstant %[[UINT]] 16
+// CHECK-SPIRV-DAG: %[[CST:[0-9]+]] = OpConstant %[[UINT]] 0
 //
 // CHECK-SPIRV: %[[TEST]] = OpFunction %{{[0-9]+}}
 // CHECK-SPIRV: %[[PTR:[0-9]+]] = OpFunctionParameter %[[UINT_PTR]]
 // CHECK-SPIRV: %[[CMP:[0-9]+]] = OpFunctionParameter %[[UINT]]
 // CHECK-SPIRV: %[[VAL:[0-9]+]] = OpFunctionParameter %[[UINT]]
-// CHECK-SPIRV: %{{[0-9]+}} = OpAtomicCompareExchange %[[UINT]] %[[PTR]] %[[DEVICE_SCOPE]] %[[SEQ_CST]] %[[SEQ_CST]] %[[VAL]] %[[CMP]]
-// CHECK-SPIRV: %{{[0-9]+}} = OpAtomicCompareExchange %[[UINT]] %[[PTR]] %[[DEVICE_SCOPE]] %[[SEQ_CST]] %[[SEQ_CST]] %[[VAL]] %[[CMP]]
+// CHECK-SPIRV: %{{[0-9]+}} = OpAtomicCompareExchange %[[UINT]] %[[PTR]] %[[SCOPE]] %[[CST]] %[[CST]] %[[VAL]] %[[CMP]]
+// CHECK-SPIRV: %{{[0-9]+}} = OpAtomicCompareExchange %[[UINT]] %[[PTR]] %[[SCOPE]] %[[CST]] %[[CST]] %[[VAL]] %[[CMP]]
 
 // References:
 // [1]: https://www.khronos.org/registry/OpenCL/sdk/2.0/docs/man/xhtml/atomic_cmpxchg.html

--- a/llvm/test/CodeGen/SPIRV/transcoding/memory_access.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/memory_access.ll
@@ -1,19 +1,18 @@
 ; RUN: llc -O0 -global-isel %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
-; FIXME: Fix, what to do with 3, 7, 6? "Volatile|Aligned"?
 ; CHECK-SPIRV-NOT: OpStore %{{[0-9]+}} %{{[0-9]+}} Volatile Aligned 8
-; CHECK-SPIRV: OpStore %{{[0-9]+}} %{{[0-9]+}} 3 8
+; CHECK-SPIRV: OpStore %{{[0-9]+}} %{{[0-9]+}} Volatile|Aligned 8
 ; CHECK-SPIRV-NOT: %{{[0-9]+}} = OpLoad %{{[0-9]+}} %{{[0-9]+}} Volatile Aligned 8
-; CHECK-SPIRV: %{{[0-9]+}} = OpLoad %{{[0-9]+}} %{{[0-9]+}} 3 8
+; CHECK-SPIRV: %{{[0-9]+}} = OpLoad %{{[0-9]+}} %{{[0-9]+}} Volatile|Aligned 8
 ; CHECK-SPIRV: %{{[0-9]+}} = OpLoad %{{[0-9]+}} %{{[0-9]+}} Aligned 4
 ; CHECK-SPIRV-NOT: %{{[0-9]+}} = OpLoad %{{[0-9]+}} %{{[0-9]+}} Volatile Aligned 8
-; CHECK-SPIRV: %{{[0-9]+}} = OpLoad %{{[0-9]+}} %{{[0-9]+}} 3 8
+; CHECK-SPIRV: %{{[0-9]+}} = OpLoad %{{[0-9]+}} %{{[0-9]+}} Volatile|Aligned 8
 ; CHECK-SPIRV-NOT: %{{[0-9]+}} = OpLoad %{{[0-9]+}} %{{[0-9]+}} Volatile Aligned 0
-; CHECK-SPIRV: %{{[0-9]+}} = OpLoad %{{[0-9]+}} %{{[0-9]+}} 3 8
+; CHECK-SPIRV: %{{[0-9]+}} = OpLoad %{{[0-9]+}} %{{[0-9]+}} Volatile|Aligned 8
 ; CHECK-SPIRV-NOT: %{{[0-9]+}} = OpLoad %{{[0-9]+}} %{{[0-9]+}} Volatile Aligned 8
-; CHECK-SPIRV: %{{[0-9]+}} = OpLoad %{{[0-9]+}} %{{[0-9]+}} 7 8
+; CHECK-SPIRV: %{{[0-9]+}} = OpLoad %{{[0-9]+}} %{{[0-9]+}} Volatile|Aligned|Nontemporal 8
 ; CHECK-SPIRV-NOT: OpStore %{{[0-9]+}} %{{[0-9]+}} Aligned 4
-; CHECK-SPIRV: OpStore %{{[0-9]+}} %{{[0-9]+}} 6 4
+; CHECK-SPIRV: OpStore %{{[0-9]+}} %{{[0-9]+}} Aligned|Nontemporal 4
 ; CHECK-SPIRV-NOT: OpStore %{{[0-9]+}} %{{[0-9]+}} Aligned 0
 ; CHECK-SPIRV: OpStore %{{[0-9]+}} %{{[0-9]+}}
 


### PR DESCRIPTION
This change implements atomic_cmpxchg, atomic_work_item_fence, atomic_load_explicit builtins as it's done in Translator (atomic_load_explicit is implemented partly). Also it corrects 2 tests.