### PR TITLE
[SPIR-V] fix issues related to constants in support of builtins

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -210,6 +210,8 @@ bool SPIRVCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
       for (auto Arg : Info.OrigArgs) {
         assert(Arg.Regs.size() == 1 && "Call arg has multiple VRegs");
         argVRegs.push_back(Arg.Regs[0]);
+        auto SPIRVTy = TR->getOrCreateSPIRVType(Arg.Ty, MIRBuilder);
+        TR->assignSPIRVTypeToVReg(SPIRVTy, Arg.Regs[0], MIRBuilder);
       }
       return generateOpenCLBuiltinCall(
           doubleUnderscore ? funcName : demangledName, MIRBuilder, resVReg,


### PR DESCRIPTION
This change fixes issues related to new spv_track_constant intrinsic in SPIRVOpenCLBIFs.cpp. Sometimes SPIRV type info of actual parameter registers is omitted in SPIRVOpenCLBIFs.cpp, this patch evaluates it just before call to generateOpenCLBuiltinCall(). getIConstVal and getLiteralValueForConstant look like duplication, so the last is removed.

It is expected that 4 tests will be passed (transcoding/memory_access.ll, AtomicCompareExchange_cl20.ll, transcoding/OpGroupAllAny.ll, ranscoding/cl-types.ll).