### PR TITLE
[SPIR-V] add insertelt/extractelt intrinsics, fix errors

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -23,5 +23,7 @@ let TargetPrefix = "spv" in {
   def int_spv_store : Intrinsic<[], [llvm_i32_ty, llvm_anyptr_ty, llvm_i16_ty, llvm_i8_ty], [ImmArg<ArgIndex<2>>, ImmArg<ArgIndex<3>>]>;
   def int_spv_extractv : Intrinsic<[llvm_any_ty], [llvm_i32_ty, llvm_vararg_ty]>;
   def int_spv_insertv : Intrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_any_ty, llvm_vararg_ty]>;
+  def int_spv_extractelt : Intrinsic<[llvm_any_ty], [llvm_any_ty, llvm_anyint_ty]>;
+  def int_spv_insertelt : Intrinsic<[llvm_any_ty], [llvm_any_ty, llvm_any_ty, llvm_anyint_ty]>;
   def int_spv_const_composite : Intrinsic<[llvm_i32_ty], [llvm_vararg_ty]>;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
@@ -434,10 +434,8 @@ def OpGenericCastToPtrExplicit : Op<123, (outs ID:$r), (ins TYPE:$t, ID:$p, Stor
 def OpBitcast : UnOp<"OpBitcast", 124>;
 
 //3.32.12 Composite Instructions
-def OpVectorExtractDynamicI: Op<77, (outs ID:$res), (ins TYPE:$type, vID:$vec, ID:$idx),
+def OpVectorExtractDynamic: Op<77, (outs ID:$res), (ins TYPE:$type, vID:$vec, ID:$idx),
                   "$res = OpVectorExtractDynamic $type $vec $idx", [(set ID:$res, (assigntype (vector_extract vID:$vec, ID:$idx), TYPE:$type))]>;
-def OpVectorExtractDynamicF: Op<77, (outs ID:$res), (ins TYPE:$type, vfID:$vec, ID:$idx),
-                  "$res = OpVectorExtractDynamic $type $vec $idx", [(set ID:$res, (assigntype (vector_extract vfID:$vec, ID:$idx), TYPE:$type))]>;
 
 def OpVectorInsertDynamic: Op<78, (outs ID:$res), (ins TYPE:$ty, ID:$vec, ID:$comp, ID:$idx),
                   "$res = OpVectorInsertDynamic $ty $vec $comp $idx">;

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -24,6 +24,7 @@
 #include "llvm/IR/Type.h"
 
 #include <algorithm>
+#include <cassert>
 
 using namespace llvm;
 using namespace LegalizeActions;
@@ -131,7 +132,7 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
 
   // TODO: add proper rules for vectors legalization
   getActionDefinitionsBuilder(
-      {G_BUILD_VECTOR, G_SHUFFLE_VECTOR, G_INSERT_VECTOR_ELT})
+      {G_BUILD_VECTOR, G_SHUFFLE_VECTOR})
       .alwaysLegal();
 
   getActionDefinitionsBuilder(G_ADDRSPACE_CAST)
@@ -302,6 +303,7 @@ createNewIdReg(Register ValReg, unsigned Opcode, MachineRegisterInfo &MRI,
                const SPIRVTypeRegistry &TR) {
   auto NewT = LLT::scalar(32);
   auto SpvType = TR.getSPIRVTypeForVReg(ValReg);
+  assert(SpvType && "VReg is expected to have SPIRV type");
   bool isFloat = SpvType->getOpcode() == SPIRV::OpTypeFloat;
   bool isVectorFloat =
       SpvType->getOpcode() == SPIRV::OpTypeVector &&

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -239,8 +239,11 @@ class SPIRVInstructionSelect : public InstructionSelect {
       for (auto &MI : MBB) {
         if (MI.getOpcode() == SPIRV::ASSIGN_TYPE) {
           auto &SrcOp = MI.getOperand(1);
-          if (isTypeFoldingSupported(MRI.getVRegDef(SrcOp.getReg())->getOpcode()))
+          if (isTypeFoldingSupported(MRI.getVRegDef(SrcOp.getReg())->getOpcode())) {
+            if (MRI.getType(MI.getOperand(0).getReg()).isVector())
+              MRI.setRegClass(MI.getOperand(0).getReg(), &SPIRV::IDRegClass);
             MRI.setType(MI.getOperand(0).getReg(), LLT::scalar(32));
+          }
         }
       }
     }

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/sqrt.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/sqrt.ll
@@ -11,12 +11,16 @@
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv32-unknown-unknown"
 
+; We need to store sqrt results, otherwise isel does not emit sqrts as dead insts.
 ; Function Attrs: noinline nounwind optnone
-define spir_func void @test_sqrt() #0 {
+define spir_func void @test_sqrt(float* %x, double* %y, <4 x double>* %z) #0 {
 entry:
   %0 = call float @llvm.sqrt.f32(float 0x40091EB860000000)
+  store float %0, float* %x
   %1 = call double @llvm.sqrt.f64(double 2.710000e+00)
+  store double %1, double* %y
   %2 = call <4 x double> @llvm.sqrt.v4f64(<4 x double> <double 5.000000e-01, double 2.000000e-01, double 3.000000e-01, double 4.000000e-01>)
+  store <4 x double> %2, <4 x double>* %z
 ; CHECK: %{{[0-9]+}} = OpExtInst %[[Float]] %[[ExtInstSetId]] sqrt %[[FloatArg]]
 ; CHECK: %{{[0-9]+}} = OpExtInst %[[Double]] %[[ExtInstSetId]] sqrt %[[DoubleArg]]
 ; CHECK: %{{[0-9]+}} = OpExtInst %[[Double4]] %[[ExtInstSetId]] sqrt %[[Double4Arg]]


### PR DESCRIPTION
The change adds insertelt/extractelt intrinsics and fixs several errors.

As a result 6 new tests passed (instructions/vector-shuffle.ll, llvm-intrinsics/sqrt.ll, SampledImageRetType.ll,  transcoding/OpConstantSampler.ll, transcoding/sub_group_ballot.ll, transcoding/sub_group_extended_types.ll) and one does not fail on compilation (transcoding/builtin_vars_arithmetics.ll).