### PR TITLE
[SPIR-V] support sub_group/work_group* OpenCL builtins, add corresponding instructions and capabilities, fix errors

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVAddRequirementsPass.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAddRequirementsPass.cpp
@@ -333,6 +333,81 @@ void addInstrRequirements(const MachineInstr &MI,
     }
     break;
   }
+  case SPIRV::OpGroupNonUniformIAdd:
+  case SPIRV::OpGroupNonUniformFAdd:
+  case SPIRV::OpGroupNonUniformIMul:
+  case SPIRV::OpGroupNonUniformFMul:
+  case SPIRV::OpGroupNonUniformSMin:
+  case SPIRV::OpGroupNonUniformUMin:
+  case SPIRV::OpGroupNonUniformFMin:
+  case SPIRV::OpGroupNonUniformSMax:
+  case SPIRV::OpGroupNonUniformUMax:
+  case SPIRV::OpGroupNonUniformFMax:
+  case SPIRV::OpGroupNonUniformBitwiseAnd:
+  case SPIRV::OpGroupNonUniformBitwiseOr:
+  case SPIRV::OpGroupNonUniformBitwiseXor:
+  case SPIRV::OpGroupNonUniformLogicalAnd:
+  case SPIRV::OpGroupNonUniformLogicalOr:
+  case SPIRV::OpGroupNonUniformLogicalXor: {
+    auto groupOp = MI.getOperand(3).getImm();
+    switch(groupOp) {
+    case GroupOperation::Reduce:
+    case GroupOperation::InclusiveScan:
+    case GroupOperation::ExclusiveScan:
+      reqs.addCapability(Kernel);
+      reqs.addCapability(GroupNonUniformArithmetic);
+      reqs.addCapability(GroupNonUniformBallot);
+      break;
+    case GroupOperation::ClusteredReduce:
+      reqs.addCapability(GroupNonUniformClustered);
+      break;
+    case GroupOperation::PartitionedReduceNV:
+    case GroupOperation::PartitionedInclusiveScanNV:
+    case GroupOperation::PartitionedExclusiveScanNV:
+      reqs.addCapability(GroupNonUniformPartitionedNV);
+      break;
+    }
+    break;
+  }
+  case SPIRV::OpGroupNonUniformShuffle:
+  case SPIRV::OpGroupNonUniformShuffleXor:
+    reqs.addCapability(GroupNonUniformShuffle);
+    break;
+  case SPIRV::OpGroupNonUniformShuffleUp:
+  case SPIRV::OpGroupNonUniformShuffleDown:
+    reqs.addCapability(GroupNonUniformShuffleRelative);
+    break;
+  case SPIRV::OpGroupAll:
+  case SPIRV::OpGroupAny:
+  case SPIRV::OpGroupBroadcast:
+  case SPIRV::OpGroupIAdd:
+  case SPIRV::OpGroupFAdd:
+  case SPIRV::OpGroupFMin:
+  case SPIRV::OpGroupUMin:
+  case SPIRV::OpGroupSMin:
+  case SPIRV::OpGroupFMax:
+  case SPIRV::OpGroupUMax:
+  case SPIRV::OpGroupSMax:
+    reqs.addCapability(Groups);
+    break;
+  case SPIRV::OpGroupNonUniformElect:
+    reqs.addCapability(GroupNonUniform);
+    break;
+  case SPIRV::OpGroupNonUniformAll:
+  case SPIRV::OpGroupNonUniformAny:
+  case SPIRV::OpGroupNonUniformAllEqual:
+    reqs.addCapability(GroupNonUniformVote);
+    break;
+  case SPIRV::OpGroupNonUniformBroadcast:
+  case SPIRV::OpGroupNonUniformBroadcastFirst:
+  case SPIRV::OpGroupNonUniformBallot:
+  case SPIRV::OpGroupNonUniformInverseBallot:
+  case SPIRV::OpGroupNonUniformBallotBitExtract:
+  case SPIRV::OpGroupNonUniformBallotBitCount:
+  case SPIRV::OpGroupNonUniformBallotFindLSB:
+  case SPIRV::OpGroupNonUniformBallotFindMSB:
+    reqs.addCapability(GroupNonUniformBallot);
+    break;
   default:
     break;
   }

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
@@ -42,19 +42,22 @@ public:
   unsigned getNumRegistersForCallingConv(LLVMContext &Context,
                                          CallingConv::ID CC,
                                          EVT VT) const override {
-    if(VT.isVector() && VT.getVectorElementType() == MVT::i1
-       && VT.getVectorNumElements() == 3)
+    if (VT.isVector() && VT.getVectorNumElements() == 3
+        && (VT.getVectorElementType() == MVT::i1
+            || VT.getVectorElementType() == MVT::i8))
       return 1;
-    return getNumRegisters(Context, VT);;
+    return getNumRegisters(Context, VT);
   }
 
   // Avoid fail on v3i1 argument. Maybe we need to return i32 for all types.
   MVT getRegisterTypeForCallingConv(LLVMContext &Context,
                                     CallingConv::ID CC,
                                     EVT VT) const override {
-    if(VT.isVector() && VT.getVectorElementType() == MVT::i1
-       && VT.getVectorNumElements() == 3)
-      return MVT::v4i1;
+    if (VT.isVector() && VT.getVectorNumElements() == 3)
+      if (VT.getVectorElementType() == MVT::i1)
+        return MVT::v4i1;
+      else if (VT.getVectorElementType() == MVT::i8)
+        return MVT::v4i8;
     return getRegisterType(Context, VT);
   }
 };

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
@@ -53,11 +53,12 @@ public:
   MVT getRegisterTypeForCallingConv(LLVMContext &Context,
                                     CallingConv::ID CC,
                                     EVT VT) const override {
-    if (VT.isVector() && VT.getVectorNumElements() == 3)
+    if (VT.isVector() && VT.getVectorNumElements() == 3) {
       if (VT.getVectorElementType() == MVT::i1)
         return MVT::v4i1;
       else if (VT.getVectorElementType() == MVT::i8)
         return MVT::v4i8;
+    }
     return getRegisterType(Context, VT);
   }
 };

--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
@@ -672,9 +672,77 @@ def OpMemoryNamedBarrier: Op<329, (outs), (ins ID:$barr, ID:$mem, ID:$sem),
                   "OpMemoryNamedBarrier $barr $mem $sem">;
 
 // TODO Complete this list, or auto-generate it, to include later sections such as
-// 3.32.21. Group and Subgroup Instructions,
+// 3.37.21. Group and Subgroup Instructions
+
+def OpGroupAll: Op<261, (outs ID:$res), (ins TYPE:$ty, ID:$scope, ID:$pr),
+                  "$res = OpGroupAll $ty $scope $pr">;
+def OpGroupAny: Op<262, (outs ID:$res), (ins TYPE:$ty, ID:$scope, ID:$pr),
+                  "$res = OpGroupAny $ty $scope $pr">;
+def OpGroupBroadcast: Op<263, (outs ID:$res), (ins TYPE:$ty, ID:$scope,
+                               ID:$val, ID:$id),
+                  "$res = OpGroupBroadcast $ty $scope $val $id">;
+class OpGroup<string name, bits<16> opCode>: Op<opCode, (outs ID:$res),
+                  (ins TYPE:$ty, ID:$scope, GroupOperation:$groupOp, ID:$x),
+                  "$res = OpGroup"#name#" $ty $scope $groupOp $x">;
+def OpGroupIAdd: OpGroup<"IAdd", 264>;
+def OpGroupFAdd: OpGroup<"FAdd", 265>;
+def OpGroupFMin: OpGroup<"FMin", 266>;
+def OpGroupUMin: OpGroup<"UMin", 267>;
+def OpGroupSMin: OpGroup<"SMin", 268>;
+def OpGroupFMax: OpGroup<"FMax", 269>;
+def OpGroupUMax: OpGroup<"UMax", 270>;
+def OpGroupSMax: OpGroup<"SMax", 271>;
+
+
 // 3.32.22. Device-Side Enqueue Instructions,
 // 3.32.23. Pipe Instructions,
-// 3.32.24. Non-Uniform Instructions,
-// and possibly 3.32.25. Reserved Instructions.
 
+// 3.37.24. Non-Uniform Instructions
+def OpGroupNonUniformElect: Op<333, (outs ID:$res), (ins TYPE:$ty, ID:$scope),
+                  "$res = OpGroupNonUniformElect $ty $scope">;
+class OpGroupNU3<string name, bits<16> opCode>: Op<opCode,
+                  (outs ID:$res), (ins TYPE:$ty, ID:$scope, ID:$pred),
+                  "$res = OpGroupNonUniform"#name#" $ty $scope $pred">;
+class OpGroupNU4<string name, bits<16> opCode>: Op<opCode,
+                  (outs ID:$res), (ins TYPE:$ty, ID:$scope, ID:$val, ID:$id),
+                  "$res = OpGroupNonUniform"#name#" $ty $scope $val $id">;
+def OpGroupNonUniformAll: OpGroupNU3<"All", 334>;
+def OpGroupNonUniformAny: OpGroupNU3<"Any", 335>;
+def OpGroupNonUniformAllEqual: OpGroupNU3<"AllEqual", 336>;
+def OpGroupNonUniformBroadcast: OpGroupNU4<"Broadcast", 337>;
+def OpGroupNonUniformBroadcastFirst: OpGroupNU3<"BroadcastFirst", 338>;
+def OpGroupNonUniformBallot: OpGroupNU3<"Ballot", 339>;
+def OpGroupNonUniformInverseBallot: OpGroupNU3<"InverseBallot", 340>;
+def OpGroupNonUniformBallotBitExtract: OpGroupNU4<"BallotBitExtract", 341>;
+def OpGroupNonUniformBallotBitCount: Op<342, (outs ID:$res),
+                  (ins TYPE:$ty, ID:$scope, GroupOperation:$groupOp, ID:$val),
+                  "$res = OpGroupNonUniformBallotBitCount "
+                          "$ty $scope $groupOp $val">;
+def OpGroupNonUniformBallotFindLSB: OpGroupNU3<"BallotFindLSB", 343>;
+def OpGroupNonUniformBallotFindMSB: OpGroupNU3<"BallotFindMSB", 344>;
+def OpGroupNonUniformShuffle: OpGroupNU4<"Shuffle", 345>;
+def OpGroupNonUniformShuffleXor: OpGroupNU4<"ShuffleXor", 346>;
+def OpGroupNonUniformShuffleUp: OpGroupNU4<"ShuffleUp", 347>;
+def OpGroupNonUniformShuffleDown: OpGroupNU4<"ShuffleDown", 348>;
+class OpGroupNUGroup<string name, bits<16> opCode>: Op<opCode, (outs ID:$res),
+                  (ins TYPE:$ty, ID:$scope, GroupOperation:$groupOp,
+                   ID:$val, variable_ops),
+                  "$res = OpGroupNonUniform"#name#" $ty $scope $groupOp $val">;
+def OpGroupNonUniformIAdd: OpGroupNUGroup<"IAdd", 349>;
+def OpGroupNonUniformFAdd: OpGroupNUGroup<"FAdd", 350>;
+def OpGroupNonUniformIMul: OpGroupNUGroup<"IMul", 351>;
+def OpGroupNonUniformFMul: OpGroupNUGroup<"FMul", 352>;
+def OpGroupNonUniformSMin: OpGroupNUGroup<"SMin", 353>;
+def OpGroupNonUniformUMin: OpGroupNUGroup<"UMin", 354>;
+def OpGroupNonUniformFMin: OpGroupNUGroup<"FMin", 355>;
+def OpGroupNonUniformSMax: OpGroupNUGroup<"SMax", 356>;
+def OpGroupNonUniformUMax: OpGroupNUGroup<"UMax", 357>;
+def OpGroupNonUniformFMax: OpGroupNUGroup<"FMax", 358>;
+def OpGroupNonUniformBitwiseAnd: OpGroupNUGroup<"BitwiseAnd", 359>;
+def OpGroupNonUniformBitwiseOr: OpGroupNUGroup<"BitwiseOr", 360>;
+def OpGroupNonUniformBitwiseXor: OpGroupNUGroup<"BitwiseXor", 361>;
+def OpGroupNonUniformLogicalAnd: OpGroupNUGroup<"LogicalAnd", 362>;
+def OpGroupNonUniformLogicalOr: OpGroupNUGroup<"LogicalOr", 363>;
+def OpGroupNonUniformLogicalXor: OpGroupNUGroup<"LogicalXor", 364>;
+
+// and possibly 3.32.25. Reserved Instructions.

