### PR TITLE
[SPIR-V] build OpVariable and OpDecorate in TR, fix errors

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -86,24 +86,25 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
       if (Arg.hasName())
         buildOpName(VRegs[i][0], Arg.getName(), MIRBuilder);
       if (Arg.getType()->isPointerTy()) {
-        auto DerefBytes = (unsigned) Arg.getDereferenceableBytes();
+        auto DerefBytes = static_cast<unsigned>(Arg.getDereferenceableBytes());
         if (DerefBytes != 0)
-          TR->buildDecoration(VRegs[i][0], MIRBuilder,
-                              Decoration::MaxByteOffset, {DerefBytes});
+          buildOpDecorate(VRegs[i][0], MIRBuilder, Decoration::MaxByteOffset,
+                          {DerefBytes});
       }
       if (Arg.hasAttribute(Attribute::Alignment)) {
-        auto Alignment = (unsigned) Arg.getAttribute(Attribute::Alignment)
-                                       .getValueAsInt();
-        TR->buildDecoration(VRegs[i][0], MIRBuilder, Decoration::Alignment,
-                            {Alignment});
+        auto Alignment =
+            static_cast<unsigned>(Arg.getAttribute(Attribute::Alignment)
+                                     .getValueAsInt());
+        buildOpDecorate(VRegs[i][0], MIRBuilder, Decoration::Alignment,
+                        {Alignment});
       }
       if (Arg.hasAttribute(Attribute::ReadOnly)) {
-        TR->buildDecoration(VRegs[i][0], MIRBuilder, Decoration::FuncParamAttr,
-                            {FunctionParameterAttribute::NoWrite});
+        buildOpDecorate(VRegs[i][0], MIRBuilder, Decoration::FuncParamAttr,
+                        {FunctionParameterAttribute::NoWrite});
       }
       if (Arg.hasAttribute(Attribute::ZExt)) {
-        TR->buildDecoration(VRegs[i][0], MIRBuilder, Decoration::FuncParamAttr,
-                            {FunctionParameterAttribute::Zext});
+        buildOpDecorate(VRegs[i][0], MIRBuilder, Decoration::FuncParamAttr,
+                        {FunctionParameterAttribute::Zext});
       }
       ++i;
     }
@@ -188,7 +189,7 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
   } else if (F.getLinkage() == GlobalValue::LinkageTypes::ExternalLinkage ||
              F.getLinkage() == GlobalValue::LinkOnceODRLinkage) {
     auto LnkTy = F.isDeclaration() ? LinkageType::Import : LinkageType::Export;
-    TR->buildDecoration(funcVReg, MIRBuilder, Decoration::LinkageAttributes,
+    buildOpDecorate(funcVReg, MIRBuilder, Decoration::LinkageAttributes,
                     {LnkTy}, F.getGlobalIdentifier());
   }
 

--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -86,31 +86,24 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
       if (Arg.hasName())
         buildOpName(VRegs[i][0], Arg.getName(), MIRBuilder);
       if (Arg.getType()->isPointerTy()) {
-        uint64_t DerefBytes = Arg.getDereferenceableBytes();
+        auto DerefBytes = (unsigned) Arg.getDereferenceableBytes();
         if (DerefBytes != 0)
-          MIRBuilder.buildInstr(SPIRV::OpDecorate)
-                   .addUse(VRegs[i][0])
-                   .addImm(Decoration::MaxByteOffset)
-                   .addImm(DerefBytes);
+          TR->buildDecoration(VRegs[i][0], MIRBuilder,
+                              Decoration::MaxByteOffset, {DerefBytes});
       }
       if (Arg.hasAttribute(Attribute::Alignment)) {
-        auto Alignment = Arg.getAttribute(Attribute::Alignment).getValueAsInt();
-        MIRBuilder.buildInstr(SPIRV::OpDecorate)
-                   .addUse(VRegs[i][0])
-                   .addImm(Decoration::Alignment)
-                   .addImm(Alignment);
+        auto Alignment = (unsigned) Arg.getAttribute(Attribute::Alignment)
+                                       .getValueAsInt();
+        TR->buildDecoration(VRegs[i][0], MIRBuilder, Decoration::Alignment,
+                            {Alignment});
       }
       if (Arg.hasAttribute(Attribute::ReadOnly)) {
-        MIRBuilder.buildInstr(SPIRV::OpDecorate)
-                   .addUse(VRegs[i][0])
-                   .addImm(Decoration::FuncParamAttr)
-                   .addImm(FunctionParameterAttribute::NoWrite);
+        TR->buildDecoration(VRegs[i][0], MIRBuilder, Decoration::FuncParamAttr,
+                            {FunctionParameterAttribute::NoWrite});
       }
       if (Arg.hasAttribute(Attribute::ZExt)) {
-        MIRBuilder.buildInstr(SPIRV::OpDecorate)
-                   .addUse(VRegs[i][0])
-                   .addImm(Decoration::FuncParamAttr)
-                   .addImm(FunctionParameterAttribute::Zext);
+        TR->buildDecoration(VRegs[i][0], MIRBuilder, Decoration::FuncParamAttr,
+                            {FunctionParameterAttribute::Zext});
       }
       ++i;
     }
