### PR TITLE
[SPIR-V] fix different errors in read_image builtin implementation

### DIFF
--- a/llvm/lib/Target/SPIRV/InstPrinter/SPIRVInstPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/InstPrinter/SPIRVInstPrinter.cpp
@@ -146,6 +146,7 @@ void SPIRVInstPrinter::printInst(const MCInst *MI, uint64_t Address,
         case SPIRV::OpImageSparseDrefGather:
         case SPIRV::OpImageSparseRead:
         case SPIRV::OpImageSampleFootprintNV:
+          OS << ' ';
           printImageOperand(MI, firstVariableIndex, OS);
           printRemainingVariableOps(MI, numFixedOps + 1, OS);
           break;

--- a/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
@@ -464,7 +464,6 @@ static bool genReadImageMSAA(MachineIRBuilder &MIRBuilder, Register resVReg,
   return TR->constrainRegOperands(MIB);
 }
 
-
 static bool genReadImage(MachineIRBuilder &MIRBuilder, Register resVReg,
                          SPIRVType *retType,
                          const SmallVectorImpl<Register> &OrigArgs,
@@ -1074,6 +1073,7 @@ bool llvm::generateOpenCLBuiltinCall(const StringRef demangledName,
                                      const SmallVectorImpl<Register> &args,
                                      SPIRVTypeRegistry *TR) {
   LLVM_DEBUG(dbgs() << "Generating OpenCL Builtin: " << demangledName << "\n");
+
   SPIRVType *retTy = nullptr;
   if (OrigRetTy && !OrigRetTy->isVoidTy())
     retTy = TR->assignTypeToVReg(OrigRetTy, OrigRet, MIRBuilder);

--- a/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
@@ -401,18 +401,21 @@ static bool genSampledReadImage(MachineIRBuilder &MIRBuilder, Register resVReg,
                                 SPIRVType *retType,
                                 const SmallVectorImpl<Register> &OrigArgs,
                                 SPIRVTypeRegistry *TR) {
-
+  assert(OrigArgs.size() > 2);
   const auto MRI = MIRBuilder.getMRI();
 
   Register image = OrigArgs[0];
   Register sampler = OrigArgs[1];
 
   if (!TR->isScalarOfType(OrigArgs[1], SPIRV::OpTypeSampler)) {
-    auto sampMask = getLiteralValueForConstant(OrigArgs[1], MRI);
-    Register res;
-    sampler = buildSamplerLiteral(sampMask, res,
-                                  TR->getSPIRVTypeForVReg(sampler),
-                                  MIRBuilder, TR);
+    MachineInstr *samplerInstr = MRI->getVRegDef(sampler);
+    if (samplerInstr->getOperand(1).isCImm()) {
+      auto sampMask = getLiteralValueForConstant(OrigArgs[1], MRI);
+      Register res;
+      sampler = buildSamplerLiteral(sampMask, res,
+                                    TR->getSPIRVTypeForVReg(sampler),
+                                    MIRBuilder, TR);
+    }
   }
 
   Register sampledImage = buildOpSampledImage(image, sampler, MIRBuilder, TR);
@@ -420,16 +423,47 @@ static bool genSampledReadImage(MachineIRBuilder &MIRBuilder, Register resVReg,
   Register coord = OrigArgs[2];
   Register lod = TR->buildConstantFP(APFloat::getZero(APFloat::IEEEsingle()),
                                      MIRBuilder);
+  // OpImageSampleExplicitLod always returns 4-element vector.
+  SPIRVType *tmpType = retType;
+  if (tmpType->getOpcode() != SPIRV::OpTypeVector)
+    tmpType = TR->getOrCreateSPIRVVectorType(retType, 4, MIRBuilder);
+  auto llt = LLT::scalar(TR->getScalarOrVectorBitWidth(tmpType));
+  Register tmpReg = MRI->createGenericVirtualRegister(llt);
+  TR->assignSPIRVTypeToVReg(tmpType, tmpReg, MIRBuilder);
 
   auto MIB = MIRBuilder.buildInstr(SPIRV::OpImageSampleExplicitLod)
-                 .addDef(resVReg)
-                 .addUse(TR->getSPIRVTypeID(retType))
+                 .addDef(tmpReg)
+                 .addUse(TR->getSPIRVTypeID(tmpType))
                  .addUse(sampledImage)
                  .addUse(coord)
                  .addImm(ImageOperand::Lod)
                  .addUse(lod);
+  TR->constrainRegOperands(MIB);
+
+  MIB = MIRBuilder.buildInstr(SPIRV::OpCompositeExtract)
+                 .addDef(resVReg)
+                 .addUse(TR->getSPIRVTypeID(retType))
+                 .addUse(tmpReg)
+                 .addImm(0);
+  return  TR->constrainRegOperands(MIB);
+}
+
+static bool genReadImageMSAA(MachineIRBuilder &MIRBuilder, Register resVReg,
+                         SPIRVType *retType,
+                         const SmallVectorImpl<Register> &OrigArgs,
+                         SPIRVTypeRegistry *TR) {
+  Register image = OrigArgs[0];
+  Register coord = OrigArgs[1];
+  auto MIB = MIRBuilder.buildInstr(SPIRV::OpImageRead)
+                 .addDef(resVReg)
+                 .addUse(TR->getSPIRVTypeID(retType))
+                 .addUse(image)
+                 .addUse(coord)
+                 .addImm(ImageOperand::Sample)
+                 .addUse(OrigArgs[2]);
   return TR->constrainRegOperands(MIB);
 }
+
 
 static bool genReadImage(MachineIRBuilder &MIRBuilder, Register resVReg,
                          SPIRVType *retType,
@@ -509,7 +543,7 @@ static bool genImageSizeQuery(MachineIRBuilder &MIRBuilder, Register resVReg,
                    .addUse(TR->getSPIRVTypeID(sizeVecTy))
                    .addUse(img);
   } else {
-    auto lodReg = buildIConstant(0, I32Ty, MIRBuilder, TR);
+    auto lodReg = TR->buildConstantInt(0, MIRBuilder, I32Ty);
     MIB = MIRBuilder.buildInstr(SPIRV::OpImageQuerySizeLod)
                    .addDef(sizeVec)
                    .addUse(TR->getSPIRVTypeID(sizeVecTy))
@@ -1040,7 +1074,6 @@ bool llvm::generateOpenCLBuiltinCall(const StringRef demangledName,
                                      const SmallVectorImpl<Register> &args,
                                      SPIRVTypeRegistry *TR) {
   LLVM_DEBUG(dbgs() << "Generating OpenCL Builtin: " << demangledName << "\n");
-
   SPIRVType *retTy = nullptr;
   if (OrigRetTy && !OrigRetTy->isVoidTy())
     retTy = TR->assignTypeToVReg(OrigRetTy, OrigRet, MIRBuilder);
@@ -1143,8 +1176,10 @@ bool llvm::generateOpenCLBuiltinCall(const StringRef demangledName,
   }
   case 'r':
     if (nameNoArgs.startswith("read_image")) {
-      if (args.size() > 2)
+      if (demangledName.find("ocl_sampler") != StringRef::npos)
         return genSampledReadImage(MIRBuilder, OrigRet, retTy, args, TR);
+      else if (demangledName.find("msaa") != StringRef::npos)
+        return genReadImageMSAA(MIRBuilder, OrigRet, retTy, args, TR);
       else
         return genReadImage(MIRBuilder, OrigRet, retTy, args, TR);
     }


### PR DESCRIPTION
This patch fixes the runtime fail #9 and makes 2 tests passed (transcoding/OpImageSampleExplicitLod.ll, transcoding/OpImageReadMS.ll).