--- a/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
@@ -65,7 +65,7 @@ enum CLMemFenceFlags {
   CLK_IMAGE_MEM_FENCE = 0x4
 };
 
-static StringMap<unsigned> OpenCLBIMap({
+static StringMap<unsigned> OpenCLBIToOperationMap({
 #define _SPIRV_OP(x, y) {#x, SPIRV::Op##y},
   _SPIRV_OP(isequal, FOrdEqual)
   _SPIRV_OP(isnotequal, FUnordNotEqual)
@@ -83,6 +83,87 @@ static StringMap<unsigned> OpenCLBIMap({
   _SPIRV_OP(signbit, SignBitSet)
   _SPIRV_OP(any, Any)
   _SPIRV_OP(all, All)
+  // CL 2.0 workgroup builtins
+  _SPIRV_OP(group_all, GroupAll)
+  _SPIRV_OP(group_any, GroupAny)
+  _SPIRV_OP(group_broadcast, GroupBroadcast)
+  _SPIRV_OP(group_iadd, GroupIAdd)
+  _SPIRV_OP(group_fadd, GroupFAdd)
+  _SPIRV_OP(group_fmin, GroupFMin)
+  _SPIRV_OP(group_umin, GroupUMin)
+  _SPIRV_OP(group_smin, GroupSMin)
+  _SPIRV_OP(group_fmax, GroupFMax)
+  _SPIRV_OP(group_umax, GroupUMax)
+  _SPIRV_OP(group_smax, GroupSMax)
+  // cl_khr_subgroup_non_uniform_vote
+  _SPIRV_OP(group_elect, GroupNonUniformElect)
+  _SPIRV_OP(group_non_uniform_all, GroupNonUniformAll)
+  _SPIRV_OP(group_non_uniform_any, GroupNonUniformAny)
+  _SPIRV_OP(group_non_uniform_all_equal, GroupNonUniformAllEqual)
+  // cl_khr_subgroup_ballot
+  _SPIRV_OP(group_non_uniform_broadcast, GroupNonUniformBroadcast)
+  _SPIRV_OP(group_broadcast_first, GroupNonUniformBroadcastFirst)
+  _SPIRV_OP(group_ballot, GroupNonUniformBallot)
+  _SPIRV_OP(group_inverse_ballot, GroupNonUniformInverseBallot)
+  _SPIRV_OP(group_ballot_bit_extract, GroupNonUniformBallotBitExtract)
+  _SPIRV_OP(group_ballot_bit_count, GroupNonUniformBallotBitCount)
+  _SPIRV_OP(group_ballot_inclusive_scan, GroupNonUniformBallotBitCount)
+  _SPIRV_OP(group_ballot_exclusive_scan, GroupNonUniformBallotBitCount)
+  _SPIRV_OP(group_ballot_find_lsb, GroupNonUniformBallotFindLSB)
+  _SPIRV_OP(group_ballot_find_msb, GroupNonUniformBallotFindMSB)
+  // cl_khr_subgroup_non_uniform_arithmetic
+  _SPIRV_OP(group_non_uniform_iadd, GroupNonUniformIAdd)
+  _SPIRV_OP(group_non_uniform_fadd, GroupNonUniformFAdd)
+  _SPIRV_OP(group_non_uniform_imul, GroupNonUniformIMul)
+  _SPIRV_OP(group_non_uniform_fmul, GroupNonUniformFMul)
+  _SPIRV_OP(group_non_uniform_smin, GroupNonUniformSMin)
+  _SPIRV_OP(group_non_uniform_umin, GroupNonUniformUMin)
+  _SPIRV_OP(group_non_uniform_fmin, GroupNonUniformFMin)
+  _SPIRV_OP(group_non_uniform_smax, GroupNonUniformSMax)
+  _SPIRV_OP(group_non_uniform_umax, GroupNonUniformUMax)
+  _SPIRV_OP(group_non_uniform_fmax, GroupNonUniformFMax)
+  _SPIRV_OP(group_non_uniform_iand, GroupNonUniformBitwiseAnd)
+  _SPIRV_OP(group_non_uniform_ior, GroupNonUniformBitwiseOr)
+  _SPIRV_OP(group_non_uniform_ixor, GroupNonUniformBitwiseXor)
+  _SPIRV_OP(group_non_uniform_logical_iand, GroupNonUniformLogicalAnd)
+  _SPIRV_OP(group_non_uniform_logical_ior, GroupNonUniformLogicalOr)
+  _SPIRV_OP(group_non_uniform_logical_ixor, GroupNonUniformLogicalXor)
+  // cl_khr_subgroup_shuffle
+  _SPIRV_OP(group_shuffle, GroupNonUniformShuffle)
+  _SPIRV_OP(group_shuffle_xor, GroupNonUniformShuffleXor)
+  // cl_khr_subgroup_shuffle_relative
+  _SPIRV_OP(group_shuffle_up, GroupNonUniformShuffleUp)
+  _SPIRV_OP(group_shuffle_down, GroupNonUniformShuffleDown)
+#undef _SPIRV_OP
+});
+
+static StringMap<BuiltIn::BuiltIn> OpenCLBIToBuiltInVarMap({
+#define _SPIRV_OP(x, y) {#x, BuiltIn::y},
+  // cl_khr_subgroup_ballot
+  _SPIRV_OP(get_sub_group_eq_mask, SubgroupEqMask)
+  _SPIRV_OP(get_sub_group_ge_mask, SubgroupGeMask)
+  _SPIRV_OP(get_sub_group_gt_mask, SubgroupGtMask)
+  _SPIRV_OP(get_sub_group_le_mask, SubgroupLeMask)
+  _SPIRV_OP(get_sub_group_lt_mask, SubgroupLtMask)
+#undef _SPIRV_OP
+});
+
+static StringMap<GroupOperation::GroupOperation> GroupOperationMap({
+#define _SPIRV_OP(x, y) {#x, GroupOperation::y},
+  _SPIRV_OP(reduce, Reduce)
+  _SPIRV_OP(scan_inclusive, InclusiveScan)
+  _SPIRV_OP(scan_exclusive, ExclusiveScan)
+  _SPIRV_OP(ballot_bit_count, Reduce)
+  _SPIRV_OP(ballot_inclusive_scan, InclusiveScan)
+  _SPIRV_OP(ballot_exclusive_scan, ExclusiveScan)
+  _SPIRV_OP(non_uniform_reduce, Reduce)
+  _SPIRV_OP(non_uniform_scan_inclusive, InclusiveScan)
+  _SPIRV_OP(non_uniform_scan_exclusive, ExclusiveScan)
+  _SPIRV_OP(non_uniform_reduce_logical, Reduce)
+  _SPIRV_OP(non_uniform_scan_inclusive_logical, InclusiveScan)
+  _SPIRV_OP(non_uniform_scan_exclusive_logical, ExclusiveScan)
+  _SPIRV_OP(clustered_reduce, ClusteredReduce)
+  _SPIRV_OP(clustered_reduce_logical, ClusteredReduce)
 #undef _SPIRV_OP
 });
 
@@ -236,17 +317,20 @@ static Register buildOpVariable(SPIRVType *BaseType,
 }
 
 static Register buildLoad(SPIRVType *BaseType, Register PtrVReg,
-                          MachineIRBuilder &MIRBuilder, SPIRVTypeRegistry *TR) {
+                          MachineIRBuilder &MIRBuilder, SPIRVTypeRegistry *TR,
+                          LLT llt, Register dstReg = Register(0)) {
   const auto MRI = MIRBuilder.getMRI();
-  Register Reg = MRI->createVirtualRegister(&SPIRV::IDRegClass);
-  MRI->setType(Reg, LLT::scalar(32));
-  TR->assignSPIRVTypeToVReg(BaseType, Reg, MIRBuilder);
+  if (!dstReg.isValid()) {
+    dstReg = MRI->createVirtualRegister(&SPIRV::IDRegClass);
+    MRI->setType(dstReg, LLT::scalar(32));
+    TR->assignSPIRVTypeToVReg(BaseType, dstReg, MIRBuilder);
+  }
 
   // TODO: consider using correct address space and alignment
   // p0 is canonical type for selection though
   auto PtrInfo = MachinePointerInfo();
-  MIRBuilder.buildLoad(Reg, PtrVReg, PtrInfo, Align());
-  return Reg;
+  MIRBuilder.buildLoad(dstReg, PtrVReg, PtrInfo, Align());
+  return dstReg;
 }
 
 static uint64_t getLiteralValueForConstant(Register constVReg,
@@ -299,6 +383,21 @@ static Register buildIConstant(uint64_t Val, SPIRVType *type,
   auto Reg = MIRBuilder.getMRI()->createGenericVirtualRegister(llt);
   buildIConstant(Reg, Val, type, MIRBuilder, TR);
   return Reg;
+}
+
+static Register buildBuiltInLoad(MachineIRBuilder &MIRBuilder,
+                              SPIRVType *varType,
+                              SPIRVTypeRegistry *TR, BuiltIn::BuiltIn builtIn,
+                              LLT llt, Register Reg = Register(0)) {
+  // Set up the global OpVariable with the necessary builtin decorations
+  Register var = buildOpVariable(varType, StorageClass::Input, MIRBuilder, TR);
+  decorateBuiltIn(var, builtIn, MIRBuilder, TR);
+  decorateConstant(var, MIRBuilder, TR);
+
+  // Load the value from the global variable
+  Register loadedReg = buildLoad(varType, var, MIRBuilder, TR, llt, Reg);
+  MIRBuilder.getMRI()->setType(loadedReg, llt);
+  return loadedReg;
 }
 
 // These queries ask for a single size_t result for a given dimension index, e.g
@@ -362,16 +461,8 @@ static bool genWorkgroupQuery(MachineIRBuilder &MIRBuilder, Register resVReg,
   } else { // If it could be in range, we need to load from the given builtin
 
     auto Vec3Ty = TR->getOrCreateSPIRVVectorType(PtrSizeTy, 3, MIRBuilder);
-
-    // Set up the global OpVariable with the necessary builtin decorations
-    Register globVar = buildOpVariable(Vec3Ty, StorageClass::Input, MIRBuilder, TR);
-    decorateBuiltIn(globVar, builtIn, MIRBuilder, TR);
-    decorateConstant(globVar, MIRBuilder, TR);
-
-    // Load the Vec3 from the global variable
-    Register loadedVector =
-        buildLoad(Vec3Ty, globVar, MIRBuilder, TR);
-    MRI->setType(loadedVector, LLT::fixed_vector(3, ptrSize));
+    Register loadedVector = buildBuiltInLoad(MIRBuilder, Vec3Ty, TR, builtIn,
+                                             LLT::fixed_vector(3, ptrSize));
 
     // Set up the vreg to extract the result to (possibly a new temporary one)
     Register extr = resVReg;
@@ -809,7 +900,7 @@ static bool genAtomicCmpXchg(MachineIRBuilder &MIRBuilder, Register resVReg,
     scopeReg = TR->buildConstantInt(scope, MIRBuilder, I32Ty);
 
   Register expected = isCmpxchg ? expectedArg :
-      buildLoad(spvDesiredTy, expectedArg, MIRBuilder, TR);
+      buildLoad(spvDesiredTy, expectedArg, MIRBuilder, TR, LLT::scalar(32));
   MRI->setType(expected, desiredLLT);
   Register tmp = !isCmpxchg ? MRI->createGenericVirtualRegister(desiredLLT) :
                               resVReg;
@@ -1084,7 +1175,7 @@ static bool genDotOrFMul(Register resVReg, const SPIRVType *resType,
     OpCode = OpFMulS;
   }
 
- auto MIB = MIRBuilder.buildInstr(OpCode)
+  auto MIB = MIRBuilder.buildInstr(OpCode)
                  .addDef(resVReg)
                  .addUse(TR->getSPIRVTypeID(resType))
                  .addUse(OrigArgs[0])
@@ -1092,24 +1183,47 @@ static bool genDotOrFMul(Register resVReg, const SPIRVType *resType,
   return TR->constrainRegOperands(MIB);
 }
 
-static bool genOpenCLRelational(MachineIRBuilder &MIRBuilder,
-    unsigned opcode, Register resVReg, const SPIRVType *resType,
-    const SmallVectorImpl<Register> &OrigArgs, SPIRVTypeRegistry *TR) {
-  auto relTy = TR->getOrCreateSPIRVBoolType(MIRBuilder);
-  bool isVectorRes = resType->getOpcode() == SPIRV::OpTypeVector;
+static Register buildScalarOrVectorBoolReg(MachineIRBuilder &MIRBuilder,
+    SPIRVType *&boolTy, const SPIRVType *resType, SPIRVTypeRegistry *TR) {
   LLT lltTy;
-  if (isVectorRes) {
+  boolTy = TR->getOrCreateSPIRVBoolType(MIRBuilder);
+  if (resType->getOpcode() == SPIRV::OpTypeVector) {
     unsigned vecElts = resType->getOperand(2).getImm();
-    relTy = TR->getOrCreateSPIRVVectorType(relTy, vecElts, MIRBuilder);
-    auto LLVMVecTy = cast<FixedVectorType>(TR->getTypeForSPIRVType(relTy));
+    boolTy = TR->getOrCreateSPIRVVectorType(boolTy, vecElts, MIRBuilder);
+    auto LLVMVecTy = cast<FixedVectorType>(TR->getTypeForSPIRVType(boolTy));
     lltTy = LLT::vector(LLVMVecTy->getElementCount(), 1);
   } else {
     lltTy = LLT::scalar(1);
   }
   const auto MRI = MIRBuilder.getMRI();
-  auto cmpReg = MRI->createGenericVirtualRegister(lltTy);
+  auto resReg = MRI->createGenericVirtualRegister(lltTy);
+  TR->assignSPIRVTypeToVReg(boolTy, resReg, MIRBuilder);
+  return resReg;
+}
+
+static bool buildScalarOrVectorSelect(MachineIRBuilder &MIRBuilder,
+    Register resReg, Register srcReg, const SPIRVType *resType,
+    SPIRVTypeRegistry *TR) {
+  Register trueConst;
+  Register falseConst;
+  auto bits = TR->getScalarOrVectorBitWidth(resType);
+  if (resType->getOpcode() == SPIRV::OpTypeVector) {
+     auto ones = APInt::getAllOnesValue(bits).getZExtValue();
+     trueConst = TR->buildConstantIntVector(ones, MIRBuilder, resType);
+     falseConst = TR->buildConstantIntVector(0, MIRBuilder, resType);
+  } else {
+     trueConst = TR->buildConstantInt(1, MIRBuilder, resType);
+     falseConst = TR->buildConstantInt(0, MIRBuilder, resType);
+  }
+  return MIRBuilder.buildSelect(resReg, srcReg, trueConst, falseConst);
+}
+
+static bool genOpenCLRelational(MachineIRBuilder &MIRBuilder,
+    unsigned opcode, Register resVReg, const SPIRVType *resType,
+    const SmallVectorImpl<Register> &OrigArgs, SPIRVTypeRegistry *TR) {
+  SPIRVType *relTy;
+  auto cmpReg = buildScalarOrVectorBoolReg(MIRBuilder, relTy, resType, TR);
   // Build relational instruction
-  TR->assignSPIRVTypeToVReg(relTy, cmpReg, MIRBuilder);
   auto MIB = MIRBuilder.buildInstr(opcode)
                  .addDef(cmpReg)
                  .addUse(TR->getSPIRVTypeID(relTy));
@@ -1118,18 +1232,84 @@ static bool genOpenCLRelational(MachineIRBuilder &MIRBuilder,
   }
   TR->constrainRegOperands(MIB);
   // Build select instruction
-  Register trueConst;
-  Register falseConst;
-  auto bits = TR->getScalarOrVectorBitWidth(resType);
-  if (isVectorRes) {
-     auto ones = APInt::getAllOnesValue(bits).getZExtValue();
-     trueConst = TR->buildConstantIntVector(ones, MIRBuilder, resType);
-     falseConst = TR->buildConstantIntVector(0, MIRBuilder, resType);
-  } else {
-     trueConst = TR->buildConstantInt(1, MIRBuilder, resType);
-     falseConst = TR->buildConstantInt(0, MIRBuilder, resType);
+  return buildScalarOrVectorSelect(MIRBuilder, resVReg, cmpReg, resType, TR);
+}
+
+static bool genOpenCLOpGroup(MachineIRBuilder &MIRBuilder, StringRef name,
+    unsigned opcode, Register resVReg, const SPIRVType *resType,
+    const SmallVectorImpl<Register> &OrigArgs, SPIRVTypeRegistry *TR) {
+  using namespace SPIRV;
+  const bool isElect = opcode == OpGroupNonUniformElect;
+  const bool isAllOrAny = opcode == OpGroupAll || opcode == OpGroupAny
+                          || opcode == OpGroupNonUniformAll
+                          || opcode == OpGroupNonUniformAny;
+  const bool isAllEqual = opcode == OpGroupNonUniformAllEqual;
+  const bool isBallot = opcode == OpGroupNonUniformBallot;
+  const bool isInverseBallot = opcode == OpGroupNonUniformInverseBallot;
+  const bool isBallotBitExtract = opcode == OpGroupNonUniformBallotBitExtract;
+  const bool isBallotFindBit = opcode == OpGroupNonUniformBallotFindLSB
+                               || opcode == OpGroupNonUniformBallotFindMSB;
+  const bool isLogical = opcode == OpGroupNonUniformLogicalAnd
+                         || opcode == OpGroupNonUniformLogicalOr
+                         || opcode == OpGroupNonUniformLogicalXor;
+  const bool noGroupOperation = isElect || isAllOrAny || isAllEqual
+                                || isBallot || isInverseBallot
+                                || isBallotBitExtract || isBallotFindBit
+                                || opcode == OpGroupNonUniformShuffle
+                                || opcode == OpGroupNonUniformShuffleXor
+                                || opcode == OpGroupNonUniformShuffleUp
+                                || opcode == OpGroupNonUniformShuffleDown
+                                || opcode == OpGroupBroadcast
+                                || opcode == OpGroupNonUniformBroadcast
+                                || opcode == OpGroupNonUniformBroadcastFirst;
+  const bool hasBoolArg = (isAllOrAny && !isAllEqual) || isBallot || isLogical;
+  const auto MRI = MIRBuilder.getMRI();
+  Register arg0;
+  if (hasBoolArg) {
+    auto argInstr = MRI->getVRegDef(OrigArgs[0]);
+    // TODO: support non-constant bool values
+    assert(argInstr->getOpcode() == TargetOpcode::G_CONSTANT
+           && "Only constant bool value args are supported");
+    if (TR->getSPIRVTypeForVReg(OrigArgs[0])->getOpcode() != OpTypeBool) {
+      auto boolTy = TR->getOrCreateSPIRVBoolType(MIRBuilder);
+      arg0 = TR->buildConstantInt(getLiteralValueForConstant(OrigArgs[0], MRI),
+                                  MIRBuilder, boolTy);
+    }
   }
-  MIRBuilder.buildSelect(resVReg, cmpReg, trueConst, falseConst);
+  Register groupReg = resVReg;
+  SPIRVType* groupTy = resType;
+  // TODO: maybe we need to check whether the result type is already boolean
+  // and in this case do not insert select instruction.
+  const bool hasBoolReturnTy = isElect || isAllOrAny || isAllEqual || isLogical
+                               || isInverseBallot || isBallotBitExtract;
+  if (hasBoolReturnTy)
+    groupReg = buildScalarOrVectorBoolReg(MIRBuilder, groupTy, resType, TR);
+  const auto I32Ty = TR->getOrCreateSPIRVIntegerType(32, MIRBuilder);
+  auto scope = name.startswith("sub_group") ? Scope::Subgroup
+                                            : Scope::Workgroup;
+  Register scopeReg = TR->buildConstantInt(scope, MIRBuilder, I32Ty);
+  // Build OpGroup* instruction
+  auto MIB = MIRBuilder.buildInstr(opcode)
+                 .addDef(groupReg)
+                 .addUse(TR->getSPIRVTypeID(groupTy))
+                 .addUse(scopeReg);
+  if (!noGroupOperation) {
+    auto start = name.find("group_") + strlen("group_");
+    auto end = opcode == OpGroupNonUniformBallotBitCount
+               ? StringRef::npos : name.rfind('_');
+    auto groupOp = GroupOperationMap.lookup(name.slice(start, end));
+    MIB.addImm(groupOp);
+  }
+  if (OrigArgs.size() > 0) {
+    MIB.addUse(arg0.isValid() ? arg0 : OrigArgs[0]);
+    for (unsigned i = 1; i < OrigArgs.size(); i++) {
+      MIB.addUse(OrigArgs[i]);
+    }
+  }
+  TR->constrainRegOperands(MIB);
+  // Build select instruction
+  if (hasBoolReturnTy)
+    buildScalarOrVectorSelect(MIRBuilder, resVReg, groupReg, resType, TR);
   return true;
 }
 
@@ -1147,6 +1327,50 @@ static bool genOpenCLExtInst(OpenCL_std::OpenCL_std extInstID,
     MIB.addUse(arg);
   }
   return TR->constrainRegOperands(MIB);
+}
+
+static std::string modifyBINameForLookup(StringRef nameNoArgs, SPIRVType *retTy,
+    char firstArgC) {
+  std::string modifiedName = nameNoArgs.str();
+  if (nameNoArgs.startswith("sub_group_")
+      || nameNoArgs.startswith("work_group_")) {
+    if (nameNoArgs.contains("group_all")
+        || nameNoArgs.contains("group_any")
+        || nameNoArgs.startswith("sub_group_shuffle")
+        || nameNoArgs.contains("group_broadcast")
+        || nameNoArgs.startswith("sub_group_elect")
+        || nameNoArgs.startswith("sub_group_non_uniform_all") // includes _equal
+        || nameNoArgs.startswith("sub_group_non_uniform_any")
+        || nameNoArgs.startswith("sub_group_non_uniform_broadcast")
+        || nameNoArgs.startswith("sub_group_broadcast_first")
+        || nameNoArgs.startswith("sub_group_ballot") // includes all ballot_*
+        || nameNoArgs.startswith("sub_group_inverse_ballot")) {
+      modifiedName = nameNoArgs.substr(nameNoArgs.find("group")).str();
+    } else {
+      // This mainly implements non-uniform arithmetic builtins.
+      auto logicalOp = nameNoArgs.contains("logical_") ? "logical_" : "";
+      auto nameSuffix = nameNoArgs.substr(nameNoArgs.rfind('_') + 1).str();
+      auto nonUniform = nameNoArgs.contains("clustered_")
+                        || nameNoArgs.contains("non_uniform_") ? "non_uniform_"
+                                                               : "";
+      char OpTyC = 0;
+      if (retTy->getOpcode() == SPIRV::OpTypeFloat)
+        OpTyC = 'f';
+      else if (retTy->getOpcode() == SPIRV::OpTypeInt) {
+        if (nameSuffix == "max" || nameSuffix == "min") {
+          // Get signedness from "unsigned" argument type of the demangled name.
+          OpTyC = firstArgC;
+          if (OpTyC != 'u')
+            OpTyC = 's';
+        } else
+          OpTyC = 'i';
+      } else
+        llvm_unreachable("Invalid OpenCL group builtin argument type");
+      modifiedName = "group_" + std::string(nonUniform)
+                     + std::string(logicalOp) + OpTyC + nameSuffix;
+    }
+  }
+  return modifiedName;
 }
 
 bool llvm::generateOpenCLBuiltinCall(const StringRef demangledName,
@@ -1213,9 +1437,11 @@ bool llvm::generateOpenCLBuiltinCall(const StringRef demangledName,
     nameNoArgs = tmpStr.second;
     returnTypeStr = tmpStr.first;
   }
-
+  // Modify the names of builtins to use smaller map of opcodes.
+  auto modifiedName = modifyBINameForLookup(nameNoArgs, retTy,
+                                            demangledName[firstBraceIdx + 1]);
   using namespace SPIRV;
-  const unsigned opcode = OpenCLBIMap.lookup(nameNoArgs);
+  const unsigned opcode = OpenCLBIToOperationMap.lookup(modifiedName);
   switch (opcode) {
   case OpFOrdEqual:
   case OpFUnordNotEqual:
@@ -1234,6 +1460,70 @@ bool llvm::generateOpenCLBuiltinCall(const StringRef demangledName,
   case OpAny:
   case OpAll:
     return genOpenCLRelational(MIRBuilder, opcode, OrigRet, retTy, args, TR);
+  case OpGroupAll:
+  case OpGroupAny:
+  case OpGroupBroadcast:
+  case OpGroupIAdd:
+  case OpGroupFAdd:
+  case OpGroupFMin:
+  case OpGroupUMin:
+  case OpGroupSMin:
+  case OpGroupFMax:
+  case OpGroupUMax:
+  case OpGroupSMax:
+  case OpGroupNonUniformElect:
+  case OpGroupNonUniformAll:
+  case OpGroupNonUniformAny:
+  case OpGroupNonUniformAllEqual:
+  case OpGroupNonUniformBroadcast:
+  case OpGroupNonUniformBroadcastFirst:
+  case OpGroupNonUniformBallot:
+  case OpGroupNonUniformInverseBallot:
+  case OpGroupNonUniformBallotBitExtract:
+  case OpGroupNonUniformBallotBitCount:
+  case OpGroupNonUniformBallotFindLSB:
+  case OpGroupNonUniformBallotFindMSB:
+  case OpGroupNonUniformShuffle:
+  case OpGroupNonUniformShuffleXor:
+  case OpGroupNonUniformShuffleUp:
+  case OpGroupNonUniformShuffleDown:
+  case OpGroupNonUniformIAdd:
+  case OpGroupNonUniformFAdd:
+  case OpGroupNonUniformIMul:
+  case OpGroupNonUniformFMul:
+  case OpGroupNonUniformSMin:
+  case OpGroupNonUniformUMin:
+  case OpGroupNonUniformFMin:
+  case OpGroupNonUniformSMax:
+  case OpGroupNonUniformUMax:
+  case OpGroupNonUniformFMax:
+  case OpGroupNonUniformBitwiseAnd:
+  case OpGroupNonUniformBitwiseOr:
+  case OpGroupNonUniformBitwiseXor:
+  case OpGroupNonUniformLogicalAnd:
+  case OpGroupNonUniformLogicalOr:
+  case OpGroupNonUniformLogicalXor:
+    return genOpenCLOpGroup(MIRBuilder, nameNoArgs, opcode, OrigRet, retTy,
+                            args, TR);
+  default:
+    break;
+  }
+
+  const BuiltIn::BuiltIn builtInVar = OpenCLBIToBuiltInVarMap.lookup(nameNoArgs);
+  switch (builtInVar) {
+  case BuiltIn::SubgroupEqMask:
+  case BuiltIn::SubgroupGeMask:
+  case BuiltIn::SubgroupGtMask:
+  case BuiltIn::SubgroupLeMask:
+  case BuiltIn::SubgroupLtMask: {
+    unsigned BitWidth = TR->getScalarOrVectorBitWidth(retTy);
+    LLT llt;
+    if (retTy->getOpcode() == SPIRV::OpTypeVector)
+      llt = LLT::fixed_vector(retTy->getOperand(2).getImm(), BitWidth);
+    else
+      llt = LLT::scalar(BitWidth);
+    return buildBuiltInLoad(MIRBuilder, retTy, TR, builtInVar, llt, OrigRet);
+  }
   default:
     break;
   }

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
@@ -171,7 +171,8 @@ void SPIRVSubtarget::initAvailableCapabilities(const Triple &TT) {
   } else {
     // Add the min requirements for different OpenCL and SPIR-V versions
     addCaps(availableCaps,
-            {Addresses, Float16Buffer, Int16, Int8, Kernel, Linkage, Vector16});
+            {Addresses, Float16Buffer, Int16, Int8, Kernel, Linkage, Vector16,
+             Groups});
     if (openCLFullProfile) {
       addCaps(availableCaps, {Int64, Int64Atomics});
     }
@@ -185,6 +186,12 @@ void SPIRVSubtarget::initAvailableCapabilities(const Triple &TT) {
     if (isAtLeastVer(targetSPIRVVersion, 11) &&
         isAtLeastVer(targetOpenCLVersion, 22)) {
       addCaps(availableCaps, {SubgroupDispatch, PipeStorage});
+    }
+    if (isAtLeastVer(targetSPIRVVersion, 13)) {
+      addCaps(availableCaps, {GroupNonUniform, GroupNonUniformVote,
+                              GroupNonUniformArithmetic, GroupNonUniformBallot,
+                              GroupNonUniformClustered, GroupNonUniformShuffle,
+                              GroupNonUniformShuffleRelative});
     }
 
     // TODO Remove this - it's only here because the tests assume it's supported

--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
@@ -472,6 +472,8 @@ unsigned SPIRVTypeRegistry::getScalarOrVectorBitWidth(const SPIRVType *type) con
   if (type && (type->getOpcode() == SPIRV::OpTypeInt ||
                type->getOpcode() == SPIRV::OpTypeFloat)) {
     return type->getOperand(1).getImm();
+  } else if (type && type->getOpcode() == SPIRV::OpTypeBool) {
+    return 1;
   }
   llvm_unreachable("Attempting to get bit width of non-integer/float type.");
 }

--- a/llvm/test/CodeGen/SPIRV/transcoding/sub_group_ballot.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/sub_group_ballot.ll
@@ -231,7 +231,7 @@ target triple = "spirv64-unknown-unknown"
 ; CHECK-SPIRV-DAG: %[[float_0:[0-9]+]] = OpConstant %[[float]] 0
 ; CHECK-SPIRV-DAG: %[[double_0:[0-9]+]] = OpConstant %[[double]] 0
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[char]] %[[ScopeSubgroup]] %[[char_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[char2_0:[0-9]+]] = OpVectorShuffle %[[char2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[char2]] %[[ScopeSubgroup]] %[[char2_0]] %[[int_0]]
@@ -295,7 +295,7 @@ declare dso_local spir_func <16 x i8> @_Z31sub_group_non_uniform_broadcastDv16_c
 ; Function Attrs: convergent
 declare dso_local spir_func signext i8 @_Z25sub_group_broadcast_firstc(i8 signext) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[char]] %[[ScopeSubgroup]] %[[char_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[char2_0:[0-9]+]] = OpVectorShuffle %[[char2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[char2]] %[[ScopeSubgroup]] %[[char2_0]] %[[int_0]]
@@ -359,7 +359,7 @@ declare dso_local spir_func <16 x i8> @_Z31sub_group_non_uniform_broadcastDv16_h
 ; Function Attrs: convergent
 declare dso_local spir_func zeroext i8 @_Z25sub_group_broadcast_firsth(i8 zeroext) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[short]] %[[ScopeSubgroup]] %[[short_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[short2_0:[0-9]+]] = OpVectorShuffle %[[short2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[short2]] %[[ScopeSubgroup]] %[[short2_0]] %[[int_0]]
@@ -423,7 +423,7 @@ declare dso_local spir_func <16 x i16> @_Z31sub_group_non_uniform_broadcastDv16_
 ; Function Attrs: convergent
 declare dso_local spir_func signext i16 @_Z25sub_group_broadcast_firsts(i16 signext) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[short]] %[[ScopeSubgroup]] %[[short_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[short2_0:[0-9]+]] = OpVectorShuffle %[[short2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[short2]] %[[ScopeSubgroup]] %[[short2_0]] %[[int_0]]
@@ -487,7 +487,7 @@ declare dso_local spir_func <16 x i16> @_Z31sub_group_non_uniform_broadcastDv16_
 ; Function Attrs: convergent
 declare dso_local spir_func zeroext i16 @_Z25sub_group_broadcast_firstt(i16 zeroext) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[int]] %[[ScopeSubgroup]] %[[int_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[int2_0:[0-9]+]] = OpVectorShuffle %[[int2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[int2]] %[[ScopeSubgroup]] %[[int2_0]] %[[int_0]]
@@ -551,7 +551,7 @@ declare dso_local spir_func <16 x i32> @_Z31sub_group_non_uniform_broadcastDv16_
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z25sub_group_broadcast_firsti(i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[int]] %[[ScopeSubgroup]] %[[int_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[int2_0:[0-9]+]] = OpVectorShuffle %[[int2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[int2]] %[[ScopeSubgroup]] %[[int2_0]] %[[int_0]]
@@ -616,7 +616,7 @@ declare dso_local spir_func <16 x i32> @_Z31sub_group_non_uniform_broadcastDv16_
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z25sub_group_broadcast_firstj(i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[long]] %[[ScopeSubgroup]] %[[long_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[long2_0:[0-9]+]] = OpVectorShuffle %[[long2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[long2]] %[[ScopeSubgroup]] %[[long2_0]] %[[int_0]]
@@ -680,7 +680,7 @@ declare dso_local spir_func <16 x i64> @_Z31sub_group_non_uniform_broadcastDv16_
 ; Function Attrs: convergent
 declare dso_local spir_func i64 @_Z25sub_group_broadcast_firstl(i64) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[long]] %[[ScopeSubgroup]] %[[long_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[long2_0:[0-9]+]] = OpVectorShuffle %[[long2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[long2]] %[[ScopeSubgroup]] %[[long2_0]] %[[int_0]]
@@ -744,7 +744,7 @@ declare dso_local spir_func <16 x i64> @_Z31sub_group_non_uniform_broadcastDv16_
 ; Function Attrs: convergent
 declare dso_local spir_func i64 @_Z25sub_group_broadcast_firstm(i64) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[float]] %[[ScopeSubgroup]] %[[float_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[float2_0:[0-9]+]] = OpVectorShuffle %[[float2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[float2]] %[[ScopeSubgroup]] %[[float2_0]] %[[int_0]]
@@ -808,7 +808,7 @@ declare dso_local spir_func <16 x float> @_Z31sub_group_non_uniform_broadcastDv1
 ; Function Attrs: convergent
 declare dso_local spir_func float @_Z25sub_group_broadcast_firstf(float) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[half]] %[[ScopeSubgroup]] %[[half_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[half2_0:[0-9]+]] = OpVectorShuffle %[[half2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[half2]] %[[ScopeSubgroup]] %[[half2_0]] %[[int_0]]
@@ -872,7 +872,7 @@ declare dso_local spir_func <16 x half> @_Z31sub_group_non_uniform_broadcastDv16
 ; Function Attrs: convergent
 declare dso_local spir_func half @_Z25sub_group_broadcast_firstDh(half) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[double]] %[[ScopeSubgroup]] %[[double_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[double2_0:[0-9]+]] = OpVectorShuffle %[[double2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBroadcast %[[double2]] %[[ScopeSubgroup]] %[[double2_0]] %[[int_0]]
@@ -936,7 +936,7 @@ declare dso_local spir_func <16 x double> @_Z31sub_group_non_uniform_broadcastDv
 ; Function Attrs: convergent
 declare dso_local spir_func double @_Z25sub_group_broadcast_firstd(double) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %[[ballot:[0-9]+]] = OpGroupNonUniformBallot %[[int4]] %[[ScopeSubgroup]] %[[false]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformInverseBallot %[[bool]] %[[ScopeSubgroup]] %[[ballot]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBallotBitExtract %[[bool]] %[[ScopeSubgroup]] %[[ballot]] %[[int_0]]
@@ -997,7 +997,7 @@ declare dso_local spir_func i32 @_Z25sub_group_ballot_find_lsbDv4_j(<4 x i32>) l
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z25sub_group_ballot_find_msbDv4_j(<4 x i32>) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpLoad %[[int4]] %[[eqMask]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpLoad %[[int4]] %[[geMask]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpLoad %[[int4]] %[[gtMask]]

--- a/llvm/test/CodeGen/SPIRV/transcoding/sub_group_clustered_reduce.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/sub_group_clustered_reduce.ll
@@ -202,7 +202,7 @@ source_filename = "sub_group_clustered_reduce.cl"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv64-unknown-unknown"
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIAdd %[[char]] %[[ScopeSubgroup]] ClusteredReduce %[[char_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIMul %[[char]] %[[ScopeSubgroup]] ClusteredReduce %[[char_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformSMin %[[char]] %[[ScopeSubgroup]] ClusteredReduce %[[char_0]] %[[int_2]]
@@ -237,7 +237,7 @@ declare dso_local spir_func signext i8 @_Z30sub_group_clustered_reduce_mincj(i8 
 ; Function Attrs: convergent
 declare dso_local spir_func signext i8 @_Z30sub_group_clustered_reduce_maxcj(i8 signext, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIAdd %[[char]] %[[ScopeSubgroup]] ClusteredReduce %[[char_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIMul %[[char]] %[[ScopeSubgroup]] ClusteredReduce %[[char_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformUMin %[[char]] %[[ScopeSubgroup]] ClusteredReduce %[[char_0]] %[[int_2]]
@@ -272,7 +272,7 @@ declare dso_local spir_func zeroext i8 @_Z30sub_group_clustered_reduce_minhj(i8 
 ; Function Attrs: convergent
 declare dso_local spir_func zeroext i8 @_Z30sub_group_clustered_reduce_maxhj(i8 zeroext, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIAdd %[[short]] %[[ScopeSubgroup]] ClusteredReduce %[[short_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIMul %[[short]] %[[ScopeSubgroup]] ClusteredReduce %[[short_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformSMin %[[short]] %[[ScopeSubgroup]] ClusteredReduce %[[short_0]] %[[int_2]]
@@ -307,7 +307,7 @@ declare dso_local spir_func signext i16 @_Z30sub_group_clustered_reduce_minsj(i1
 ; Function Attrs: convergent
 declare dso_local spir_func signext i16 @_Z30sub_group_clustered_reduce_maxsj(i16 signext, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIAdd %[[short]] %[[ScopeSubgroup]] ClusteredReduce %[[short_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIMul %[[short]] %[[ScopeSubgroup]] ClusteredReduce %[[short_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformUMin %[[short]] %[[ScopeSubgroup]] ClusteredReduce %[[short_0]] %[[int_2]]
@@ -342,7 +342,7 @@ declare dso_local spir_func zeroext i16 @_Z30sub_group_clustered_reduce_mintj(i1
 ; Function Attrs: convergent
 declare dso_local spir_func zeroext i16 @_Z30sub_group_clustered_reduce_maxtj(i16 zeroext, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIAdd %[[int]] %[[ScopeSubgroup]] ClusteredReduce %[[int_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIMul %[[int]] %[[ScopeSubgroup]] ClusteredReduce %[[int_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformSMin %[[int]] %[[ScopeSubgroup]] ClusteredReduce %[[int_0]] %[[int_2]]
@@ -377,7 +377,7 @@ declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_minij(i32, i32) 
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_maxij(i32, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIAdd %[[int]] %[[ScopeSubgroup]] ClusteredReduce %[[int_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIMul %[[int]] %[[ScopeSubgroup]] ClusteredReduce %[[int_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformUMin %[[int]] %[[ScopeSubgroup]] ClusteredReduce %[[int_0]] %[[int_2]]
@@ -412,7 +412,7 @@ declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_minjj(i32, i32) 
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_maxjj(i32, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIAdd %[[long]] %[[ScopeSubgroup]] ClusteredReduce %[[long_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIMul %[[long]] %[[ScopeSubgroup]] ClusteredReduce %[[long_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformSMin %[[long]] %[[ScopeSubgroup]] ClusteredReduce %[[long_0]] %[[int_2]]
@@ -447,7 +447,7 @@ declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_minlj(i64, i32) 
 ; Function Attrs: convergent
 declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_maxlj(i64, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIAdd %[[long]] %[[ScopeSubgroup]] ClusteredReduce %[[long_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIMul %[[long]] %[[ScopeSubgroup]] ClusteredReduce %[[long_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformUMin %[[long]] %[[ScopeSubgroup]] ClusteredReduce %[[long_0]] %[[int_2]]
@@ -482,7 +482,7 @@ declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_minmj(i64, i32) 
 ; Function Attrs: convergent
 declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_maxmj(i64, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFAdd %[[float]] %[[ScopeSubgroup]] ClusteredReduce %[[float_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFMul %[[float]] %[[ScopeSubgroup]] ClusteredReduce %[[float_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFMin %[[float]] %[[ScopeSubgroup]] ClusteredReduce %[[float_0]] %[[int_2]]
@@ -517,7 +517,7 @@ declare dso_local spir_func float @_Z30sub_group_clustered_reduce_minfj(float, i
 ; Function Attrs: convergent
 declare dso_local spir_func float @_Z30sub_group_clustered_reduce_maxfj(float, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFAdd %[[half]] %[[ScopeSubgroup]] ClusteredReduce %[[half_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFMul %[[half]] %[[ScopeSubgroup]] ClusteredReduce %[[half_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFMin %[[half]] %[[ScopeSubgroup]] ClusteredReduce %[[half_0]] %[[int_2]]
@@ -552,7 +552,7 @@ declare dso_local spir_func half @_Z30sub_group_clustered_reduce_minDhj(half, i3
 ; Function Attrs: convergent
 declare dso_local spir_func half @_Z30sub_group_clustered_reduce_maxDhj(half, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFAdd %[[double]] %[[ScopeSubgroup]] ClusteredReduce %[[double_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFMul %[[double]] %[[ScopeSubgroup]] ClusteredReduce %[[double_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFMin %[[double]] %[[ScopeSubgroup]] ClusteredReduce %[[double_0]] %[[int_2]]
@@ -587,7 +587,7 @@ declare dso_local spir_func double @_Z30sub_group_clustered_reduce_mindj(double,
 ; Function Attrs: convergent
 declare dso_local spir_func double @_Z30sub_group_clustered_reduce_maxdj(double, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseAnd %[[char]] %[[ScopeSubgroup]] ClusteredReduce %[[char_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseOr  %[[char]] %[[ScopeSubgroup]] ClusteredReduce %[[char_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseXor %[[char]] %[[ScopeSubgroup]] ClusteredReduce %[[char_0]] %[[int_2]]
@@ -615,7 +615,7 @@ declare dso_local spir_func signext i8 @_Z29sub_group_clustered_reduce_orcj(i8 s
 ; Function Attrs: convergent
 declare dso_local spir_func signext i8 @_Z30sub_group_clustered_reduce_xorcj(i8 signext, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseAnd %[[char]] %[[ScopeSubgroup]] ClusteredReduce %[[char_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseOr  %[[char]] %[[ScopeSubgroup]] ClusteredReduce %[[char_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseXor %[[char]] %[[ScopeSubgroup]] ClusteredReduce %[[char_0]] %[[int_2]]
@@ -643,7 +643,7 @@ declare dso_local spir_func zeroext i8 @_Z29sub_group_clustered_reduce_orhj(i8 z
 ; Function Attrs: convergent
 declare dso_local spir_func zeroext i8 @_Z30sub_group_clustered_reduce_xorhj(i8 zeroext, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseAnd %[[short]] %[[ScopeSubgroup]] ClusteredReduce %[[short_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseOr  %[[short]] %[[ScopeSubgroup]] ClusteredReduce %[[short_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseXor %[[short]] %[[ScopeSubgroup]] ClusteredReduce %[[short_0]] %[[int_2]]
@@ -671,7 +671,7 @@ declare dso_local spir_func signext i16 @_Z29sub_group_clustered_reduce_orsj(i16
 ; Function Attrs: convergent
 declare dso_local spir_func signext i16 @_Z30sub_group_clustered_reduce_xorsj(i16 signext, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseAnd %[[short]] %[[ScopeSubgroup]] ClusteredReduce %[[short_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseOr  %[[short]] %[[ScopeSubgroup]] ClusteredReduce %[[short_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseXor %[[short]] %[[ScopeSubgroup]] ClusteredReduce %[[short_0]] %[[int_2]]
@@ -699,7 +699,7 @@ declare dso_local spir_func zeroext i16 @_Z29sub_group_clustered_reduce_ortj(i16
 ; Function Attrs: convergent
 declare dso_local spir_func zeroext i16 @_Z30sub_group_clustered_reduce_xortj(i16 zeroext, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseAnd %[[int]] %[[ScopeSubgroup]] ClusteredReduce %[[int_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseOr  %[[int]] %[[ScopeSubgroup]] ClusteredReduce %[[int_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseXor %[[int]] %[[ScopeSubgroup]] ClusteredReduce %[[int_0]] %[[int_2]]
@@ -727,7 +727,7 @@ declare dso_local spir_func i32 @_Z29sub_group_clustered_reduce_orij(i32, i32) l
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_xorij(i32, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseAnd %[[int]] %[[ScopeSubgroup]] ClusteredReduce %[[int_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseOr  %[[int]] %[[ScopeSubgroup]] ClusteredReduce %[[int_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseXor %[[int]] %[[ScopeSubgroup]] ClusteredReduce %[[int_0]] %[[int_2]]
@@ -755,7 +755,7 @@ declare dso_local spir_func i32 @_Z29sub_group_clustered_reduce_orjj(i32, i32) l
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z30sub_group_clustered_reduce_xorjj(i32, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseAnd %[[long]] %[[ScopeSubgroup]] ClusteredReduce %[[long_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseOr  %[[long]] %[[ScopeSubgroup]] ClusteredReduce %[[long_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseXor %[[long]] %[[ScopeSubgroup]] ClusteredReduce %[[long_0]] %[[int_2]]
@@ -783,7 +783,7 @@ declare dso_local spir_func i64 @_Z29sub_group_clustered_reduce_orlj(i64, i32) l
 ; Function Attrs: convergent
 declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_xorlj(i64, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseAnd %[[long]] %[[ScopeSubgroup]] ClusteredReduce %[[long_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseOr  %[[long]] %[[ScopeSubgroup]] ClusteredReduce %[[long_0]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseXor %[[long]] %[[ScopeSubgroup]] ClusteredReduce %[[long_0]] %[[int_2]]
@@ -811,7 +811,7 @@ declare dso_local spir_func i64 @_Z29sub_group_clustered_reduce_ormj(i64, i32) l
 ; Function Attrs: convergent
 declare dso_local spir_func i64 @_Z30sub_group_clustered_reduce_xormj(i64, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformLogicalAnd %[[bool]] %[[ScopeSubgroup]] ClusteredReduce %[[false]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformLogicalOr  %[[bool]] %[[ScopeSubgroup]] ClusteredReduce %[[false]] %[[int_2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformLogicalXor %[[bool]] %[[ScopeSubgroup]] ClusteredReduce %[[false]] %[[int_2]]

--- a/llvm/test/CodeGen/SPIRV/transcoding/sub_group_extended_types.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/sub_group_extended_types.ll
@@ -245,7 +245,7 @@ source_filename = "sub_group_extended_types.cl"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv64-unknown-unknown"
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[char]] %[[ScopeSubgroup]] %[[char_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[char2_0:[0-9]+]] = OpVectorShuffle %[[char2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[char2]] %[[ScopeSubgroup]] %[[char2_0]] %[[int_0]]
@@ -302,7 +302,7 @@ declare dso_local spir_func <8 x i8> @_Z19sub_group_broadcastDv8_cj(<8 x i8>, i3
 ; Function Attrs: convergent
 declare dso_local spir_func <16 x i8> @_Z19sub_group_broadcastDv16_cj(<16 x i8>, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[char]] %[[ScopeSubgroup]] %[[char_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[char2_0:[0-9]+]] = OpVectorShuffle %[[char2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[char2]] %[[ScopeSubgroup]] %[[char2_0]] %[[int_0]]
@@ -359,7 +359,7 @@ declare dso_local spir_func <8 x i8> @_Z19sub_group_broadcastDv8_hj(<8 x i8>, i3
 ; Function Attrs: convergent
 declare dso_local spir_func <16 x i8> @_Z19sub_group_broadcastDv16_hj(<16 x i8>, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[short]] %[[ScopeSubgroup]] %[[short_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[short2_0:[0-9]+]] = OpVectorShuffle %[[short2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[short2]] %[[ScopeSubgroup]] %[[short2_0]] %[[int_0]]
@@ -416,7 +416,7 @@ declare dso_local spir_func <8 x i16> @_Z19sub_group_broadcastDv8_sj(<8 x i16>, 
 ; Function Attrs: convergent
 declare dso_local spir_func <16 x i16> @_Z19sub_group_broadcastDv16_sj(<16 x i16>, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[short]] %[[ScopeSubgroup]] %[[short_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[short2_0:[0-9]+]] = OpVectorShuffle %[[short2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[short2]] %[[ScopeSubgroup]] %[[short2_0]] %[[int_0]]
@@ -473,7 +473,7 @@ declare dso_local spir_func <8 x i16> @_Z19sub_group_broadcastDv8_tj(<8 x i16>, 
 ; Function Attrs: convergent
 declare dso_local spir_func <16 x i16> @_Z19sub_group_broadcastDv16_tj(<16 x i16>, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[int]] %[[ScopeSubgroup]] %[[int_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[int2_0:[0-9]+]] = OpVectorShuffle %[[int2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[int2]] %[[ScopeSubgroup]] %[[int2_0]] %[[int_0]]
@@ -530,7 +530,7 @@ declare dso_local spir_func <8 x i32> @_Z19sub_group_broadcastDv8_ij(<8 x i32>, 
 ; Function Attrs: convergent
 declare dso_local spir_func <16 x i32> @_Z19sub_group_broadcastDv16_ij(<16 x i32>, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[int]] %[[ScopeSubgroup]] %[[int_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[int2_0:[0-9]+]] = OpVectorShuffle %[[int2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[int2]] %[[ScopeSubgroup]] %[[int2_0]] %[[int_0]]
@@ -587,7 +587,7 @@ declare dso_local spir_func <8 x i32> @_Z19sub_group_broadcastDv8_jj(<8 x i32>, 
 ; Function Attrs: convergent
 declare dso_local spir_func <16 x i32> @_Z19sub_group_broadcastDv16_jj(<16 x i32>, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[long]] %[[ScopeSubgroup]] %[[long_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[long2_0:[0-9]+]] = OpVectorShuffle %[[long2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[long2]] %[[ScopeSubgroup]] %[[long2_0]] %[[int_0]]
@@ -644,7 +644,7 @@ declare dso_local spir_func <8 x i64> @_Z19sub_group_broadcastDv8_lj(<8 x i64>, 
 ; Function Attrs: convergent
 declare dso_local spir_func <16 x i64> @_Z19sub_group_broadcastDv16_lj(<16 x i64>, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[long]] %[[ScopeSubgroup]] %[[long_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[long2_0:[0-9]+]] = OpVectorShuffle %[[long2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[long2]] %[[ScopeSubgroup]] %[[long2_0]] %[[int_0]]
@@ -701,7 +701,7 @@ declare dso_local spir_func <8 x i64> @_Z19sub_group_broadcastDv8_mj(<8 x i64>, 
 ; Function Attrs: convergent
 declare dso_local spir_func <16 x i64> @_Z19sub_group_broadcastDv16_mj(<16 x i64>, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[float]] %[[ScopeSubgroup]] %[[float_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[float2_0:[0-9]+]] = OpVectorShuffle %[[float2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[float2]] %[[ScopeSubgroup]] %[[float2_0]] %[[int_0]]
@@ -758,7 +758,7 @@ declare dso_local spir_func <8 x float> @_Z19sub_group_broadcastDv8_fj(<8 x floa
 ; Function Attrs: convergent
 declare dso_local spir_func <16 x float> @_Z19sub_group_broadcastDv16_fj(<16 x float>, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[half]] %[[ScopeSubgroup]] %[[half_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[half2_0:[0-9]+]] = OpVectorShuffle %[[half2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[half2]] %[[ScopeSubgroup]] %[[half2_0]] %[[int_0]]
@@ -815,7 +815,7 @@ declare dso_local spir_func <8 x half> @_Z19sub_group_broadcastDv8_Dhj(<8 x half
 ; Function Attrs: convergent
 declare dso_local spir_func <16 x half> @_Z19sub_group_broadcastDv16_Dhj(<16 x half>, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[double]] %[[ScopeSubgroup]] %[[double_0]] %[[int_0]]
 ; CHECK-SPIRV: %[[double2_0:[0-9]+]] = OpVectorShuffle %[[double2]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupBroadcast %[[double2]] %[[ScopeSubgroup]] %[[double2_0]] %[[int_0]]
@@ -872,7 +872,7 @@ declare dso_local spir_func <8 x double> @_Z19sub_group_broadcastDv8_dj(<8 x dou
 ; Function Attrs: convergent
 declare dso_local spir_func <16 x double> @_Z19sub_group_broadcastDv16_dj(<16 x double>, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupIAdd %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupSMin %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupSMax %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
@@ -942,7 +942,7 @@ declare dso_local spir_func signext i8 @_Z28sub_group_scan_exclusive_minc(i8 sig
 ; Function Attrs: convergent
 declare dso_local spir_func signext i8 @_Z28sub_group_scan_exclusive_maxc(i8 signext) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupIAdd %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupUMin %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupUMax %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
@@ -1012,7 +1012,7 @@ declare dso_local spir_func zeroext i8 @_Z28sub_group_scan_exclusive_minh(i8 zer
 ; Function Attrs: convergent
 declare dso_local spir_func zeroext i8 @_Z28sub_group_scan_exclusive_maxh(i8 zeroext) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupIAdd %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupSMin %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupSMax %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]
@@ -1082,7 +1082,7 @@ declare dso_local spir_func signext i16 @_Z28sub_group_scan_exclusive_mins(i16 s
 ; Function Attrs: convergent
 declare dso_local spir_func signext i16 @_Z28sub_group_scan_exclusive_maxs(i16 signext) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupIAdd %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupUMin %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupUMax %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]

--- a/llvm/test/CodeGen/SPIRV/transcoding/sub_group_non_uniform_arithmetic.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/sub_group_non_uniform_arithmetic.ll
@@ -336,7 +336,7 @@ source_filename = "sub_group_non_uniform_arithmetic.cl"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv64-unknown-unknown"
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIAdd %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIMul %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformSMin %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
@@ -427,7 +427,7 @@ declare dso_local spir_func signext i8 @_Z40sub_group_non_uniform_scan_exclusive
 ; Function Attrs: convergent
 declare dso_local spir_func signext i8 @_Z40sub_group_non_uniform_scan_exclusive_maxc(i8 signext) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIAdd %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIMul %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformUMin %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
@@ -518,7 +518,7 @@ declare dso_local spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_exclusive
 ; Function Attrs: convergent
 declare dso_local spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_exclusive_maxh(i8 zeroext) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIAdd %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIMul %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformSMin %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]
@@ -609,7 +609,7 @@ declare dso_local spir_func signext i16 @_Z40sub_group_non_uniform_scan_exclusiv
 ; Function Attrs: convergent
 declare dso_local spir_func signext i16 @_Z40sub_group_non_uniform_scan_exclusive_maxs(i16 signext) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIAdd %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIMul %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformUMin %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]
@@ -700,7 +700,7 @@ declare dso_local spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_exclusiv
 ; Function Attrs: convergent
 declare dso_local spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_exclusive_maxt(i16 zeroext) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIAdd %[[int]] %[[ScopeSubgroup]] Reduce %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIMul %[[int]] %[[ScopeSubgroup]] Reduce %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformSMin %[[int]] %[[ScopeSubgroup]] Reduce %[[int_0]]
@@ -791,7 +791,7 @@ declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_mini(i
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_maxi(i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIAdd %[[int]] %[[ScopeSubgroup]] Reduce %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIMul %[[int]] %[[ScopeSubgroup]] Reduce %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformUMin %[[int]] %[[ScopeSubgroup]] Reduce %[[int_0]]
@@ -882,7 +882,7 @@ declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_minj(i
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_maxj(i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIAdd %[[long]] %[[ScopeSubgroup]] Reduce %[[long_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIMul %[[long]] %[[ScopeSubgroup]] Reduce %[[long_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformSMin %[[long]] %[[ScopeSubgroup]] Reduce %[[long_0]]
@@ -973,7 +973,7 @@ declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_minl(i
 ; Function Attrs: convergent
 declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_maxl(i64) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIAdd %[[long]] %[[ScopeSubgroup]] Reduce %[[long_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformIMul %[[long]] %[[ScopeSubgroup]] Reduce %[[long_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformUMin %[[long]] %[[ScopeSubgroup]] Reduce %[[long_0]]
@@ -1064,7 +1064,7 @@ declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_minm(i
 ; Function Attrs: convergent
 declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_maxm(i64) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFAdd %[[float]] %[[ScopeSubgroup]] Reduce %[[float_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFMul %[[float]] %[[ScopeSubgroup]] Reduce %[[float_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFMin %[[float]] %[[ScopeSubgroup]] Reduce %[[float_0]]
@@ -1155,7 +1155,7 @@ declare dso_local spir_func float @_Z40sub_group_non_uniform_scan_exclusive_minf
 ; Function Attrs: convergent
 declare dso_local spir_func float @_Z40sub_group_non_uniform_scan_exclusive_maxf(float) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFAdd %[[half]] %[[ScopeSubgroup]] Reduce %[[half_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFMul %[[half]] %[[ScopeSubgroup]] Reduce %[[half_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFMin %[[half]] %[[ScopeSubgroup]] Reduce %[[half_0]]
@@ -1246,7 +1246,7 @@ declare dso_local spir_func half @_Z40sub_group_non_uniform_scan_exclusive_minDh
 ; Function Attrs: convergent
 declare dso_local spir_func half @_Z40sub_group_non_uniform_scan_exclusive_maxDh(half) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFAdd %[[double]] %[[ScopeSubgroup]] Reduce %[[double_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFMul %[[double]] %[[ScopeSubgroup]] Reduce %[[double_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformFMin %[[double]] %[[ScopeSubgroup]] Reduce %[[double_0]]
@@ -1337,7 +1337,7 @@ declare dso_local spir_func double @_Z40sub_group_non_uniform_scan_exclusive_min
 ; Function Attrs: convergent
 declare dso_local spir_func double @_Z40sub_group_non_uniform_scan_exclusive_maxd(double) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseAnd %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseOr  %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseXor %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
@@ -1407,7 +1407,7 @@ declare dso_local spir_func signext i8 @_Z39sub_group_non_uniform_scan_exclusive
 ; Function Attrs: convergent
 declare dso_local spir_func signext i8 @_Z40sub_group_non_uniform_scan_exclusive_xorc(i8 signext) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseAnd %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseOr  %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseXor %[[char]] %[[ScopeSubgroup]] Reduce %[[char_0]]
@@ -1477,7 +1477,7 @@ declare dso_local spir_func zeroext i8 @_Z39sub_group_non_uniform_scan_exclusive
 ; Function Attrs: convergent
 declare dso_local spir_func zeroext i8 @_Z40sub_group_non_uniform_scan_exclusive_xorh(i8 zeroext) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseAnd %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseOr  %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseXor %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]
@@ -1547,7 +1547,7 @@ declare dso_local spir_func signext i16 @_Z39sub_group_non_uniform_scan_exclusiv
 ; Function Attrs: convergent
 declare dso_local spir_func signext i16 @_Z40sub_group_non_uniform_scan_exclusive_xors(i16 signext) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseAnd %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseOr  %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseXor %[[short]] %[[ScopeSubgroup]] Reduce %[[short_0]]
@@ -1617,7 +1617,7 @@ declare dso_local spir_func zeroext i16 @_Z39sub_group_non_uniform_scan_exclusiv
 ; Function Attrs: convergent
 declare dso_local spir_func zeroext i16 @_Z40sub_group_non_uniform_scan_exclusive_xort(i16 zeroext) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseAnd %[[int]] %[[ScopeSubgroup]] Reduce %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseOr  %[[int]] %[[ScopeSubgroup]] Reduce %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseXor %[[int]] %[[ScopeSubgroup]] Reduce %[[int_0]]
@@ -1687,7 +1687,7 @@ declare dso_local spir_func i32 @_Z39sub_group_non_uniform_scan_exclusive_ori(i3
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_xori(i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseAnd %[[int]] %[[ScopeSubgroup]] Reduce %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseOr  %[[int]] %[[ScopeSubgroup]] Reduce %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseXor %[[int]] %[[ScopeSubgroup]] Reduce %[[int_0]]
@@ -1757,7 +1757,7 @@ declare dso_local spir_func i32 @_Z39sub_group_non_uniform_scan_exclusive_orj(i3
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z40sub_group_non_uniform_scan_exclusive_xorj(i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseAnd %[[long]] %[[ScopeSubgroup]] Reduce %[[long_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseOr  %[[long]] %[[ScopeSubgroup]] Reduce %[[long_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseXor %[[long]] %[[ScopeSubgroup]] Reduce %[[long_0]]
@@ -1827,7 +1827,7 @@ declare dso_local spir_func i64 @_Z39sub_group_non_uniform_scan_exclusive_orl(i6
 ; Function Attrs: convergent
 declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_xorl(i64) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseAnd %[[long]] %[[ScopeSubgroup]] Reduce %[[long_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseOr  %[[long]] %[[ScopeSubgroup]] Reduce %[[long_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformBitwiseXor %[[long]] %[[ScopeSubgroup]] Reduce %[[long_0]]
@@ -1897,7 +1897,7 @@ declare dso_local spir_func i64 @_Z39sub_group_non_uniform_scan_exclusive_orm(i6
 ; Function Attrs: convergent
 declare dso_local spir_func i64 @_Z40sub_group_non_uniform_scan_exclusive_xorm(i64) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformLogicalAnd %[[bool]] %[[ScopeSubgroup]] Reduce %[[false]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformLogicalOr  %[[bool]] %[[ScopeSubgroup]] Reduce %[[false]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformLogicalXor %[[bool]] %[[ScopeSubgroup]] Reduce %[[false]]

--- a/llvm/test/CodeGen/SPIRV/transcoding/sub_group_non_uniform_vote.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/sub_group_non_uniform_vote.ll
@@ -68,7 +68,6 @@ source_filename = "sub_group_non_uniform_vote.cl"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv64-unknown-unknown"
 
-; CHECK-SPIRV-DAG: OpCapability GroupNonUniform
 ; CHECK-SPIRV-DAG: OpCapability GroupNonUniformVote
 
 ; CHECK-SPIRV-DAG: %[[bool:[0-9]+]] = OpTypeBool
@@ -90,7 +89,7 @@ target triple = "spirv64-unknown-unknown"
 ; CHECK-SPIRV-DAG: %[[float_0:[0-9]+]] = OpConstant %[[float]] 0
 ; CHECK-SPIRV-DAG: %[[double_0:[0-9]+]] = OpConstant %[[double]] 0
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformElect %[[bool]] %[[ScopeSubgroup]]
 ; CHECK-SPIRV: OpFunctionEnd
 
@@ -104,7 +103,7 @@ define dso_local spir_kernel void @testSubGroupElect(i32 addrspace(1)* nocapture
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z15sub_group_electv() local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformAll %[[bool]] %[[ScopeSubgroup]] %[[false]]
 ; CHECK-SPIRV: OpFunctionEnd
 
@@ -118,7 +117,7 @@ define dso_local spir_kernel void @testSubGroupNonUniformAll(i32 addrspace(1)* n
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z25sub_group_non_uniform_alli(i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformAny %[[bool]] %[[ScopeSubgroup]] %[[false]]
 ; CHECK-SPIRV: OpFunctionEnd
 
@@ -132,7 +131,7 @@ define dso_local spir_kernel void @testSubGroupNonUniformAny(i32 addrspace(1)* n
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z25sub_group_non_uniform_anyi(i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformAllEqual %[[bool]] %[[ScopeSubgroup]] %[[char_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformAllEqual %[[bool]] %[[ScopeSubgroup]] %[[char_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformAllEqual %[[bool]] %[[ScopeSubgroup]] %[[short_0]]

--- a/llvm/test/CodeGen/SPIRV/transcoding/sub_group_shuffle.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/sub_group_shuffle.ll
@@ -105,7 +105,7 @@ source_filename = "sub_group_shuffle.cl"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv64-unknown-unknown"
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffle %[[char]] %[[ScopeSubgroup]] %[[char_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleXor %[[char]] %[[ScopeSubgroup]] %[[char_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -126,7 +126,7 @@ declare dso_local spir_func signext i8 @_Z17sub_group_shufflecj(i8 signext, i32)
 ; Function Attrs: convergent
 declare dso_local spir_func signext i8 @_Z21sub_group_shuffle_xorcj(i8 signext, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffle %[[char]] %[[ScopeSubgroup]] %[[char_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleXor %[[char]] %[[ScopeSubgroup]] %[[char_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -147,7 +147,7 @@ declare dso_local spir_func zeroext i8 @_Z17sub_group_shufflehj(i8 zeroext, i32)
 ; Function Attrs: convergent
 declare dso_local spir_func zeroext i8 @_Z21sub_group_shuffle_xorhj(i8 zeroext, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffle %[[short]] %[[ScopeSubgroup]] %[[short_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleXor %[[short]] %[[ScopeSubgroup]] %[[short_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -168,7 +168,7 @@ declare dso_local spir_func signext i16 @_Z17sub_group_shufflesj(i16 signext, i3
 ; Function Attrs: convergent
 declare dso_local spir_func signext i16 @_Z21sub_group_shuffle_xorsj(i16 signext, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffle %[[short]] %[[ScopeSubgroup]] %[[short_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleXor %[[short]] %[[ScopeSubgroup]] %[[short_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -189,7 +189,7 @@ declare dso_local spir_func zeroext i16 @_Z17sub_group_shuffletj(i16 zeroext, i3
 ; Function Attrs: convergent
 declare dso_local spir_func zeroext i16 @_Z21sub_group_shuffle_xortj(i16 zeroext, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffle %[[int]] %[[ScopeSubgroup]] %[[int_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleXor %[[int]] %[[ScopeSubgroup]] %[[int_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -210,7 +210,7 @@ declare dso_local spir_func i32 @_Z17sub_group_shuffleij(i32, i32) local_unnamed
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z21sub_group_shuffle_xorij(i32, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffle %[[int]] %[[ScopeSubgroup]] %[[int_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleXor %[[int]] %[[ScopeSubgroup]] %[[int_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -231,7 +231,7 @@ declare dso_local spir_func i32 @_Z17sub_group_shufflejj(i32, i32) local_unnamed
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z21sub_group_shuffle_xorjj(i32, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffle %[[long]] %[[ScopeSubgroup]] %[[long_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleXor %[[long]] %[[ScopeSubgroup]] %[[long_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -252,7 +252,7 @@ declare dso_local spir_func i64 @_Z17sub_group_shufflelj(i64, i32) local_unnamed
 ; Function Attrs: convergent
 declare dso_local spir_func i64 @_Z21sub_group_shuffle_xorlj(i64, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffle %[[long]] %[[ScopeSubgroup]] %[[long_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleXor %[[long]] %[[ScopeSubgroup]] %[[long_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -273,7 +273,7 @@ declare dso_local spir_func i64 @_Z17sub_group_shufflemj(i64, i32) local_unnamed
 ; Function Attrs: convergent
 declare dso_local spir_func i64 @_Z21sub_group_shuffle_xormj(i64, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffle %[[float]] %[[ScopeSubgroup]] %[[float_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleXor %[[float]] %[[ScopeSubgroup]] %[[float_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -294,7 +294,7 @@ declare dso_local spir_func float @_Z17sub_group_shufflefj(float, i32) local_unn
 ; Function Attrs: convergent
 declare dso_local spir_func float @_Z21sub_group_shuffle_xorfj(float, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffle %[[half]] %[[ScopeSubgroup]] %[[half_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleXor %[[half]] %[[ScopeSubgroup]] %[[half_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -315,7 +315,7 @@ declare dso_local spir_func half @_Z17sub_group_shuffleDhj(half, i32) local_unna
 ; Function Attrs: convergent
 declare dso_local spir_func half @_Z21sub_group_shuffle_xorDhj(half, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffle %[[double]] %[[ScopeSubgroup]] %[[double_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleXor %[[double]] %[[ScopeSubgroup]] %[[double_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd

--- a/llvm/test/CodeGen/SPIRV/transcoding/sub_group_shuffle_relative.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/sub_group_shuffle_relative.ll
@@ -105,7 +105,7 @@ source_filename = "sub_group_shuffle_relative.cl"
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv64-unknown-unknown"
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleUp %[[char]] %[[ScopeSubgroup]] %[[char_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleDown %[[char]] %[[ScopeSubgroup]] %[[char_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -126,7 +126,7 @@ declare dso_local spir_func signext i8 @_Z20sub_group_shuffle_upcj(i8 signext, i
 ; Function Attrs: convergent
 declare dso_local spir_func signext i8 @_Z22sub_group_shuffle_downcj(i8 signext, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleUp %[[char]] %[[ScopeSubgroup]] %[[char_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleDown %[[char]] %[[ScopeSubgroup]] %[[char_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -147,7 +147,7 @@ declare dso_local spir_func zeroext i8 @_Z20sub_group_shuffle_uphj(i8 zeroext, i
 ; Function Attrs: convergent
 declare dso_local spir_func zeroext i8 @_Z22sub_group_shuffle_downhj(i8 zeroext, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleUp %[[short]] %[[ScopeSubgroup]] %[[short_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleDown %[[short]] %[[ScopeSubgroup]] %[[short_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -168,7 +168,7 @@ declare dso_local spir_func signext i16 @_Z20sub_group_shuffle_upsj(i16 signext,
 ; Function Attrs: convergent
 declare dso_local spir_func signext i16 @_Z22sub_group_shuffle_downsj(i16 signext, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleUp %[[short]] %[[ScopeSubgroup]] %[[short_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleDown %[[short]] %[[ScopeSubgroup]] %[[short_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -189,7 +189,7 @@ declare dso_local spir_func zeroext i16 @_Z20sub_group_shuffle_uptj(i16 zeroext,
 ; Function Attrs: convergent
 declare dso_local spir_func zeroext i16 @_Z22sub_group_shuffle_downtj(i16 zeroext, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleUp %[[int]] %[[ScopeSubgroup]] %[[int_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleDown %[[int]] %[[ScopeSubgroup]] %[[int_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -210,7 +210,7 @@ declare dso_local spir_func i32 @_Z20sub_group_shuffle_upij(i32, i32) local_unna
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z22sub_group_shuffle_downij(i32, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleUp %[[int]] %[[ScopeSubgroup]] %[[int_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleDown %[[int]] %[[ScopeSubgroup]] %[[int_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -231,7 +231,7 @@ declare dso_local spir_func i32 @_Z20sub_group_shuffle_upjj(i32, i32) local_unna
 ; Function Attrs: convergent
 declare dso_local spir_func i32 @_Z22sub_group_shuffle_downjj(i32, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleUp %[[long]] %[[ScopeSubgroup]] %[[long_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleDown %[[long]] %[[ScopeSubgroup]] %[[long_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -252,7 +252,7 @@ declare dso_local spir_func i64 @_Z20sub_group_shuffle_uplj(i64, i32) local_unna
 ; Function Attrs: convergent
 declare dso_local spir_func i64 @_Z22sub_group_shuffle_downlj(i64, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleUp %[[long]] %[[ScopeSubgroup]] %[[long_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleDown %[[long]] %[[ScopeSubgroup]] %[[long_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -273,7 +273,7 @@ declare dso_local spir_func i64 @_Z20sub_group_shuffle_upmj(i64, i32) local_unna
 ; Function Attrs: convergent
 declare dso_local spir_func i64 @_Z22sub_group_shuffle_downmj(i64, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleUp %[[float]] %[[ScopeSubgroup]] %[[float_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleDown %[[float]] %[[ScopeSubgroup]] %[[float_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -294,7 +294,7 @@ declare dso_local spir_func float @_Z20sub_group_shuffle_upfj(float, i32) local_
 ; Function Attrs: convergent
 declare dso_local spir_func float @_Z22sub_group_shuffle_downfj(float, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleUp %[[half]] %[[ScopeSubgroup]] %[[half_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleDown %[[half]] %[[ScopeSubgroup]] %[[half_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd
@@ -315,7 +315,7 @@ declare dso_local spir_func half @_Z20sub_group_shuffle_upDhj(half, i32) local_u
 ; Function Attrs: convergent
 declare dso_local spir_func half @_Z22sub_group_shuffle_downDhj(half, i32) local_unnamed_addr #1
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleUp %[[double]] %[[ScopeSubgroup]] %[[double_0]] %[[int_0]]
 ; CHECK-SPIRV: %{{[0-9]+}} = OpGroupNonUniformShuffleDown %[[double]] %[[ScopeSubgroup]] %[[double_0]] %[[int_0]]
 ; CHECK-SPIRV: OpFunctionEnd


### PR DESCRIPTION
The change adds support for most of sub_group*/work_group* and get_sub_group_*_mask OpenCL builtins. Group/Subgroup and Non-Uniform instructions were added with correspondent capabilities.

CHECK-SPIRV-LABELs were replaced by CHECK-SPIRVs in 7 tests due to the strange behavior of the firsts.

7 tests are expected to pass (transcoding/sub_group_clustered_reduce.ll, transcoding/sub_group_extended_types.ll, ranscoding/sub_group_non_uniform_arithmetic.ll, transcoding/sub_group_non_uniform_vote.ll, transcoding/sub_group_shuffle.ll, transcoding/sub_group_shuffle_relative.ll, transcoding/OpGroupAllAny.ll).