@@ -194,12 +187,9 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
     addStringImm(F.getName(), MIB);
   } else if (F.getLinkage() == GlobalValue::LinkageTypes::ExternalLinkage ||
              F.getLinkage() == GlobalValue::LinkOnceODRLinkage) {
-    auto MIB = MIRBuilder.buildInstr(SPIRV::OpDecorate)
-                   .addUse(funcVReg)
-                   .addImm(Decoration::LinkageAttributes);
-    addStringImm(F.getGlobalIdentifier(), MIB);
-    auto lnk = F.isDeclaration() ? LinkageType::Import : LinkageType::Export;
-    MIB.addImm(lnk);
+    auto LnkTy = F.isDeclaration() ? LinkageType::Import : LinkageType::Export;
+    TR->buildDecoration(funcVReg, MIRBuilder, Decoration::LinkageAttributes,
+                    {LnkTy}, F.getGlobalIdentifier());
   }
 
   return true;

--- a/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.h
+++ b/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.h
@@ -99,11 +99,11 @@ public:
     return CT.find(C, MF, R);
   }
 
-  bool find(const GlobalValue *GV, MachineFunction *MF, Register R) {
+  bool find(const GlobalValue *GV, MachineFunction *MF, Register& R) {
     return GT.find(GV, MF, R);
   }
 
-  bool find(const Function *F, MachineFunction *MF, Register R) {
+  bool find(const Function *F, MachineFunction *MF, Register& R) {
     return FT.find(F, MF, R);
   }
 

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -573,27 +573,18 @@ static bool canUseNUW(unsigned opCode) {
   }
 }
 
-static void decorate(Register target, Decoration::Decoration dec,
-                     MachineIRBuilder &MIRBuilder) {
-  MIRBuilder.buildInstr(SPIRV::OpDecorate).addUse(target).addImm(dec);
-}
-
 // TODO: move to GenerateDecorations pass
-static void handleIntegerWrapFlags(const MachineInstr &I, Register target,
-                                   unsigned newOpcode, const SPIRVSubtarget &ST,
-                                   MachineIRBuilder &MIRBuilder) {
-  if (I.getFlag(MachineInstr::MIFlag::NoSWrap)) {
-    if (canUseNSW(newOpcode) &&
-        canUseDecoration(Decoration::NoSignedWrap, ST)) {
-      decorate(target, Decoration::NoSignedWrap, MIRBuilder);
-    }
-  }
-  if (I.getFlag(MachineInstr::MIFlag::NoUWrap)) {
-    if (canUseNUW(newOpcode) &&
-        canUseDecoration(Decoration::NoUnsignedWrap, ST)) {
-      decorate(target, Decoration::NoUnsignedWrap, MIRBuilder);
-    }
-  }
+static void handleIntegerWrapFlags(const MachineInstr &I, Register Target,
+                                   unsigned NewOpcode, const SPIRVSubtarget &ST,
+                                   MachineIRBuilder &MIRBuilder,
+                                   SPIRVTypeRegistry &TR) {
+  if (I.getFlag(MachineInstr::MIFlag::NoSWrap) && canUseNSW(NewOpcode) &&
+      canUseDecoration(Decoration::NoSignedWrap, ST))
+    TR.buildDecoration(Target, MIRBuilder, Decoration::NoSignedWrap, {});
+
+  if (I.getFlag(MachineInstr::MIFlag::NoUWrap) && canUseNUW(NewOpcode) &&
+       canUseDecoration(Decoration::NoUnsignedWrap, ST))
+    TR.buildDecoration(Target, MIRBuilder, Decoration::NoUnsignedWrap, {});
 }
 
 bool SPIRVInstructionSelector::selectUnOp(Register resVReg,
@@ -601,7 +592,7 @@ bool SPIRVInstructionSelector::selectUnOp(Register resVReg,
                                           const MachineInstr &I,
                                           MachineIRBuilder &MIRBuilder,
                                           unsigned newOpcode) const {
-  handleIntegerWrapFlags(I, resVReg, newOpcode, STI, MIRBuilder);
+  handleIntegerWrapFlags(I, resVReg, newOpcode, STI, MIRBuilder, TR);
   return MIRBuilder.buildInstr(newOpcode)
       .addDef(resVReg)
       .addUse(TR.getSPIRVTypeID(resType))
@@ -1515,86 +1506,32 @@ bool SPIRVInstructionSelector::selectPhi(Register resVReg,
 }
 
 bool SPIRVInstructionSelector::selectGlobalValue(
-    Register resVReg, const MachineInstr &I, MachineIRBuilder &MIRBuilder,
+    Register ResVReg, const MachineInstr &I, MachineIRBuilder &MIRBuilder,
     const MachineInstr *Init) const {
   auto *GV = I.getOperand(1).getGlobal();
-  SPIRVType *resType =
+  SPIRVType *ResType =
       TR.getOrCreateSPIRVType(GV->getType(), MIRBuilder, AQ::ReadWrite, false);
 
-  auto globalIdent = GV->getGlobalIdentifier();
-  auto globalVar = dyn_cast<GlobalVariable>(GV);
+  auto GlobalIdent = GV->getGlobalIdentifier();
+  auto GlobalVar = dyn_cast<GlobalVariable>(GV);
 
-  bool HasInit = globalVar && globalVar->hasInitializer() &&
-                 !isa<UndefValue>(globalVar->getInitializer());
+  bool HasInit = GlobalVar && GlobalVar->hasInitializer() &&
+                 !isa<UndefValue>(GlobalVar->getInitializer());
   // Skip empty declaration for GVs with initilaizers till we get the decl with
   // passed initializer.
   if (HasInit && !Init)
     return true;
 
-  // Skip if we have already output it.
-  if (DT.find(GV, &MIRBuilder.getMF(), resVReg))
-    return true;
+  auto AddrSpace = GV->getAddressSpace();
+  auto Storage = TR.addressSpaceToStorageClass(AddrSpace);
+  bool HasLnkTy = GV->getLinkage() != GlobalValue::InternalLinkage &&
+      Storage != StorageClass::Function;
+  auto LnkType = (GV->isDeclaration() || GV->hasAvailableExternallyLinkage()) ?
+                 LinkageType::Import : LinkageType::Export;
 
-  auto addrSpace = GV->getAddressSpace();
-  auto storage = TR.addressSpaceToStorageClass(addrSpace);
-  auto MIB = MIRBuilder.buildInstr(SPIRV::OpVariable)
-                 .addDef(resVReg)
-                 .addUse(TR.getSPIRVTypeID(resType))
-                 .addImm(storage);
-
-  if (HasInit != 0) {
-    MIB.addUse(Init->getOperand(0).getReg());
-    // TODO should this check be here?
-    // if (storage != StorageClass::UniformConstant) {
-    //   auto ucAddrspace =
-    //   TR.StorageClassToAddressSpace(StorageClass::UniformConstant); errs() <<
-    //   "OpVariable initializers are only valid for the "
-    //             "UniformConstant storage class (addrspace "
-    //          << ucAddrspace << ") in: " << *GV << "\n";
-    //   return false;
-    // }
-  }
-
-  // ISel may introduce a new register on this step, so we need to add it to
-  // DT and correct its type avoiding fails on the next stage.
-  bool result = MIB.constrainAllUses(TII, TRI, RBI);
-  auto Reg = MIB->getOperand(0).getReg();
-  DT.add(GV, &MIRBuilder.getMF(), Reg);
-
-  auto MRI = MIRBuilder.getMRI();
-  if (MRI->getType(Reg).isPointer())
-    MRI->setType(Reg, LLT::pointer(MRI->getType(Reg).getAddressSpace(), 32));
-
-  // If it's a global variable with name, output OpName for it.
-  if (globalVar && globalVar->hasName())
-    buildOpName(Reg, globalVar->getName(), MIRBuilder);
-
-  // Output decorations for the GV.
-  // TODO: maybe move to GenerateDecorations pass.
-  if (globalVar && globalVar->isConstant())
-    decorate(Reg, Decoration::Constant, MIRBuilder);
-
-  if (globalVar && globalVar->getAlign().valueOrOne().value() != 1) {
-    auto Alignment = globalVar->getAlign().valueOrOne().value();
-    MIRBuilder.buildInstr(SPIRV::OpDecorate)
-                   .addUse(Reg)
-                   .addImm(Decoration::Alignment)
-                   .addImm(Alignment);
-  }
-
-  if (GV->getLinkage() != GlobalValue::InternalLinkage &&
-      storage != StorageClass::Function) {
-    bool IsImport = GV->isDeclaration() ||
-                    GV->hasAvailableExternallyLinkage();
-    auto LinkageType = IsImport ? LinkageType::Import : LinkageType::Export;
-    MIB = MIRBuilder.buildInstr(SPIRV::OpDecorate)
-                   .addUse(Reg)
-                   .addImm(Decoration::LinkageAttributes);
-    addStringImm(globalIdent, MIB);
-    MIB.addImm(LinkageType);
-  }
-
-  return result;
+  auto Reg = TR.buildGlobalVariable(ResVReg, ResType, GlobalIdent, GV, Storage,
+    Init, GlobalVar && GlobalVar->isConstant(), HasLnkTy, LnkType, MIRBuilder);
+  return Reg.isValid();
 }
 
 namespace llvm {

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -580,11 +580,11 @@ static void handleIntegerWrapFlags(const MachineInstr &I, Register Target,
                                    SPIRVTypeRegistry &TR) {
   if (I.getFlag(MachineInstr::MIFlag::NoSWrap) && canUseNSW(NewOpcode) &&
       canUseDecoration(Decoration::NoSignedWrap, ST))
-    TR.buildDecoration(Target, MIRBuilder, Decoration::NoSignedWrap, {});
+    buildOpDecorate(Target, MIRBuilder, Decoration::NoSignedWrap, {});
 
   if (I.getFlag(MachineInstr::MIFlag::NoUWrap) && canUseNUW(NewOpcode) &&
        canUseDecoration(Decoration::NoUnsignedWrap, ST))
-    TR.buildDecoration(Target, MIRBuilder, Decoration::NoUnsignedWrap, {});
+    buildOpDecorate(Target, MIRBuilder, Decoration::NoUnsignedWrap, {});
 }
 
 bool SPIRVInstructionSelector::selectUnOp(Register resVReg,

--- a/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
@@ -320,7 +320,7 @@ static Register buildBuiltInLoad(MachineIRBuilder &MIRBuilder,
   Register Var = TR->buildGlobalVariable(NewReg, PtrTy,
       getLinkStrForBuiltIn(builtIn), nullptr, StorageClass::Input, nullptr,
       true, true, LinkageType::Import, MIRBuilder);
-  TR->buildDecoration(Var, MIRBuilder, Decoration::BuiltIn, {builtIn});
+  buildOpDecorate(Var, MIRBuilder, Decoration::BuiltIn, {builtIn});
 
   // Load the value from the global variable
   Register loadedReg = buildLoad(varType, Var, MIRBuilder, TR, llt, Reg);
@@ -1049,17 +1049,11 @@ static bool genConvertInstr(MachineIRBuilder &MIRBuilder,
     }
   }
 
-  namespace Dec = Decoration;
-  bool success = true;
   if (isSat)
-    success &= TR->buildDecoration(ret, MIRBuilder, Dec::SaturatedConversion,
-                                   {});
-  if (isRounded && success)
-    success &= TR->buildDecoration(ret, MIRBuilder, Dec::FPRoundingMode,
-                                   {roundingMode});
-  if (!success)
-    return false;
-
+    buildOpDecorate(ret, MIRBuilder, Decoration::SaturatedConversion, {});
+  if (isRounded)
+    buildOpDecorate(ret, MIRBuilder, Decoration::FPRoundingMode,
+                               {roundingMode});
   if (isFromInt) {
     if (isToInt) { // I -> I
       auto op = dstSign ? OpUConvert : OpSConvert;

--- a/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
@@ -251,73 +251,6 @@ static Register buildSamplerLiteral(uint64_t samplerBitmask, Register res,
   return sampler;
 }
 
-static bool decorate(Register target, Decoration::Decoration decoration,
-                     MachineIRBuilder &MIRBuilder, SPIRVTypeRegistry *TR) {
-  auto MIB = MIRBuilder.buildInstr(SPIRV::OpDecorate)
-                 .addUse(target)
-                 .addImm(decoration);
-  return TR->constrainRegOperands(MIB);
-}
-
-static bool decorate(Register target, Decoration::Decoration decoration,
-                     uint32_t decArg, MachineIRBuilder &MIRBuilder,
-                     SPIRVTypeRegistry *TR) {
-  auto MIB = MIRBuilder.buildInstr(SPIRV::OpDecorate)
-                 .addUse(target)
-                 .addImm(decoration)
-                 .addImm(decArg);
-  return TR->constrainRegOperands(MIB);
-}
-
-static bool decorateLinkage(Register target, const StringRef name,
-                            LinkageType::LinkageType linkageType,
-                            MachineIRBuilder &MIRBuilder,
-                            SPIRVTypeRegistry *TR) {
-  auto MIB = MIRBuilder.buildInstr(SPIRV::OpDecorate)
-                 .addUse(target)
-                 .addImm(Decoration::LinkageAttributes);
-  addStringImm(name, MIB);
-  MIB.addImm(LinkageType::Import);
-  bool success = TR->constrainRegOperands(MIB);
-
-  auto nameMIB = MIRBuilder.buildInstr(SPIRV::OpName).addUse(target);
-  addStringImm(name, nameMIB);
-  return success;
-}
-
-static bool decorateConstant(Register target, MachineIRBuilder &MIRBuilder,
-                             SPIRVTypeRegistry *TR) {
-  return decorate(target, Decoration::Constant, MIRBuilder, TR);
-}
-
-static bool decorateBuiltIn(Register target, BuiltIn::BuiltIn builtInID,
-                            MachineIRBuilder &MIRBuilder,
-                            SPIRVTypeRegistry *TR) {
-  bool succ = decorate(target, Decoration::BuiltIn, builtInID, MIRBuilder, TR);
-  succ = succ && decorateLinkage(target, getLinkStrForBuiltIn(builtInID),
-                                 LinkageType::Import, MIRBuilder, TR);
-  return succ;
-}
-
-static Register buildOpVariable(SPIRVType *BaseType,
-                                StorageClass::StorageClass Storage,
-                                MachineIRBuilder &MIRBuilder,
-                                SPIRVTypeRegistry *TR) {
-  auto Reg = MIRBuilder.getMRI()->createVirtualRegister(&SPIRV::IDRegClass);
-  // TODO: consider using correct address space
-  // p0 is canonical type for selection though
-  MIRBuilder.getMRI()->setType(Reg, LLT::pointer(0, TR->getPointerSize()));
-  SPIRVType *PtrTy =
-      TR->getOrCreateSPIRVPointerType(BaseType, MIRBuilder, Storage);
-  TR->assignSPIRVTypeToVReg(PtrTy, Reg, MIRBuilder);
-  auto MIB = MIRBuilder.buildInstr(SPIRV::OpVariable)
-                 .addDef(Reg)
-                 .addUse(TR->getSPIRVTypeID(PtrTy))
-                 .addImm(Storage);
-  TR->constrainRegOperands(MIB);
-  return Reg;
-}
-
 static Register buildLoad(SPIRVType *BaseType, Register PtrVReg,
                           MachineIRBuilder &MIRBuilder, SPIRVTypeRegistry *TR,
                           LLT llt, Register dstReg = Register(0)) {
@@ -377,13 +310,20 @@ static Register buildBuiltInLoad(MachineIRBuilder &MIRBuilder,
                               SPIRVType *varType,
                               SPIRVTypeRegistry *TR, BuiltIn::BuiltIn builtIn,
                               LLT llt, Register Reg = Register(0)) {
+  Register NewReg = MIRBuilder.getMRI()->createVirtualRegister(&SPIRV::IDRegClass);
+  MIRBuilder.getMRI()->setType(NewReg, LLT::pointer(0, TR->getPointerSize()));
+  SPIRVType *PtrTy =
+      TR->getOrCreateSPIRVPointerType(varType, MIRBuilder, StorageClass::Input);
+  TR->assignSPIRVTypeToVReg(PtrTy, NewReg, MIRBuilder);
+
   // Set up the global OpVariable with the necessary builtin decorations
-  Register var = buildOpVariable(varType, StorageClass::Input, MIRBuilder, TR);
-  decorateBuiltIn(var, builtIn, MIRBuilder, TR);
-  decorateConstant(var, MIRBuilder, TR);
+  Register Var = TR->buildGlobalVariable(NewReg, PtrTy,
+      getLinkStrForBuiltIn(builtIn), nullptr, StorageClass::Input, nullptr,
+      true, true, LinkageType::Import, MIRBuilder);
+  TR->buildDecoration(Var, MIRBuilder, Decoration::BuiltIn, {builtIn});
 
   // Load the value from the global variable
-  Register loadedReg = buildLoad(varType, var, MIRBuilder, TR, llt, Reg);
+  Register loadedReg = buildLoad(varType, Var, MIRBuilder, TR, llt, Reg);
   MIRBuilder.getMRI()->setType(loadedReg, llt);
   return loadedReg;
 }
@@ -460,8 +400,12 @@ static bool genWorkgroupQuery(MachineIRBuilder &MIRBuilder, Register resVReg,
       TR->assignSPIRVTypeToVReg(PtrSizeTy, extr, MIRBuilder);
     }
 
-    // Use G_EXTRACT_VECTOR_ELT so dynamic vs static extraction is handled later
-    MIRBuilder.buildExtractVectorElement(extr, loadedVector, idxVReg);
+    // Use Intrinsic::spv_extractelt so dynamic vs static extraction is
+    // handled later: extr = spv_extractelt loadedVector, idxVReg
+    MachineInstrBuilder ExtractInst = MIRBuilder.buildIntrinsic(
+        Intrinsic::spv_extractelt, ArrayRef<Register>{extr}, true);
+    ExtractInst.addUse(loadedVector)
+               .addUse(idxVReg);
 
     // If the index is dynamic, need check if it's < 3, and then use a select
     if (!isConstantIndex) {
@@ -1108,9 +1052,11 @@ static bool genConvertInstr(MachineIRBuilder &MIRBuilder,
   namespace Dec = Decoration;
   bool success = true;
   if (isSat)
-    success &= decorate(ret, Dec::SaturatedConversion, MIRBuilder, TR);
+    success &= TR->buildDecoration(ret, MIRBuilder, Dec::SaturatedConversion,
+                                   {});
   if (isRounded && success)
-    success &= decorate(ret, Dec::FPRoundingMode, roundingMode, MIRBuilder, TR);
+    success &= TR->buildDecoration(ret, MIRBuilder, Dec::FPRoundingMode,
+                                   {roundingMode});
   if (!success)
     return false;
 

--- a/llvm/lib/Target/SPIRV/SPIRVStrings.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVStrings.cpp
@@ -75,3 +75,15 @@ void buildOpName(Register target, const StringRef &name,
     addStringImm(name, MIB);
   }
 }
+
+void buildOpDecorate(Register Reg, MachineIRBuilder &MIRBuilder,
+    Decoration::Decoration Dec, const std::vector<uint32_t> &DecArgs,
+    StringRef StrImm) {
+  auto MIB = MIRBuilder.buildInstr(SPIRV::OpDecorate)
+                 .addUse(Reg)
+                 .addImm(Dec);
+  if (!StrImm.empty())
+    addStringImm(StrImm, MIB);
+  for (const auto &DecArg : DecArgs)
+    MIB.addImm(DecArg);
+}

--- a/llvm/lib/Target/SPIRV/SPIRVStrings.h
+++ b/llvm/lib/Target/SPIRV/SPIRVStrings.h
@@ -17,6 +17,7 @@
 #ifndef LLVM_LIB_TARGET_SPIRV_SPIRVSTRINGS_H
 #define LLVM_LIB_TARGET_SPIRV_SPIRVSTRINGS_H
 
+#include "SPIRVEnums.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 #include "llvm/CodeGen/MachineInstr.h"
@@ -39,4 +40,8 @@ std::string getStringImm(const llvm::MachineInstr &MI, unsigned int startIndex);
 void buildOpName(llvm::Register target, const llvm::StringRef &name,
                  llvm::MachineIRBuilder &MIRBuilder);
 
+// Add an OpDecorate instruction for the given Reg.
+void buildOpDecorate(llvm::Register Reg, llvm::MachineIRBuilder &MIRBuilder,
+    Decoration::Decoration Dec, const std::vector<uint32_t> &DecArgs,
+    llvm::StringRef StrImm = "");
 #endif

--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
@@ -387,6 +387,93 @@ SPIRVTypeRegistry::buildConstantSampler(Register resReg, unsigned int addrMode,
   return res->getOperand(0).getReg();
 }
 
+bool
+SPIRVTypeRegistry::buildDecoration(Register Reg, MachineIRBuilder &MIRBuilder,
+    Decoration::Decoration Dec, const std::vector<uint32_t> &DecArgs,
+    StringRef StrImm) {
+  auto MIB = MIRBuilder.buildInstr(SPIRV::OpDecorate)
+                 .addUse(Reg)
+                 .addImm(Dec);
+  if (!StrImm.empty())
+    addStringImm(StrImm, MIB);
+  for (const auto &DecArg : DecArgs)
+    MIB.addImm(DecArg);
+  return constrainRegOperands(MIB);
+}
+
+Register
+SPIRVTypeRegistry::buildGlobalVariable(Register ResVReg, SPIRVType *BaseType,
+    StringRef Name, const GlobalValue *GV, StorageClass::StorageClass Storage,
+    const MachineInstr *Init, bool IsConst, bool HasLinkageTy,
+    LinkageType::LinkageType LinkageType, MachineIRBuilder &MIRBuilder) {
+  const GlobalVariable *GVar = nullptr;
+  if (GV)
+    GVar = dyn_cast<const GlobalVariable>(GV);
+  else {
+    // If GV is not passed explicitly, use the name to find or construct
+    // the global variable.
+    auto *Module = MIRBuilder.getMBB().getBasicBlock()->getModule();
+    GVar = Module->getGlobalVariable(Name);
+    if (GVar == nullptr) {
+      auto Ty = getTypeForSPIRVType(BaseType);//TODO check type
+      GVar = new GlobalVariable(*const_cast<llvm::Module*>(Module),
+           const_cast<Type *>(Ty), false, GlobalValue::ExternalLinkage,
+           nullptr, Twine(Name));
+    }
+    GV = GVar;
+  }
+  assert(GV && "Global variable is expected");
+  Register Reg;
+  if (DT.find(GV, &MIRBuilder.getMF(), Reg)) {
+    if (Reg != ResVReg)
+      MIRBuilder.buildCopy(ResVReg, Reg);
+    return ResVReg;
+  }
+
+  auto MIB = MIRBuilder.buildInstr(SPIRV::OpVariable)
+                 .addDef(ResVReg)
+                 .addUse(getSPIRVTypeID(BaseType))
+                 .addImm(Storage);
+
+  if (Init != 0) {
+    MIB.addUse(Init->getOperand(0).getReg());
+  }
+
+  // ISel may introduce a new register on this step, so we need to add it to
+  // DT and correct its type avoiding fails on the next stage.
+  constrainRegOperands(MIB, CurMF);
+  Reg = MIB->getOperand(0).getReg();
+  DT.add(GV, &MIRBuilder.getMF(), Reg);
+
+  // Set to Reg the same type as ResVReg has.
+  auto MRI = MIRBuilder.getMRI();
+  assert(MRI->getType(ResVReg).isPointer() && "Pointer type is expected");
+  if (Reg != ResVReg) {
+    LLT RegLLTy = LLT::pointer(MRI->getType(ResVReg).getAddressSpace(), 32);
+    MRI->setType(Reg, RegLLTy);
+    assignSPIRVTypeToVReg(BaseType, Reg, MIRBuilder);
+  }
+
+  // If it's a global variable with name, output OpName for it.
+  if (GVar && GVar->hasName())
+    buildOpName(Reg, GVar->getName(), MIRBuilder);
+
+  // Output decorations for the GV.
+  // TODO: maybe move to GenerateDecorations pass.
+  if (IsConst)
+    buildDecoration(Reg, MIRBuilder, Decoration::Constant, {});
+
+  if (GVar && GVar->getAlign().valueOrOne().value() != 1) {
+    unsigned Alignment = (unsigned) GVar->getAlign().valueOrOne().value();
+    buildDecoration(Reg, MIRBuilder, Decoration::Alignment, {Alignment});
+  }
+
+  if (HasLinkageTy)
+    buildDecoration(Reg, MIRBuilder, Decoration::LinkageAttributes,
+                    {LinkageType}, Name);
+  return Reg;
+}
+
 SPIRVType *SPIRVTypeRegistry::getOpTypeArray(uint32_t numElems,
                                              SPIRVType *elemType,
                                              MachineIRBuilder &MIRBuilder,

--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
@@ -387,20 +387,6 @@ SPIRVTypeRegistry::buildConstantSampler(Register resReg, unsigned int addrMode,
   return res->getOperand(0).getReg();
 }
 
-bool
-SPIRVTypeRegistry::buildDecoration(Register Reg, MachineIRBuilder &MIRBuilder,
-    Decoration::Decoration Dec, const std::vector<uint32_t> &DecArgs,
-    StringRef StrImm) {
-  auto MIB = MIRBuilder.buildInstr(SPIRV::OpDecorate)
-                 .addUse(Reg)
-                 .addImm(Dec);
-  if (!StrImm.empty())
-    addStringImm(StrImm, MIB);
-  for (const auto &DecArg : DecArgs)
-    MIB.addImm(DecArg);
-  return constrainRegOperands(MIB);
-}
-
 Register
 SPIRVTypeRegistry::buildGlobalVariable(Register ResVReg, SPIRVType *BaseType,
     StringRef Name, const GlobalValue *GV, StorageClass::StorageClass Storage,
@@ -461,15 +447,15 @@ SPIRVTypeRegistry::buildGlobalVariable(Register ResVReg, SPIRVType *BaseType,
   // Output decorations for the GV.
   // TODO: maybe move to GenerateDecorations pass.
   if (IsConst)
-    buildDecoration(Reg, MIRBuilder, Decoration::Constant, {});
+    buildOpDecorate(Reg, MIRBuilder, Decoration::Constant, {});
 
   if (GVar && GVar->getAlign().valueOrOne().value() != 1) {
     unsigned Alignment = (unsigned) GVar->getAlign().valueOrOne().value();
-    buildDecoration(Reg, MIRBuilder, Decoration::Alignment, {Alignment});
+    buildOpDecorate(Reg, MIRBuilder, Decoration::Alignment, {Alignment});
   }
 
   if (HasLinkageTy)
-    buildDecoration(Reg, MIRBuilder, Decoration::LinkageAttributes,
+    buildOpDecorate(Reg, MIRBuilder, Decoration::LinkageAttributes,
                     {LinkageType}, Name);
   return Reg;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
@@ -241,10 +241,6 @@ public:
   Register buildConstantSampler(Register res, unsigned int addrMode,
       unsigned int param, unsigned int filerMode,
       MachineIRBuilder &MIRBuilder, SPIRVType *spvType);
-
-  bool buildDecoration(Register Reg, MachineIRBuilder &MIRBuilder,
-      Decoration::Decoration Dec, const std::vector<uint32_t> &DecArgs,
-      StringRef StrImm = "");
   Register buildGlobalVariable(Register Reg, SPIRVType *BaseType,
       StringRef Name, const GlobalValue *GV, StorageClass::StorageClass Storage,
       const MachineInstr *Init, bool IsConst,  bool HasLinkageTy,

--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
@@ -242,6 +242,14 @@ public:
       unsigned int param, unsigned int filerMode,
       MachineIRBuilder &MIRBuilder, SPIRVType *spvType);
 
+  bool buildDecoration(Register Reg, MachineIRBuilder &MIRBuilder,
+      Decoration::Decoration Dec, const std::vector<uint32_t> &DecArgs,
+      StringRef StrImm = "");
+  Register buildGlobalVariable(Register Reg, SPIRVType *BaseType,
+      StringRef Name, const GlobalValue *GV, StorageClass::StorageClass Storage,
+      const MachineInstr *Init, bool IsConst,  bool HasLinkageTy,
+      LinkageType::LinkageType LinkageType, MachineIRBuilder &MIRBuilder);
+
   // convenient helpers for getting types
   // w/ check for duplicates
   SPIRVType *getOrCreateSPIRVIntegerType(unsigned BitWidth,


### PR DESCRIPTION
The change moves OpVariable and the most of OpDecorates building to one place (TR). All OpVariables are checked in DT.

SPIRVDuplicatesTracker.h: fix error for GV and F.
SPIRVOpenCLBIFs.cpp: buildExtractVectorElement was changed to spv_extractelt intrinsic call since the last one can be selected into both OpCompositeExtract and OpVectorExtractDynamic depending on its arguments.

One LIT test is passed (opencl/get_global_id.ll).