### PR TITLE
[SPIR-V] decorate __spirv builtin vars, support 2 builtin functions

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEnums.h
+++ b/llvm/lib/Target/SPIRV/SPIRVEnums.h
@@ -655,7 +655,7 @@ GEN_ENUM_HEADER(Decoration)
   X(N, SampleMask, 20, {Shader}, {}, 0, 0)                                     \
   X(N, FragDepth, 22, {Shader}, {}, 0, 0)                                      \
   X(N, HelperInvocation, 23, {Shader}, {}, 0, 0)                               \
-  X(N, NumWorkGroups, 24, {}, {}, 0, 0)                                        \
+  X(N, NumWorkgroups, 24, {}, {}, 0, 0)                                        \
   X(N, WorkgroupSize, 25, {}, {}, 0, 0)                                        \
   X(N, WorkgroupId, 26, {}, {}, 0, 0)                                          \
   X(N, LocalInvocationId, 27, {}, {}, 0, 0)                                    \

--- a/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.h
+++ b/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.h
@@ -26,5 +26,6 @@ bool generateOpenCLBuiltinCall(const StringRef demangledName,
                                const Type *OrigRetTy,
                                const SmallVectorImpl<Register> &args,
                                SPIRVTypeRegistry *TR);
+bool getSpirvBuilInIdByName(StringRef Name, BuiltIn::BuiltIn &BI);
 } // end namespace llvm
 #endif

--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.cpp
@@ -457,6 +457,11 @@ SPIRVTypeRegistry::buildGlobalVariable(Register ResVReg, SPIRVType *BaseType,
   if (HasLinkageTy)
     buildOpDecorate(Reg, MIRBuilder, Decoration::LinkageAttributes,
                     {LinkageType}, Name);
+
+  BuiltIn::BuiltIn BuiltInId;
+  if (getSpirvBuilInIdByName(Name, BuiltInId))
+    buildOpDecorate(Reg, MIRBuilder, Decoration::BuiltIn, {BuiltInId});
+
   return Reg;
 }
 

--- a/llvm/test/CodeGen/SPIRV/transcoding/builtin_vars.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/builtin_vars.ll
@@ -9,9 +9,12 @@ target triple = "spirv32-unknown-unknown"
 @__spirv_BuiltInGlobalLinearId = external addrspace(1) global i32
 
 ; Function Attrs: nounwind readnone
-define spir_kernel void @f() #0 !kernel_arg_addr_space !0 !kernel_arg_access_qual !0 !kernel_arg_type !0 !kernel_arg_base_type !0 !kernel_arg_type_qual !0 {
+define spir_kernel void @f(i32 addrspace(1)* nocapture %order) #0 !kernel_arg_addr_space !0 !kernel_arg_access_qual !0 !kernel_arg_type !0 !kernel_arg_base_type !0 !kernel_arg_type_qual !0 {
 entry:
   %0 = load i32, i32 addrspace(4)* addrspacecast (i32 addrspace(1)* @__spirv_BuiltInGlobalLinearId to i32 addrspace(4)*), align 4
+  ; Need to store the result somewhere, otherwise the access to GlobalLinearId
+  ; may be removed.
+  store i32 %0, i32 addrspace(1)* %order, align 4
   ret void
 }
 


### PR DESCRIPTION
The change add support of __spirv builtin var decoration and 2 builtin functions (__spirv_BuiltInGlobalLinearId, __spirv_BuiltInGlobalInvocationId), fix typo in builtin name (NumWorkgroups), move global var decoration with "BuiltIn" to buildGlobalVariable.

5 LIT tests should pass (builtin_vars-decorate.ll, transcoding/builtin_calls.ll, transcoding/builtin_vars.ll, transcoding/builtin_vars_arithmetics.ll, transcoding/builtin_vars_opt.ll).