### PR TITLE
[SPIR-V] add SPIRVTargetInfo.h, minor changes

### DIFF
--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCTargetDesc.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCTargetDesc.cpp
@@ -16,6 +16,7 @@
 #include "MCTargetDesc/SPIRVMCTargetDesc.h"
 #include "InstPrinter/SPIRVInstPrinter.h"
 #include "SPIRVTargetStreamer.h"
+#include "TargetInfo/SPIRVTargetInfo.h"
 #include "llvm/MC/MCInstrAnalysis.h"
 #include "llvm/MC/MCInstrInfo.h"
 #include "llvm/MC/MCRegisterInfo.h"

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCTargetDesc.h
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCTargetDesc.h
@@ -29,10 +29,6 @@ class MCSubtargetInfo;
 class MCTargetOptions;
 class Target;
 
-Target &getTheSPIRV32Target();
-Target &getTheSPIRV64Target();
-Target &getTheSPIRVLogicalTarget();
-
 MCCodeEmitter *createSPIRVMCCodeEmitter(const MCInstrInfo &MCII,
                                         const MCRegisterInfo &MRI,
                                         MCContext &Ctx);

--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -17,6 +17,7 @@
 #include "SPIRVInstrInfo.h"
 #include "SPIRVMCInstLower.h"
 #include "SPIRVTargetMachine.h"
+#include "TargetInfo/SPIRVTargetInfo.h"
 #include "llvm/CodeGen/AsmPrinter.h"
 #include "llvm/CodeGen/MachineConstantPool.h"
 #include "llvm/CodeGen/MachineFunctionPass.h"

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
@@ -30,6 +30,7 @@
 #include "SPIRVStrings.h"
 #include "SPIRVSubtarget.h"
 #include "SPIRVTypeRegistry.h"
+#include "TargetInfo/SPIRVTargetInfo.h"
 
 #include "llvm/CodeGen/MachineModuleInfo.h"
 

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -11,7 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "SPIRVTargetMachine.h"
-#include "MCTargetDesc/SPIRVMCAsmInfo.h"
+#include "TargetInfo/SPIRVTargetInfo.h"
 #include "SPIRV.h"
 #include "SPIRVCallLowering.h"
 #include "SPIRVIRTranslator.h"
@@ -45,7 +45,7 @@ createSPIRVInstructionSelector(const SPIRVTargetMachine &TM,
                                SPIRVSubtarget &Subtarget,
                                SPIRVRegisterBankInfo &RBI);
 
-extern "C" void LLVMInitializeSPIRVTarget() {
+extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeSPIRVTarget() {
   // Register the target.
   RegisterTargetMachine<SPIRVTargetMachine> X(getTheSPIRV32Target());
   RegisterTargetMachine<SPIRVTargetMachine> Y(getTheSPIRV64Target());

--- a/llvm/lib/Target/SPIRV/TargetInfo/SPIRVTargetInfo.cpp
+++ b/llvm/lib/Target/SPIRV/TargetInfo/SPIRVTargetInfo.cpp
@@ -6,29 +6,29 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "SPIRV.h"
+#include "TargetInfo/SPIRVTargetInfo.h"
 #include "llvm/Support/TargetRegistry.h"
 
-namespace llvm {
-Target &getTheSPIRV32Target() {
-  static Target TheSPIRVTarget;
-  return TheSPIRVTarget;
+using namespace llvm;
+
+Target &llvm::getTheSPIRV32Target() {
+  static Target TheSPIRV32Target;
+  return TheSPIRV32Target;
 }
-Target &getTheSPIRV64Target() {
-  static Target TheSPIRVTarget;
-  return TheSPIRVTarget;
+Target &llvm::getTheSPIRV64Target() {
+  static Target TheSPIRV64Target;
+  return TheSPIRV64Target;
 }
-Target &getTheSPIRVLogicalTarget() {
-  static Target TheSPIRVTarget;
-  return TheSPIRVTarget;
+Target &llvm::getTheSPIRVLogicalTarget() {
+  static Target TheSPIRVLogicalTarget;
+  return TheSPIRVLogicalTarget;
 }
 
-extern "C" void LLVMInitializeSPIRVTargetInfo() {
-  RegisterTarget<Triple::spirv32, /*HasJIT=*/false> X(
-      getTheSPIRV32Target(), "spirv32", "SPIRV", "SPIRV");
-  RegisterTarget<Triple::spirv64, /*HasJIT=*/false> Y(
-      getTheSPIRV64Target(), "spirv64", "SPIRV", "SPIRV");
-  RegisterTarget<Triple::spirvlogical, /*HasJIT=*/false> Z(
-      getTheSPIRVLogicalTarget(), "spirvlogical", "SPIRV", "SPIRV");
+extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeSPIRVTargetInfo() {
+  RegisterTarget<Triple::spirv32> X(getTheSPIRV32Target(), "spirv32",
+                                    "SPIR-V 32-bit", "SPIRV");
+  RegisterTarget<Triple::spirv64> Y(getTheSPIRV64Target(), "spirv64",
+                                    "SPIR-V 64-bit", "SPIRV");
+  RegisterTarget<Triple::spirvlogical> Z(
+      getTheSPIRVLogicalTarget(), "spirvlogical", "SPIR-V Logical", "SPIRV");
 }
-} // namespace llvm

--- a/llvm/lib/Target/SPIRV/TargetInfo/SPIRVTargetInfo.h
+++ b/llvm/lib/Target/SPIRV/TargetInfo/SPIRVTargetInfo.h
@@ -1,0 +1,22 @@
+//===-- SPIRVTargetInfo.h - SPIRV Target Implementation ---------*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_SPIRV_TARGETINFO_SPIRVTARGETINFO_H
+#define LLVM_LIB_TARGET_SPIRV_TARGETINFO_SPIRVTARGETINFO_H
+
+namespace llvm {
+
+class Target;
+
+Target &getTheSPIRV32Target();
+Target &getTheSPIRV64Target();
+Target &getTheSPIRVLogicalTarget();
+
+} // namespace llvm
+
+#endif // LLVM_LIB_TARGET_SPIRV_TARGETINFO_SPIRVTARGETINFO_H


### PR DESCRIPTION
The change adds SPIRVTargetInfo.h and prepares in some way TargetInfoSPIRVTargetInfo.* and SPIRVTargetMachine.* for commit to LLVM.

No change is pass rate.