### PR TITLE
[SPIR-V] output names and decorations of global vars and function args

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -93,6 +93,19 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
                    .addImm(Decoration::MaxByteOffset)
                    .addImm(DerefBytes);
       }
+      if (Arg.hasAttribute(Attribute::Alignment)) {
+        auto Alignment = Arg.getAttribute(Attribute::Alignment).getValueAsInt();
+        MIRBuilder.buildInstr(SPIRV::OpDecorate)
+                   .addUse(VRegs[i][0])
+                   .addImm(Decoration::Alignment)
+                   .addImm(Alignment);
+      }
+      if (Arg.hasAttribute(Attribute::ReadOnly)) {
+        MIRBuilder.buildInstr(SPIRV::OpDecorate)
+                   .addUse(VRegs[i][0])
+                   .addImm(Decoration::FuncParamAttr)
+                   .addImm(FunctionParameterAttribute::NoWrite);
+      }
       ++i;
     }
   }
@@ -173,7 +186,8 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
                    .addImm(execModel)
                    .addUse(funcVReg);
     addStringImm(F.getName(), MIB);
-  } else if (F.getLinkage() == GlobalValue::LinkageTypes::ExternalLinkage) {
+  } else if (F.getLinkage() == GlobalValue::LinkageTypes::ExternalLinkage ||
+             F.getLinkage() == GlobalValue::LinkOnceODRLinkage) {
     auto MIB = MIRBuilder.buildInstr(SPIRV::OpDecorate)
                    .addUse(funcVReg)
                    .addImm(Decoration::LinkageAttributes);

--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -106,6 +106,12 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
                    .addImm(Decoration::FuncParamAttr)
                    .addImm(FunctionParameterAttribute::NoWrite);
       }
+      if (Arg.hasAttribute(Attribute::ZExt)) {
+        MIRBuilder.buildInstr(SPIRV::OpDecorate)
+                   .addUse(VRegs[i][0])
+                   .addImm(Decoration::FuncParamAttr)
+                   .addImm(FunctionParameterAttribute::Zext);
+      }
       ++i;
     }
   }

