### PR TITLE
[SPIR-V] support relational OpenCL builtins, fix errors

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
@@ -522,8 +522,10 @@ def OpBitCount: Op<205, (outs ID:$r), (ins TYPE:$ty, ID:$b), "$r = OpBitCount $t
 
 //3.32.15 Relational and Logical Instructions
 
-def OpAny: Op<154, (outs ID:$res), (ins ID:$vec), "$res = OpAny $vec">;
-def OpAll: Op<155, (outs ID:$res), (ins ID:$vec), "$res = OpAll $vec">;
+def OpAny: Op<154, (outs ID:$res), (ins TYPE:$ty, ID:$vec),
+                  "$res = OpAny $ty $vec">;
+def OpAll: Op<155, (outs ID:$res), (ins TYPE:$ty, ID:$vec),
+                  "$res = OpAll $ty $vec">;
 
 def OpIsNan: UnOp<"OpIsNan", 156>;
 def OpIsInf: UnOp<"OpIsInf", 157>;

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -189,6 +189,8 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
   //                  LegalityPredicate(([=](const LegalityQuery &Query) {
   //                    return Query.Types[1].getElementType() == Query.Types[0];
   //                  }))));
+  getActionDefinitionsBuilder(G_BUILD_VECTOR)
+      .legalForCartesianProduct(allVectors, {s16, s32, s64});
 
   getActionDefinitionsBuilder(G_IMPLICIT_DEF).alwaysLegal();
 

--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
@@ -220,6 +220,8 @@ public:
                             SPIRVType *spvType = nullptr);
   Register buildConstantFP(APFloat val, MachineIRBuilder &MIRBuilder,
                            SPIRVType *spvType = nullptr);
+  Register buildConstantIntVector(uint64_t val, MachineIRBuilder &MIRBuilder,
+                           SPIRVType *spvType);
   Register buildConstantSampler(Register res, unsigned int addrMode,
       unsigned int param, unsigned int filerMode,
       MachineIRBuilder &MIRBuilder, SPIRVType *spvType);

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpAllAny.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpAllAny.ll
@@ -1,8 +1,8 @@
 ; RUN: llc -O0 -global-isel %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; CHECK-SPIRV: %[[BoolTypeID:[0-9]+]] = OpTypeBool
-; CHECK-SPIRV: %[[BoolTypeID]] = OpAll
-; CHECK-SPIRV: %[[BoolTypeID]] = OpAny
+; CHECK-SPIRV: OpAll %[[BoolTypeID]]
+; CHECK-SPIRV: OpAny %[[BoolTypeID]]
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv32-unknown-unknown"


### PR DESCRIPTION
The change adds support of relational OpenCL builtins (isequal isnotequal, isgreater, isgreaterequal, isless, islessequal, islessgreater, isordered, isunordered, isfinite, isinf, isnan, isnormal, signbit, any, all).

G_BUILD_VECTOR legalizing and selection have been added (it's required for vector variants of that instruction).
Also errors in OpAny/OpAll implementation and in OpAllAny.ll test have been fixed.

6 tests (FOrdGreaterThanEqual_int.ll, transcoding/OpAllAny.ll, transcoding/isequal.ll, transcoding/relationals_float.ll, transcoding/relationals_double.ll, transcoding/relationals_half.ll) are expected to pass.
