### PR TITLE
[SPIR-V] Make >i32 constant compliant to the spec

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.h
+++ b/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.h
@@ -26,8 +26,13 @@ namespace llvm {
 template <typename T> class SPIRVDuplicatesTracker {
   using StorageKeyTy = const T *;
   using StorageValueTy = Register;
+  // TODO: consider replacing MapVector with DenseMap which
+  // requires topological sorting of the storage contents
+  // (e.g. to handle dependencies of const composites to its
+  // elements)
+  // Currently we rely on the order of insertion to be correct
   using StorageTy =
-      MapVector<StorageKeyTy, DenseMap<MachineFunction *, StorageValueTy>>;
+      MapVector<StorageKeyTy, MapVector<MachineFunction *, StorageValueTy>>;
 
 protected:
   StorageTy Storage;

--- a/llvm/lib/Target/SPIRV/SPIRVIRTranslator.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVIRTranslator.cpp
@@ -270,7 +270,6 @@ static void addConstantsToTrack(MachineFunction &MF,
             RegsAlreadyAddedToDT[&MI] = Reg;
         } else {
           if (DT->find(Const, &MF, Reg) == false) {
-            DT->add(Const, &MF, MI.getOperand(2).getReg());
             if (auto *ConstVec = dyn_cast<ConstantDataVector>(Const)) {
               auto *BuildVec = MRI.getVRegDef(MI.getOperand(2).getReg());
               assert(BuildVec &&
@@ -279,6 +278,7 @@ static void addConstantsToTrack(MachineFunction &MF,
                 DT->add(ConstVec->getElementAsConstant(i), &MF,
                         BuildVec->getOperand(1 + i).getReg());
             }
+            DT->add(Const, &MF, MI.getOperand(2).getReg());
           } else
             RegsAlreadyAddedToDT[&MI] = Reg;
         }

--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
@@ -214,14 +214,14 @@ def gi_bitcast_fimm_to_i32 : GICustomOperandRenderer<"renderFImm32">,
 def gi_bitcast_imm_to_i32 : GICustomOperandRenderer<"renderImm32">,
   GISDNodeXFormEquiv<imm_to_i32>;
 
-def PseudoConstI: IntImmLeaf<i32, [{ return true; }], imm_to_i32>;
-def PseudoConstF: FPImmLeaf<f32, [{ return true; }], fimm_to_i32>;
+def PseudoConstI: IntImmLeaf<i32, [{ return Imm.getBitWidth() <= 32; }], imm_to_i32>;
+def PseudoConstF: FPImmLeaf<f32, [{  return true; }], fimm_to_i32>;
 def ConstPseudoTrue: IntImmLeaf<i32, [{ return Imm.getBitWidth() == 1 && Imm.getZExtValue() == 1; }]>;
 def ConstPseudoFalse: IntImmLeaf<i32, [{ return Imm.getBitWidth() == 1 && Imm.getZExtValue() == 0; }]>;
 def ConstPseudoNull: IntImmLeaf<i64, [{ return Imm.isNullValue(); }]>;
 
 multiclass IntFPImm<bits<16> opCode, string name> {
-  def I: Op<opCode, (outs ID:$dst), (ins TYPE:$type, ID:$src),
+  def I: Op<opCode, (outs ID:$dst), (ins TYPE:$type, ID:$src, variable_ops),
                   "$dst = "#name#" $type $src", [(set ID:$dst, (assigntype PseudoConstI:$src, TYPE:$type))]>;
   def F: Op<opCode, (outs ID:$dst), (ins TYPE:$type, fID:$src),
                   "$dst = "#name#" $type $src", [(set ID:$dst, (assigntype PseudoConstF:$src, TYPE:$type))]>;

--- a/llvm/test/CodeGen/SPIRV/constant/local-integers-constants.ll
+++ b/llvm/test/CodeGen/SPIRV/constant/local-integers-constants.ll
@@ -38,8 +38,8 @@ define i64 @getLargeConstantI64() {
 ; CHECK-DAG: [[I64:%.+]] = OpTypeInt 64 0
 ; CHECK-DAG: [[CST_I16:%.+]] = OpConstant [[I16]] 65478
 ; CHECK-DAG: [[CST_I32:%.+]] = OpConstant [[I32]] 42
-; CHECK-DAG: [[CST_I64:%.+]] = OpConstant [[I64]] 123456789
-; CHECK-DAG: [[CST_LARGE_I64:%.+]] = OpConstant [[I64]] 34359738368
+; CHECK-DAG: [[CST_I64:%.+]] = OpConstant [[I64]] 123456789 0
+; CHECK-DAG: [[CST_LARGE_I64:%.+]] = OpConstant [[I64]] 0 8
 
 ; CHECK: [[GET_I16]] = OpFunction [[I16]]
 ; CHECK: OpReturnValue [[CST_I16]]

--- a/llvm/test/CodeGen/SPIRV/lshr-constexpr.ll
+++ b/llvm/test/CodeGen/SPIRV/lshr-constexpr.ll
@@ -3,17 +3,17 @@
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spirv64-unknown-unknown"
 
-; CHECK-SPIRV: %[[type_int32:[0-9]+]] = OpTypeInt 32 0
-; CHECK-SPIRV: %[[type_int64:[0-9]+]] = OpTypeInt 64 0
-; CHECK-SPIRV: %[[const1:[0-9]+]] = OpConstant %[[type_int32]] 1
-; CHECK-SPIRV: %[[const32:[0-9]+]] = OpConstant %[[type_int64]] 32 0
+; CHECK-SPIRV-DAG: %[[type_int32:[0-9]+]] = OpTypeInt 32 0
+; CHECK-SPIRV-DAG: %[[type_int64:[0-9]+]] = OpTypeInt 64 0
 ; CHECK-SPIRV: %[[type_vec:[0-9]+]] = OpTypeVector %[[type_int32]] 2
+; CHECK-SPIRV: %[[const1:[0-9]+]] = OpConstant %[[type_int32]] 1
 ; CHECK-SPIRV: %[[vec_const:[0-9]+]] = OpConstantComposite %[[type_vec]] %[[const1]] %[[const1]]
+; CHECK-SPIRV: %[[const32:[0-9]+]] = OpConstant %[[type_int64]] 32 0
 
 ; CHECK-SPIRV: %[[bitcast_res:[0-9]+]] = OpBitcast %[[type_int64]] %[[vec_const]]
 ; CHECK-SPIRV: %[[shift_res:[0-9]+]] = OpShiftRightLogical %[[type_int64]] %[[bitcast_res]] %[[const32]]
 ; FIXME: Have no information about OpDebugValue and it's syntax
-; CHECK-SPIRV: OpDebugValue %{{[0-9]+}} %[[shift_res]]
+; CHECK-SPIRV-DEBUG: OpDebugValue %{{[0-9]+}} %[[shift_res]]
 
 ; Function Attrs: nounwind ssp uwtable
 define void @foo() #0 !dbg !4 {

--- a/llvm/test/CodeGen/SPIRV/transcoding/sub_group_clustered_reduce.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/sub_group_clustered_reduce.ll
@@ -192,7 +192,7 @@
 ; CHECK-SPIRV-DAG: %[[short_0:[0-9]+]] = OpConstant %[[short]] 0
 ; CHECK-SPIRV-DAG: %[[int_0:[0-9]+]] = OpConstant %[[int]] 0
 ; CHECK-SPIRV-DAG: %[[int_2:[0-9]+]] = OpConstant %[[int]] 2
-; CHECK-SPIRV-DAG: %[[long_0:[0-9]+]] = OpConstant %[[long]] 0
+; CHECK-SPIRV-DAG: %[[long_0:[0-9]+]] = OpConstant %[[long]] 0 0
 ; CHECK-SPIRV-DAG: %[[half_0:[0-9]+]] = OpConstant %[[half]] 0
 ; CHECK-SPIRV-DAG: %[[float_0:[0-9]+]] = OpConstant %[[float]] 0
 ; CHECK-SPIRV-DAG: %[[double_0:[0-9]+]] = OpConstant %[[double]] 0


### PR DESCRIPTION
This also required proper handling of inter-constant dependencies
(fair for other entities being hoisted and deduplicated as well)
ensured by using a MapVector for now.