### PR TITLE
[SPIR-V] track vector constants in DT

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
@@ -354,10 +354,7 @@ SPIRVTypeRegistry::buildConstantIntVector(uint64_t val,
     Register spvVecConst = MIRBuilder.getMF().getRegInfo()
         .createGenericVirtualRegister(lltTy);
     assignTypeToVReg(LLVMVecTy, spvVecConst, MIRBuilder);
-    // NOTE: due to the current selection scheme splat vectors
-    // i.e. G_BUILD_VECTOR is selected into insert+shuffle hence
-    // no vector constant hoisting is necessary (elements are handled in
-    // buildConstantInt)
+    DT.add(ConstVec, &MIRBuilder.getMF(), spvVecConst);
     SPIRVType *spvBaseType = getOrCreateSPIRVType(LLVMBaseTy, MIRBuilder);
     auto spvScalConst = buildConstantInt(val, MIRBuilder, spvBaseType);
     MIRBuilder.buildSplatVector(spvVecConst, spvScalConst);


### PR DESCRIPTION
The change reverts the deletion of vector constants tracking in DT (accidentally removed in #62).