### PR TITLE
[SPIR-V] add missed DT registration of consts, fix composite null consts

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVPreTranslationLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreTranslationLegalizer.cpp
@@ -361,9 +361,7 @@ bool SPIRVPreTranslationLegalizer::runOnFunction(Function *Func,
       Args.push_back(EEI->getVectorOperand());
       Args.push_back(EEI->getIndexOperand());
       auto *NewEEI = B.CreateCall(IntrFn, {Args});
-      StringRef InstName = "";
-      if (I->hasName())
-        InstName = I->getName();
+      StringRef InstName = I->hasName() ? I->getName() : "";
       EEI->replaceAllUsesWith(NewEEI);
       EEI->eraseFromParent();
       I = NewEEI;
@@ -376,7 +374,7 @@ bool SPIRVPreTranslationLegalizer::runOnFunction(Function *Func,
       for (auto &Op : IEI->operands())
         Args.push_back(Op);
       auto *NewIEI = B.CreateCall(IntrFn, {Args});
-      StringRef InstName = I->hasName() ? I->getName() : "" ;
+      StringRef InstName = I->hasName() ? I->getName() : "";
       IEI->replaceAllUsesWith(NewIEI);
       IEI->eraseFromParent();
       I = NewIEI;

--- a/llvm/lib/Target/SPIRV/SPIRVPreTranslationLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreTranslationLegalizer.cpp
@@ -376,9 +376,11 @@ bool SPIRVPreTranslationLegalizer::runOnFunction(Function *Func,
       for (auto &Op : IEI->operands())
         Args.push_back(Op);
       auto *NewIEI = B.CreateCall(IntrFn, {Args});
+      StringRef InstName = I->hasName() ? I->getName() : "" ;
       IEI->replaceAllUsesWith(NewIEI);
       IEI->eraseFromParent();
       I = NewIEI;
+      I->setName(InstName);
     } else if (isa<AllocaInst>(I))
       TrackConstants = false;
 

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpVectorInsertDynamic_i16.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpVectorInsertDynamic_i16.ll
@@ -15,8 +15,8 @@
 ; CHECK-SPIRV-DAG: %[[const2:[0-9]+]] = OpConstant %[[int16]] 8
 ; CHECK-SPIRV-DAG: %[[idx2:[0-9]+]] = OpConstant %[[int32]] 1
 
-; CHECK-SPIRV: %[[vec1:[0-9]+]] = OpVectorInsertDynamic %[[int16_2]] %[[undef]] %[[const1]] %[[idx1]]
-; CHECK-SPIRV: %[[vec2:[0-9]+]] = OpVectorInsertDynamic %[[int16_2]] %[[vec1]] %[[const2]] %[[idx2]]
+; CHECK-SPIRV: %[[vec1:[0-9]+]] = OpCompositeInsert %[[int16_2]] %[[const1]] %[[undef]] 0
+; CHECK-SPIRV: %[[vec2:[0-9]+]] = OpCompositeInsert %[[int16_2]] %[[const2]] %[[vec1]] 1
 ; CHECK-SPIRV: %[[res]] = OpVectorInsertDynamic %[[int16_2]] %[[vec2]] %[[v]] %[[index]]
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"


### PR DESCRIPTION
The change adds missed registration of constants created during builtin lowering and fixes composite null constants.

Also it adds missed OpName for spv_insertelt intrinsic and corrects transcoding/OpVectorInsertDynamic_i16.ll test.

As a result this LIT test should pass.