### PR TITLE
[SPIR-V] fix issues with GV processing, fix atomicrmw.ll

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
@@ -204,6 +204,12 @@ void SPIRVTypeRegistry::generateAssignInstrs(MachineFunction &MF) {
         assignSPIRVTypeToVReg(spvTy, Reg, MIB);
         Def->getOperand(0).setReg(NewReg);
         constrainRegOperands(NewMI, &MF);
+      } else if (MI.getOpcode() == TargetOpcode::G_GLOBAL_VALUE) {
+        auto Reg = MI.getOperand(0).getReg();
+        MIB.setInsertPt(*MI.getParent(), MI);
+        Type *Ty = MI.getOperand(1).getGlobal()->getType();
+        SPIRVType *spvTy = getOrCreateSPIRVType(Ty, MIB);
+        assignSPIRVTypeToVReg(spvTy, Reg, MIB);
       }
 
       if (MII == Begin)

--- a/llvm/test/CodeGen/SPIRV/atomicrmw.ll
+++ b/llvm/test/CodeGen/SPIRV/atomicrmw.ll
@@ -1,17 +1,19 @@
 ; RUN: llc -O0 -global-isel %s -o - | FileCheck %s
 
 ; CHECK: %[[Int:[0-9]+]] = OpTypeInt 32 0
-; CHECK-DAG: %[[Scope_Device:[0-9]+]] = OpConstant %[[Int]] 1{{$}}
+; CHECK-DAG: %[[Scope_Device:[0-9]+]] = OpConstant %[[Int]] 1 {{$}}
 ; CHECK-DAG: %[[MemSem_Relaxed:[0-9]+]] = OpConstant %[[Int]] 0
 ; CHECK-DAG: %[[MemSem_Acquire:[0-9]+]] = OpConstant %[[Int]] 2
 ; CHECK-DAG: %[[MemSem_Release:[0-9]+]] = OpConstant %[[Int]] 4 {{$}}
 ; CHECK-DAG: %[[MemSem_AcquireRelease:[0-9]+]] = OpConstant %[[Int]] 8
 ; CHECK-DAG: %[[MemSem_SequentiallyConsistent:[0-9]+]] = OpConstant %[[Int]] 16
 ; CHECK-DAG: %[[Value:[0-9]+]] = OpConstant %[[Int]] 42
-; CHECK: %[[Float:[0-9]+]] = OpTypeFloat 32
-; CHECK: %[[Pointer:[0-9]+]] = OpVariable %{{[0-9]+}}
-; CHECK: %[[FPPointer:[0-9]+]] = OpVariable %{{[0-9]+}}
-; CHECK: %[[FPValue:[0-9]+]] = OpConstant %[[Float]] 1109917696
+; CHECK-DAG: %[[Float:[0-9]+]] = OpTypeFloat 32
+; CHECK-DAG: %[[PointerType:[0-9]+]] = OpTypePointer CrossWorkgroup %[[Int]]
+; CHECK-DAG: %[[FPPointerType:[0-9]+]] = OpTypePointer CrossWorkgroup %[[Float]]
+; CHECK-DAG: %[[Pointer:[0-9]+]] = OpVariable %[[PointerType]] CrossWorkgroup
+; CHECK-DAG: %[[FPPointer:[0-9]+]] = OpVariable %[[FPPointerType]] CrossWorkgroup
+; CHECK-DAG: %[[FPValue:[0-9]+]] = OpConstant %[[Float]] 1109917696
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv64-unknown-unknown"


### PR DESCRIPTION
The change fixes the issue with missed SPIRV type of vreg, assigned to GLOBAL_VALUE (ExecutionMode.ll, atomicrmw.ll and builtin_vars_opt.ll failed in SPIRVTypeRegistry.cpp with unreachable "Attempting to get storage class of non-pointer type.").

Also the degradation after #66  on builtin_vars-decorate.ll and linkage-types.ll.

Also atomicrmw.ll was corrected.