### PR TITLE
[SPIR-V] Handle unreferenced globals at the main GlobalISel phases.

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -16,6 +16,7 @@ let TargetPrefix = "spv" in {
 
   def int_spv_track_constant : Intrinsic<[llvm_any_ty], [llvm_any_ty, llvm_metadata_ty]>;
   def int_spv_init_global : Intrinsic<[], [llvm_any_ty, llvm_any_ty]>;
+  def int_spv_unref_global : Intrinsic<[], [llvm_any_ty]>;
 
   def int_spv_gep : Intrinsic<[llvm_anyptr_ty], [llvm_i1_ty, llvm_any_ty, llvm_vararg_ty], [ImmArg<ArgIndex<0>>]>;
   def int_spv_load : Intrinsic<[llvm_i32_ty], [llvm_anyptr_ty, llvm_i16_ty, llvm_i8_ty], [ImmArg<ArgIndex<1>>, ImmArg<ArgIndex<2>>]>;

--- a/llvm/lib/Target/SPIRV/SPIRVPreTranslationLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreTranslationLegalizer.cpp
@@ -259,6 +259,12 @@ bool SPIRVPreTranslationLegalizer::runOnFunction(Function *Func,
       InitInst->setArgOperand(1, Init);
       InitConsts.insert(Init);
     }
+    if ((!GV.hasInitializer() || isa<UndefValue>(GV.getInitializer())) &&
+        GV.getNumUses() == 0) {
+      auto *CTyFn = Intrinsic::getDeclaration(
+          F->getParent(), Intrinsic::spv_unref_global, GV.getType());
+      B.CreateCall(CTyFn, &GV);
+    }
   }
 
   std::vector<Instruction *> Worklist;

