### PR TITLE
[SPIR-V] build more consts using DT, correct some errors in atomics

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
@@ -709,6 +709,9 @@ static bool genAtomicCmpXchg(MachineIRBuilder &MIRBuilder, Register resVReg,
   assert(TR->isScalarOfType(desired, OpTypeInt));
 
   SPIRVType *spvObjectPtrTy = TR->getSPIRVTypeForVReg(objectPtr);
+  assert(spvObjectPtrTy->getOperand(2).isReg() && "SPIRV type is expected");
+  SPIRVType *spvObjectTy = MRI->getVRegDef(
+      spvObjectPtrTy->getOperand(2).getReg());
   auto storageClass = static_cast<StorageClass::StorageClass>(
       spvObjectPtrTy->getOperand(1).getImm());
   auto memSemStorage = getMemSemanticsForStorageClass(storageClass);
@@ -756,7 +759,7 @@ static bool genAtomicCmpXchg(MachineIRBuilder &MIRBuilder, Register resVReg,
   TR->assignSPIRVTypeToVReg(spvDesiredTy, tmp, MIRBuilder);
   auto MIB = MIRBuilder.buildInstr(OpAtomicCompareExchange)
                  .addDef(tmp)
-                 .addUse(TR->getSPIRVTypeID(retType))
+                 .addUse(TR->getSPIRVTypeID(spvObjectTy))
                  .addUse(objectPtr)
                  .addUse(scopeReg)
                  .addUse(memSemEqualReg)
@@ -764,7 +767,7 @@ static bool genAtomicCmpXchg(MachineIRBuilder &MIRBuilder, Register resVReg,
                  .addUse(desired)
                  .addUse(expected);
   if (!isCmpxchg) {
-    MIRBuilder.buildInstr(OpStore).addUse(expected).addUse(tmp);
+    MIRBuilder.buildInstr(OpStore).addUse(expectedArg).addUse(tmp);
     MIRBuilder.buildICmp(CmpInst::ICMP_EQ, resVReg, tmp, expected);
   }
   return TR->constrainRegOperands(MIB);
@@ -779,7 +782,7 @@ static bool genAtomicRMW(Register resVReg, const SPIRVType *resType,
   auto I32Ty = TR->getOrCreateSPIRVIntegerType(32, MIRBuilder);
 
   Register scopeReg;
-  auto scope = Scope::Device;
+  auto scope = Scope::Workgroup;
   if (OrigArgs.size() >= 4) {
     assert(OrigArgs.size() == 4 && "Extra args for explicit atomic RMW");
     auto clScope = static_cast<CLMemScope>(getIConstVal(OrigArgs[5], MRI));
@@ -788,13 +791,13 @@ static bool genAtomicRMW(Register resVReg, const SPIRVType *resType,
       scopeReg = OrigArgs[5];
   }
   if (!scopeReg.isValid())
-    scopeReg = buildIConstant(scope, I32Ty, MIRBuilder, TR);
+    scopeReg = TR->buildConstantInt(scope, MIRBuilder, I32Ty);
 
   auto ptr = OrigArgs[0];
   auto scSem = getMemSemanticsForStorageClass(TR->getPointerStorageClass(ptr));
 
   Register memSemReg;
-  auto memSem = MemorySemantics::SequentiallyConsistent | scSem;
+  unsigned memSem = MemorySemantics::None;
   if (OrigArgs.size() >= 3) {
     auto memOrd = static_cast<CLMemOrder>(getIConstVal(OrigArgs[2], MRI));
     memSem = getSPIRVMemSemantics(memOrd) | scSem;
@@ -802,7 +805,7 @@ static bool genAtomicRMW(Register resVReg, const SPIRVType *resType,
       memSemReg = OrigArgs[3];
   }
   if (!memSemReg.isValid())
-    memSemReg = buildIConstant(memSem, I32Ty, MIRBuilder, TR);
+    memSemReg = TR->buildConstantInt(memSem, MIRBuilder, I32Ty);
 
   auto MIB = MIRBuilder.buildInstr(RMWOpcode)
                  .addDef(resVReg)

--- a/llvm/test/CodeGen/SPIRV/AtomicCompareExchange_cl20.ll
+++ b/llvm/test/CodeGen/SPIRV/AtomicCompareExchange_cl20.ll
@@ -61,7 +61,8 @@ entry:
 ; CHECK: %[[Value:[0-9]+]] = OpLoad %[[int]] %[[desired_addr]]
 ; CHECK: %[[ComparatorWeak:[0-9]+]] = OpLoad %[[int]] %[[exp]]
   %call2 = call spir_func zeroext i1 @_Z28atomic_compare_exchange_weakPVU3AS4U7_AtomiciPU3AS4ii(i32 addrspace(4)* %4, i32 addrspace(4)* %5, i32 %6)
-; CHECK-NEXT: %[[Result:[0-9]+]] = OpAtomicCompareExchangeWeak %[[int]] %[[Pointer]] %[[DeviceScope]] %[[SequentiallyConsistent_MS]] %[[SequentiallyConsistent_MS]] %[[Value]] %[[ComparatorWeak]]
+; OpAtomicCompareExchangeWeak is depricate, use OpAtomicCompareExchange
+; CHECK-NEXT: %[[Result:[0-9]+]] = OpAtomicCompareExchange %[[int]] %[[Pointer]] %[[DeviceScope]] %[[SequentiallyConsistent_MS]] %[[SequentiallyConsistent_MS]] %[[Value]] %[[ComparatorWeak]]
 ; CHECK-NEXT: OpStore %[[exp]] %[[Result]]
 ; CHECK-NEXT: %[[CallRes:[0-9]+]] = OpIEqual %[[bool]] %[[Result]] %[[ComparatorWeak]]
 ; CHECK-NOT: %[[Result]]

--- a/llvm/test/CodeGen/SPIRV/instructions/atomic.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/atomic.ll
@@ -16,7 +16,7 @@ target triple = "spirv32-unknown-unknown"
 ; Device scope is encoded with constant 1
 ; CHECK-DAG: [[SCOPE:%.*]] = OpConstant [[I32Ty]] 1
 ; "monotonic" maps to the relaxed memory semantics, encoded with constant 0
-; CHECK-DAG: [[RELAXED:%.*]] = OpConstant [[I32Ty]] 0
+; CHECK-DAG: [[RELAXED:%.*]] = OpConstantNull [[I32Ty]]
 
 ; CHECK: [[ADD]] = OpFunction [[I32Ty]]
 ; CHECK-NEXT: [[A:%.*]] = OpFunctionParameter


### PR DESCRIPTION
This patch makes more constants using DT (to avoid duplication and apply hoisting) in SPIRVInstructionSelector.cpp and SPIRVOpenCLBIFs.cpp (genAtomicRMW). Also it corrects OpAtomicCompareExchange and AtomicRMW generation to be the same as generated by the translator.
Two tests are also corrected (AtomicCompareExchange_cl20.ll, instructions/atomic.ll).
Two lit tests are expected to pass (AtomicCompareExchange_cl20.ll, transcoding/OpenCL/atomic_legacy.cl).