### PR TITLE
[SPIR-V] support __spirv_SampledImage and __spirv_ImageSampleExplicitLod builtins, fix errors

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
@@ -233,8 +233,8 @@ static void hoistGlobalOp(MachineIRBuilder &MetaBuilder,
   ToRemove.push_back(ToHoist);
 
   if (!MetaBuilder.getMRI()->getVRegDef(MetaReg)) {
-  auto MIB = MetaBuilder.buildInstr(ToHoist->getOpcode());
-  MIB.addDef(MetaReg);
+    auto MIB = MetaBuilder.buildInstr(ToHoist->getOpcode());
+    MIB.addDef(MetaReg);
 
     for (unsigned int i = ToHoist->getNumExplicitDefs();
          i < ToHoist->getNumOperands(); ++i) {
@@ -644,10 +644,9 @@ static void numberRegistersInMBB(MachineBasicBlock &MBB,
       if (op.isReg()) {
         Register newReg;
         auto VR = localToMetaVRegAliasMap.find(op.getReg());
+        // Stops setReg crashing if reg index > max regs in func
+        addDummyVRegsUpToIndex(RegBaseIndex, MRI);
         if (VR == localToMetaVRegAliasMap.end()) {
-          // Stops setReg crashing if reg index > max regs in func
-          addDummyVRegsUpToIndex(RegBaseIndex, MRI);
-
           newReg = Register::index2VirtReg(RegBaseIndex);
           ++RegBaseIndex;
           localToMetaVRegAliasMap.insert({op.getReg(), newReg});

--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
@@ -107,6 +107,11 @@ public:
     return Res->second;
   }
 
+  // Either generate a new OpTypeXXX instruction or return an existing one
+  // corresponding to the given string containing the name of the builtin type.
+  SPIRVType *
+  getOrCreateSPIRVTypeByName(StringRef typeStr, MachineIRBuilder &MIRBuilder);
+
   // Return the SPIR-V type instruction corresponding to the given VReg, or
   // nullptr if no such type instruction exists.
   SPIRVType *getSPIRVTypeForVReg(Register VReg) const;

--- a/llvm/test/CodeGen/SPIRV/transcoding/spirv-types.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/spirv-types.ll
@@ -2,18 +2,17 @@
 ;;
 ; RUN: llc -O0 -global-isel %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
-; CHECK-SPIRV: OpCapability Float16
-; CHECK-SPIRV: OpCapability ImageBasic
-; CHECK-SPIRV: OpCapability ImageReadWrite
-; CHECK-SPIRV: OpCapability Pipes
-; CHECK-SPIRV: OpCapability DeviceEnqueue
+; CHECK-SPIRV-DAG: OpCapability Float16
+; CHECK-SPIRV-DAG: OpCapability ImageReadWrite
+; CHECK-SPIRV-DAG: OpCapability Pipes
+; CHECK-SPIRV-DAG: OpCapability DeviceEnqueue
 
 ; CHECK-SPIRV-DAG: %[[VOID:[0-9]+]] = OpTypeVoid
 ; CHECK-SPIRV-DAG: %[[INT:[0-9]+]] = OpTypeInt 32 0
 ; CHECK-SPIRV-DAG: %[[HALF:[0-9]+]] = OpTypeFloat 16
 ; CHECK-SPIRV-DAG: %[[FLOAT:[0-9]+]] = OpTypeFloat 32
-; CHECK-SPIRV-DAG: %[[PIPE_RD:[0-9]+]] = OpTypePipe 0
-; CHECK-SPIRV-DAG: %[[PIPE_WR:[0-9]+]] = OpTypePipe 1
+; CHECK-SPIRV-DAG: %[[PIPE_RD:[0-9]+]] = OpTypePipe ReadOnly
+; CHECK-SPIRV-DAG: %[[PIPE_WR:[0-9]+]] = OpTypePipe WriteOnly
 ; CHECK-SPIRV-DAG: %[[IMG1D_RD:[0-9]+]] = OpTypeImage %[[VOID]] 1D 0 0 0 0 Unknown ReadOnly
 ; CHECK-SPIRV-DAG: %[[IMG2D_RD:[0-9]+]] = OpTypeImage %[[INT]] 2D 0 0 0 0 Unknown ReadOnly
 ; CHECK-SPIRV-DAG: %[[IMG3D_RD:[0-9]+]] = OpTypeImage %[[INT]] 3D 0 0 0 0 Unknown ReadOnly


### PR DESCRIPTION
The change adds missed support of __spirv_SampledImage and __spirv_ImageSampleExplicitLod* builtins. The last one has the return type inside the builtin function name so its detection has been added too.

This patch discovers an issue with SampledImageType. Now it can be registered both in DT and SpecialTypesAndConstsMap maps (spirv-types.ll test). This causes its processing by fillLocalAliasTables two times (SPIRVGlobalTypesAndRegNumPass.cpp) and need to be fixed later.

Also errors in transcoding/spirv-types.ll were fixed.

Two tests (transcoding/spirv-types.ll, SampledImageRetType.ll) are expected to pass.