### PR TITLE
[SPIR-V] use private in IRTranslator

### DIFF
--- a/llvm/include/llvm/CodeGen/GlobalISel/IRTranslator.h
+++ b/llvm/include/llvm/CodeGen/GlobalISel/IRTranslator.h
@@ -63,7 +63,7 @@ class IRTranslator : public MachineFunctionPass {
 public:
   static char ID;
 
-protected:
+private:
   /// Interface used to lower the everything related to calls.
   const CallLowering *CLI;
 


### PR DESCRIPTION
The change substitutes "protected" specifier by "private" as it was in the original IRTranslator. Lit tests are passed.