### PR TITLE
[SPIR-V] fix issues reported by IR verifier

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVPreTranslationLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreTranslationLegalizer.cpp
@@ -269,7 +269,7 @@ bool SPIRVPreTranslationLegalizer::runOnFunction(Function *Func,
   for (auto *I : Worklist) {
     bool TrackConstants = true;
     if (!I->getType()->isVoidTy() || isa<StoreInst>(I))
-      setInsertPointSkippingPhis(B, I->getNextNode());
+      B.SetInsertPoint(I->getNextNode());
     Instruction *NewIntr = nullptr;
     if (auto *Gep = dyn_cast<GetElementPtrInst>(I)) {
       auto *IntrFn = Intrinsic::getDeclaration(
@@ -363,7 +363,7 @@ bool SPIRVPreTranslationLegalizer::runOnFunction(Function *Func,
       if (II->getIntrinsicID() == Intrinsic::spv_const_composite) {
         if (TrackConstants) {
           auto *Const = AggrConsts.at(I);
-          setInsertPointSkippingPhis(B, I->getNextNode());
+          B.SetInsertPoint(I->getNextNode());
           auto *CTyFn = Intrinsic::getDeclaration(
               F->getParent(), Intrinsic::spv_track_constant,
               {B.getInt32Ty(), B.getInt32Ty()});


### PR DESCRIPTION
The change fixes several issues reported by IR verifier with "LLVM ERROR: Broken function found, compilation aborted!" message. The issues were
- immarg operand has non-immediate parameter (fixed by Attribute::ImmArg check)
- PHI nodes not grouped at top of basic block! (fixed by dyn_cast<PHINode>(I) check and setInsertPointAfterPhi usage)
- Instruction does not dominate all uses! (fixed by isa<StoreInst>(I) check)

I have not checked whether all calls to setInsertPointAfterPhi are necessary, but the implementation solves all issues with phis.

The only one type of the "Broken function" fail is still present - "Invalid insertelement operands!" (e.g. "%23 = insertelement i32 %21, i8 %3, i64 %22") since insertelement should have the first operand of vector type. Two tests affected (transcoding/sub_group_ballot.ll, transcoding/sub_group_extended_types.ll). I think it can be resolved in the same way as InsertValueInst using an intrinsic like Intrinsic::spv_insertv.

The patch makes 3 tests passed (llvm-intrinsics/cttz.ll, llvm-intrinsics/ctlz.ll, transcoding/extract_insert_value.ll) and avoids compilation fails on several others.