### PR TITLE
[SPIR-V] correct type assignment, fix small errors

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
@@ -392,10 +392,14 @@ static void hoistInstrsToMetablock(Module &M, MachineModuleInfo &MMI,
   // OpTypes and OpConstants can have cross references so at first we create
   // new meta regs and map them to old regs, then walk the list of instructions,
   // and create new (hoisted) instructions with new meta regs instead of old ones.
+  // Also there are references to global values in constants.
   fillLocalAliasTables<Type>(MIRBuilder, DT->get<Type>(), TR, MB_TypeConstVars,
                              LocalAliasTables);
   fillLocalAliasTables<Constant>(MIRBuilder, DT->get<Constant>(), TR,
                                  MB_TypeConstVars, LocalAliasTables);
+  fillLocalAliasTables<GlobalValue>(MIRBuilder, DT->get<GlobalValue>(), TR,
+                                    MB_TypeConstVars, LocalAliasTables);
+
   hoistGlobalOps<Type>(MIRBuilder, DT->get<Type>(), TR, MB_TypeConstVars,
                        LocalAliasTables);
   hoistGlobalOps<Constant>(MIRBuilder, DT->get<Constant>(), TR,
@@ -424,8 +428,6 @@ static void hoistInstrsToMetablock(Module &M, MachineModuleInfo &MMI,
     MI->removeFromParent();
   }
   END_FOR_MF_IN_MODULE()
-  fillLocalAliasTables<GlobalValue>(MIRBuilder, DT->get<GlobalValue>(), TR,
-                                    MB_TypeConstVars, LocalAliasTables);
   hoistGlobalOps<GlobalValue>(MIRBuilder, DT->get<GlobalValue>(), TR,
                               MB_TypeConstVars, LocalAliasTables);
   fillLocalAliasTables<Function>(MIRBuilder, DT->get<Function>(), TR,

--- a/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
@@ -483,6 +483,8 @@ static bool genWorkgroupQuery(MachineIRBuilder &MIRBuilder, Register resVReg,
 
     // If the index is dynamic, need check if it's < 3, and then use a select
     if (!isConstantIndex) {
+      TR->insertAssignInstr(extr, nullptr, PtrSizeTy, MIRBuilder, *MRI);
+
       auto idxTy = TR->getSPIRVTypeForVReg(idxVReg);
       auto boolTy = TR->getOrCreateSPIRVBoolType(MIRBuilder);
 

--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
@@ -72,8 +72,17 @@ class SPIRVTypeRegistry {
   SPIRVType *createSPIRVType(const Type *type, MachineIRBuilder &MIRBuilder,
                              AQ::AccessQualifier accessQual = AQ::ReadWrite,
                              bool EmitIR = true);
-
+  // Set SPIRVType for GV, propagate it to GV's users, set register classes.
+  SPIRVType *propagateSPIRVType(MachineInstr* MI, MachineRegisterInfo &MRI,
+                                MachineIRBuilder &MIB);
 public:
+  // Insert ASSIGN_TYPE instuction between Reg and its definition, set
+  // NewReg as a dst of the definition, assign SPIRVType to both registers.
+  // If SpirvTy is provided, use it as SPIRVType in ASSIGN_TYPE, otherwise
+  // create it from Ty.
+  Register insertAssignInstr(Register Reg, Type* Ty, SPIRVType *SpirvTy,
+                             MachineIRBuilder &MIB, MachineRegisterInfo &MRI);
+
   // This interface is for walking the map in GlobalTypesAndRegNumPass.
   SpecialInstrMapTy &getSpecialTypesAndConstsMap() {
     return SpecialTypesAndConstsMap;


### PR DESCRIPTION
The change corrects type assignments and fix some other errors.

SPIRVTypeRegistry.cpp: insertAssignInstr() was isolated from generateAssignInstrs(). It's used in generateAssignInstrs() and in SPIRVOpenCLBIFs.cpp where a new register is introduced during get_global_id builtin lowering so we need to insert ASSIGN_TYPE instruction to avoid fail in ISel. propagateSPIRVType() was added to determine SPIRVType of G_GLOBAL_VALUE and propagate it to G_ADDRSPACE_CAST and COPY instructions if they are introduced by IRTranslator. Also RCs of the registers are set.

SPIRVGlobalTypesAndRegNumPass.cpp: There are references to GVs in constants so we need to fill LocalAliasTables with GVs too (as well as with Types and Consts) before starting of the instruction hoisting.

SPIRVInstructionSelector.cpp: if a new register is introduced during OpVariable emission, add it to DT and set its RC to avoid later fails.

One LIT test (llvm-intrinsics/invariant.ll) is expected to pass, compilation passes 3 other tests (opencl/get_global_id.ll, transcoding/GlobalFunAnnotate.ll, transcoding/PipeStorage.ll).