--- a/llvm/lib/Target/SPIRV/SPIRVPreTranslationLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreTranslationLegalizer.cpp
@@ -262,11 +262,8 @@ bool SPIRVPreTranslationLegalizer::runOnFunction(Function *Func,
 
   B.SetInsertPoint(&F->getEntryBlock().front());
 
-  std::unordered_set<Constant *> InitConsts;
-
   for (auto &GV : Func->getParent()->globals()) {
-    if (GV.hasInitializer() && !isa<UndefValue>(GV.getInitializer()) &&
-        !InitConsts.count(GV.getInitializer())) {
+    if (GV.hasInitializer() && !isa<UndefValue>(GV.getInitializer())) {
       auto *Init = GV.getInitializer();
       Type *Ty = isAggrToReplace(Init) ? B.getInt32Ty() : Init->getType();
       auto *IntrFn = Intrinsic::getDeclaration(
@@ -274,7 +271,6 @@ bool SPIRVPreTranslationLegalizer::runOnFunction(Function *Func,
       auto *InitInst = B.CreateCall(
           IntrFn, {&GV, isAggrToReplace(Init) ? B.getInt32(1) : Init});
       InitInst->setArgOperand(1, Init);
-      InitConsts.insert(Init);
     }
     if ((!GV.hasInitializer() || isa<UndefValue>(GV.getInitializer())) &&
         GV.getNumUses() == 0) {

--- a/llvm/test/CodeGen/SPIRV/linkage-types.ll
+++ b/llvm/test/CodeGen/SPIRV/linkage-types.ll
@@ -8,49 +8,49 @@ target triple = "spirv32-unknown-unknown"
 ; SPIRV: OpEntryPoint Kernel %[[kern:[0-9]+]] "kern"
 
 @ae = available_externally addrspace(1) global i32 79, align 4
-; SPIRV: OpName %[[ae:[0-9]+]] "ae"
+; SPIRV-DAG: OpName %[[ae:[0-9]+]] "ae"
 
 @i1 = addrspace(1) global i32 1, align 4
-; SPIRV: OpName %[[i1:[0-9]+]] "i1"
+; SPIRV-DAG: OpName %[[i1:[0-9]+]] "i1"
 
 @i2 = internal addrspace(1) global i32 2, align 4
-; SPIRV: OpName %[[i2:[0-9]+]] "i2"
+; SPIRV-DAG: OpName %[[i2:[0-9]+]] "i2"
 
 @i3 = addrspace(1) global i32 3, align 4
-; SPIRV: OpName %[[i3:[0-9]+]] "i3"
+; SPIRV-DAG: OpName %[[i3:[0-9]+]] "i3"
 
 @i4 = common addrspace(1) global i32 0, align 4
-; SPIRV: OpName %[[i4:[0-9]+]] "i4"
+; SPIRV-DAG: OpName %[[i4:[0-9]+]] "i4"
 
 @i5 = internal addrspace(1) global i32 0, align 4
-; SPIRV: OpName %[[i5:[0-9]+]] "i5"
+; SPIRV-DAG: OpName %[[i5:[0-9]+]] "i5"
 
 @color_table = addrspace(2) constant [2 x i32] [i32 0, i32 1], align 4
-; SPIRV: OpName %[[color_table:[0-9]+]] "color_table"
+; SPIRV-DAG: OpName %[[color_table:[0-9]+]] "color_table"
 
 @noise_table = external addrspace(2) constant [256 x i32]
-; SPIRV: OpName %[[noise_table:[0-9]+]] "noise_table"
+; SPIRV-DAG: OpName %[[noise_table:[0-9]+]] "noise_table"
 
 @w = addrspace(1) constant i32 0, align 4
-; SPIRV: OpName %[[w:[0-9]+]] "w"
+; SPIRV-DAG: OpName %[[w:[0-9]+]] "w"
 
 @f.color_table = internal addrspace(2) constant [2 x i32] [i32 2, i32 3], align 4
-; SPIRV: OpName %[[f_color_table:[0-9]+]] "f.color_table"
+; SPIRV-DAG: OpName %[[f_color_table:[0-9]+]] "f.color_table"
 
 @e = external addrspace(1) global i32
-; SPIRV: OpName %[[e:[0-9]+]] "e"
+; SPIRV-DAG: OpName %[[e:[0-9]+]] "e"
 
 @f.t = internal addrspace(1) global i32 5, align 4
-; SPIRV: OpName %[[f_t:[0-9]+]] "f.t"
+; SPIRV-DAG: OpName %[[f_t:[0-9]+]] "f.t"
 
 @f.stint = internal addrspace(1) global i32 0, align 4
-; SPIRV: OpName %[[f_stint:[0-9]+]] "f.stint"
+; SPIRV-DAG: OpName %[[f_stint:[0-9]+]] "f.stint"
 
 @f.inside = internal addrspace(1) global i32 0, align 4
-; SPIRV: OpName %[[f_inside:[0-9]+]] "f.inside"
+; SPIRV-DAG: OpName %[[f_inside:[0-9]+]] "f.inside"
 
 @f.b = internal addrspace(2) constant float 1.000000e+00, align 4
-; SPIRV: OpName %[[f_b:[0-9]+]] "f.b"
+; SPIRV-DAG: OpName %[[f_b:[0-9]+]] "f.b"
 
 ; SPIRV-DAG: OpName %[[foo:[0-9]+]] "foo"
 ; SPIRV-DAG: OpName %[[f:[0-9]+]] "f"


### PR DESCRIPTION
The changes adds some missed OpNames and OpDecorate for global variables, functions and function arguments. Also it allows to output more global variables.

SPIRVPreTranslationLegalizer.cpp: it's not clear what cases are supported using InitConsts, however it blocks output of GVs with the same constant initializers so I remove it for now (no tests fail).

As a result 3 LIT tests are expected to pass (linkage-types.ll, /transcoding/DecorationAlignment.ll, transcoding/readonly.ll). Also several OpenCL CTS basic tests may pass.