### PR TITLE
[SPIR-V] use composite intrinsic for constant arrays

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVPreTranslationLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreTranslationLegalizer.cpp
@@ -159,7 +159,7 @@ Function *SPIRVPreTranslationLegalizer::processFunctionSignature(
 }
 
 static bool isAggrToReplace(const Value *V) {
-  return isa<ConstantAggregate>(V)
+  return isa<ConstantAggregate>(V) || isa<ConstantDataArray>(V)
          // || isa<ConstantDataVector>(V)
          || (isa<ConstantAggregateZero>(V) && !V->getType()->isVectorTy());
 }
@@ -205,6 +205,11 @@ void SPIRVPreTranslationLegalizer::preprocessCompositeConstants(IRBuilder<> &B,
         //   for (int i = 0; i < AggrC->getNumElements(); ++i)
         //     Args.push_back(AggrC->getElementAsConstant(i));
         //   BuildCompositeIntrinsic(AggrC, Args);
+      } else if (auto *AggrC = dyn_cast<ConstantDataArray>(Op)) {
+        std::vector<Value *> Args;
+        for (unsigned i = 0; i < AggrC->getNumElements(); ++i)
+          Args.push_back(AggrC->getElementAsConstant(i));
+        BuildCompositeIntrinsic(AggrC, Args);
       } else if (isa<ConstantAggregateZero>(Op) &&
                  !Op->getType()->isVectorTy()) {
         auto *AggrC = cast<ConstantAggregateZero>(Op);


### PR DESCRIPTION
This change handles constant arrays by using spv_const_composite, otherwise they are wrapped in spv_track_constant and this causes error "LLVM ERROR: unable to translate instruction: call" in IRTranslator.cpp. 