### PR TITLE
[SPIR-V] support OpExtInst builtins with half operands

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
@@ -1117,7 +1117,7 @@ bool llvm::generateOpenCLBuiltinCall(const StringRef demangledName,
     else if (typeChar == 'c' || typeChar == 's' || typeChar == 'i' ||
              typeChar == 'l')
       idx = 1;
-    else if (typeChar == 'f' || typeChar == 'd')
+    else if (typeChar == 'f' || typeChar == 'd' || typeChar == 'h')
       idx = 2;
     if (idx != -1) {
       assert(unsigned(idx) < extInstMatch->second.size());


### PR DESCRIPTION
The patch adds support for OpExtInst builtins with half float operands. One test (transcoding/fclamp.ll) is expected to pass.