--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
@@ -288,7 +288,7 @@ SPIRVType *SPIRVTypeRegistry::getOpTypeVector(uint32_t numElems,
 
 Register
 SPIRVTypeRegistry::buildConstantInt(uint64_t val, MachineIRBuilder &MIRBuilder,
-                                    SPIRVType *spvType) {
+                                    SPIRVType *spvType, bool EmitIR) {
   auto &MF = MIRBuilder.getMF();
   Register res;
   IntegerType *LLVMIntTy;
@@ -306,7 +306,10 @@ SPIRVTypeRegistry::buildConstantInt(uint64_t val, MachineIRBuilder &MIRBuilder,
     res = MF.getRegInfo().createGenericVirtualRegister(LLT::scalar(BitWidth));
     assignTypeToVReg(LLVMIntTy, res, MIRBuilder);
     DT.add(ConstInt, &MIRBuilder.getMF(), res);
-    MIRBuilder.buildConstant(res, *ConstInt);
+    if (EmitIR)
+      MIRBuilder.buildConstant(res, *ConstInt);
+    else
+      MIRBuilder.buildInstr(SPIRV::OpConstantI).addDef(res).addImm(ConstInt->getSExtValue());
   }
   return res;
 }
@@ -388,15 +391,17 @@ SPIRVTypeRegistry::buildConstantSampler(Register resReg, unsigned int addrMode,
 
 SPIRVType *SPIRVTypeRegistry::getOpTypeArray(uint32_t numElems,
                                              SPIRVType *elemType,
-                                             MachineIRBuilder &MIRBuilder) {
+                                             MachineIRBuilder &MIRBuilder,
+                                             bool EmitIR) {
   if (elemType->getOpcode() == SPIRV::OpTypeVoid)
     report_fatal_error("Invalid array element type");
-
-  Register numElementsVReg = buildConstantInt(numElems, MIRBuilder);
+  Register numElementsVReg =
+      buildConstantInt(numElems, MIRBuilder, nullptr, EmitIR);
   auto MIB = MIRBuilder.buildInstr(SPIRV::OpTypeArray)
                  .addDef(createTypeVReg(MIRBuilder))
                  .addUse(getSPIRVTypeID(elemType))
                  .addUse(numElementsVReg);
+  assert(constrainRegOperands(MIB, CurMF));
   return MIB;
 }
 
@@ -413,11 +418,12 @@ SPIRVType *SPIRVTypeRegistry::getOpTypeOpaque(const StructType *Ty,
 
 SPIRVType *
 SPIRVTypeRegistry::getOpTypeStruct(const StructType *Ty,
-                                   MachineIRBuilder &MIRBuilder) {
+                                   MachineIRBuilder &MIRBuilder,
+                                   bool EmitIR) {
   Register ResVReg = createTypeVReg(MIRBuilder);
   auto MIB = MIRBuilder.buildInstr(SPIRV::OpTypeStruct).addDef(ResVReg);
   for (const auto &Elem : Ty->elements()) {
-    auto ElemTy = getOrCreateSPIRVType(Elem, MIRBuilder);
+    auto ElemTy = getOrCreateSPIRVType(Elem, MIRBuilder, AQ::ReadWrite, EmitIR);
     if (ElemTy->getOpcode() == SPIRV::OpTypeVoid)
       report_fatal_error("Invalid struct element type");
     MIB.addUse(getSPIRVTypeID(ElemTy));
@@ -473,7 +479,8 @@ SPIRVType *SPIRVTypeRegistry::getOpTypeFunction(
 
 SPIRVType *SPIRVTypeRegistry::createSPIRVType(const Type *Ty,
                                               MachineIRBuilder &MIRBuilder,
-                                              AQ::AccessQualifier aq) {
+                                              AQ::AccessQualifier aq,
+                                              bool EmitIR) {
   auto &TypeToSPIRVTypeMap = DT.get<Type>()->getAllUses();
   auto t = TypeToSPIRVTypeMap.find(Ty);
   if (t != TypeToSPIRVTypeMap.end()) {
@@ -497,7 +504,7 @@ SPIRVType *SPIRVTypeRegistry::createSPIRVType(const Type *Ty,
                            MIRBuilder);
   } else if (Ty->isArrayTy()) {
     auto *el = getOrCreateSPIRVType(Ty->getArrayElementType(), MIRBuilder);
-    return getOpTypeArray(Ty->getArrayNumElements(), el, MIRBuilder);
+    return getOpTypeArray(Ty->getArrayNumElements(), el, MIRBuilder, EmitIR);
   } else if (auto stype = dyn_cast<StructType>(Ty)) {
     if (isOpenCLBuiltinType(stype))
       return handleOpenCLBuiltin(stype, MIRBuilder, aq);
@@ -506,7 +513,7 @@ SPIRVType *SPIRVTypeRegistry::createSPIRVType(const Type *Ty,
     else if (stype->isOpaque())
       return getOpTypeOpaque(stype, MIRBuilder);
     else
-      return getOpTypeStruct(stype, MIRBuilder);
+      return getOpTypeStruct(stype, MIRBuilder, EmitIR);
   } else if (auto ftype = dyn_cast<FunctionType>(Ty)) {
     SPIRVType *retTy = getOrCreateSPIRVType(ftype->getReturnType(), MIRBuilder);
     SmallVector<SPIRVType *, 4> paramTypes;
@@ -528,7 +535,8 @@ SPIRVType *SPIRVTypeRegistry::createSPIRVType(const Type *Ty,
 
     // Otherwise, treat it as a regular pointer type
     auto sc = addressSpaceToStorageClass(ptype->getAddressSpace());
-    SPIRVType *spvElementType = getOrCreateSPIRVType(elemType, MIRBuilder);
+    SPIRVType *spvElementType =
+        getOrCreateSPIRVType(elemType, MIRBuilder, AQ::ReadWrite, EmitIR);
     return getOpTypePointer(sc, spvElementType, MIRBuilder);
   } else
     llvm_unreachable("Unable to convert LLVM type to SPIRVType");
@@ -547,12 +555,13 @@ SPIRVType *SPIRVTypeRegistry::getSPIRVTypeForVReg(Register VReg) const {
 SPIRVType *
 SPIRVTypeRegistry::getOrCreateSPIRVType(const Type *type,
                                         MachineIRBuilder &MIRBuilder,
-                                        AQ::AccessQualifier accessQual) {
+                                        AQ::AccessQualifier accessQual,
+                                        bool EmitIR) {
   Register reg;
   if (DT.find(type, &MIRBuilder.getMF(), reg)) {
     return getSPIRVTypeForVReg(reg);
   }
-  SPIRVType *spirvType = createSPIRVType(type, MIRBuilder, accessQual);
+  SPIRVType *spirvType = createSPIRVType(type, MIRBuilder, accessQual, EmitIR);
   VRegToTypeMap[&MIRBuilder.getMF()][getSPIRVTypeID(spirvType)] = spirvType;
   SPIRVToLLVMType[spirvType] = type;
   DT.add(type, &MIRBuilder.getMF(), getSPIRVTypeID(spirvType));

--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
@@ -70,7 +70,8 @@ class SPIRVTypeRegistry {
 
   // Add a new OpTypeXXX instruction without checking for duplicates
   SPIRVType *createSPIRVType(const Type *type, MachineIRBuilder &MIRBuilder,
-                             AQ::AccessQualifier accessQual = AQ::ReadWrite);
+                             AQ::AccessQualifier accessQual = AQ::ReadWrite,
+                             bool EmitIR = true);
 
 public:
   // This interface is for walking the map in GlobalTypesAndRegNumPass.
@@ -97,9 +98,13 @@ public:
 
   // Either generate a new OpTypeXXX instruction or return an existing one
   // corresponding to the given LLVM IR type.
+  // EmitIR controls if we emit GMIR or SPV constants (e.g. for array sizes)
+  // because this method may be called from InstructionSelector and we don't
+  // want to emit extra IR instructions there
   SPIRVType *
   getOrCreateSPIRVType(const Type *type, MachineIRBuilder &MIRBuilder,
-                       AQ::AccessQualifier accessQual = AQ ::ReadWrite);
+                       AQ::AccessQualifier accessQual = AQ ::ReadWrite,
+                       bool EmitIR = true);
 
   const Type *getTypeForSPIRVType(const SPIRVType *Ty) const {
     auto Res = SPIRVToLLVMType.find(Ty);
@@ -171,13 +176,14 @@ private:
                              MachineIRBuilder &MIRBuilder);
 
   SPIRVType *getOpTypeArray(uint32_t numElems, SPIRVType *elemType,
-                            MachineIRBuilder &MIRBuilder);
+                            MachineIRBuilder &MIRBuilder,
+                            bool EmitIR = true);
 
   SPIRVType *getOpTypeOpaque(const StructType *Ty,
                              MachineIRBuilder &MIRBuilder);
 
   SPIRVType *getOpTypeStruct(const StructType *Ty,
-                             MachineIRBuilder &MIRBuilder);
+                             MachineIRBuilder &MIRBuilder, bool EmitIR = true);
 
   SPIRVType *getOpTypePointer(StorageClass::StorageClass sc,
                               SPIRVType *elemType,
@@ -217,7 +223,8 @@ private:
                                      AQ::AccessQualifier aq = AQ::ReadWrite);
 public:
   Register buildConstantInt(uint64_t val, MachineIRBuilder &MIRBuilder,
-                            SPIRVType *spvType = nullptr);
+                            SPIRVType *spvType = nullptr,
+                            bool EmitIR = true);
   Register buildConstantFP(APFloat val, MachineIRBuilder &MIRBuilder,
                            SPIRVType *spvType = nullptr);
   Register buildConstantIntVector(uint64_t val, MachineIRBuilder &MIRBuilder,

--- a/llvm/test/CodeGen/SPIRV/capability-integers.ll
+++ b/llvm/test/CodeGen/SPIRV/capability-integers.ll
@@ -15,6 +15,10 @@ target triple = "spirv32-unknown-unknown"
 @b = addrspace(1) global i16 0, align 2
 @c = addrspace(1) global i64 0, align 8
 
+define spir_kernel void @test_atomic_fn() #0 {
+  ret void
+}
+
 !opencl.enable.FP_CONTRACT = !{}
 !opencl.ocl.version = !{!0}
 !opencl.spir.version = !{!0}


### PR DESCRIPTION
Introduce 'unref_global' intrinsic for that purpose.
Empty modules (i.e. w/o any functions) are not processed,
think we should't do that at all, fixed the LIT.