### PR TITLE
[SPIR-V] partly support llvm.memmove/memcpy intrinsics, fix errors

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -52,10 +52,10 @@ static uint32_t getFunctionControl(const Function &F) {
     funcControl |= FunctionControl::Inline;
   }
   if (F.hasFnAttribute(Attribute::AttrKind::ReadNone)) {
-    funcControl |= FunctionControl::Const;
+    funcControl |= FunctionControl::Pure;
   }
   if (F.hasFnAttribute(Attribute::AttrKind::ReadOnly)) {
-    funcControl |= FunctionControl::Pure;
+    funcControl |= FunctionControl::Const;
   }
   if (F.hasFnAttribute(Attribute::AttrKind::NoInline)) {
     funcControl |= FunctionControl::DontInline;

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -135,6 +135,10 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
       {G_BUILD_VECTOR, G_SHUFFLE_VECTOR})
       .alwaysLegal();
 
+  getActionDefinitionsBuilder({G_MEMCPY, G_MEMMOVE})
+      .legalIf(all(typeInSet(0, allWritablePtrs),
+                   typeInSet(1, allPtrs)));
+
   getActionDefinitionsBuilder(G_ADDRSPACE_CAST)
       .legalForCartesianProduct(allPtrs, allPtrs);
 

--- a/llvm/test/CodeGen/SPIRV/function/trivial-function-with-attributes.ll
+++ b/llvm/test/CodeGen/SPIRV/function/trivial-function-with-attributes.ll
@@ -56,19 +56,19 @@ define void @fn4() inlinehint {
 define void @fn5() readnone {
   ret void
 }
-; CHECK: [[FN5]] = OpFunction [[VOID]] Const [[FN]]
+; CHECK: [[FN5]] = OpFunction [[VOID]] Pure [[FN]]
 ; CHECK: OpFunctionEnd
 
 
 define void @fn6() readonly {
   ret void
 }
-; CHECK: [[FN6]] = OpFunction [[VOID]] Pure [[FN]]
+; CHECK: [[FN6]] = OpFunction [[VOID]] Const [[FN]]
 ; CHECK: OpFunctionEnd
 
 
 define void @fn7() alwaysinline readnone {
   ret void
 }
-; CHECK: [[FN7]] = OpFunction [[VOID]] Inline|Const [[FN]]
+; CHECK: [[FN7]] = OpFunction [[VOID]] Inline|Pure [[FN]]
 ; CHECK: OpFunctionEnd

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/memcpy.align.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/memcpy.align.ll
@@ -47,7 +47,7 @@ entry:
   %b1 = getelementptr inbounds %struct.A, %struct.A* %agg.result, i32 0, i32 1
   %2 = bitcast %struct.B* %b1 to i8*
   %3 = bitcast %struct.B* %b to i8*
-; CHECK-SPIRV: OpCopyMemorySized %{{[0-9]+}} %{{[0-9]+}} %{{[0-9]+}} {{.*}} Nontemporal
+; CHECK-SPIRV: OpCopyMemorySized %{{[0-9]+}} %{{[0-9]+}} %{{[0-9]+}} {{.*}} 4
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 8 %2, i8* align 4 %3, i32 8, i1 false), !tbaa.struct !4
   %4 = bitcast %struct.B* %b to i8*
   call void @llvm.lifetime.end.p0i8(i64 8, i8* %4) #2
@@ -78,7 +78,7 @@ entry:
   %b = getelementptr inbounds %struct.A, %struct.A* %a, i32 0, i32 1
   %2 = bitcast %struct.B* %agg.result to i8*
   %3 = bitcast %struct.B* %b to i8*
-; CHECK-SPIRV: OpCopyMemorySized %{{[0-9]+}} %{{[0-9]+}} %{{[0-9]+}} {{.*}} Nontemporal
+; CHECK-SPIRV: OpCopyMemorySized %{{[0-9]+}} %{{[0-9]+}} %{{[0-9]+}} {{.*}} 4
   call void @llvm.memcpy.p0i8.p0i8.i32(i8* align 4 %2, i8* align 8 %3, i32 8, i1 false), !tbaa.struct !4
   %4 = bitcast %struct.A* %a to i8*
   call void @llvm.lifetime.end.p0i8(i64 16, i8* %4) #2

--- a/llvm/test/CodeGen/SPIRV/transcoding/spirv-private-array-initialization.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/spirv-private-array-initialization.ll
@@ -20,13 +20,11 @@
 ;
 ; CHECK-SPIRV: %[[arr_i8_ptr:[0-9]+]] = OpBitcast %[[i8_ptr]] %[[arr]]
 ; CHECK-SPIRV: %[[test_arr_const_i8_ptr:[0-9]+]] = OpBitcast %[[const_i8_ptr]] %[[test_arr]]
-; FIXME: check syntax of OpCopyMemorySized
-; CHECK-SPIRV: OpCopyMemorySized %[[arr_i8_ptr]] %[[test_arr_const_i8_ptr]] %[[twelve]] Aligned Nontemporal
+; CHECK-SPIRV: OpCopyMemorySized %[[arr_i8_ptr]] %[[test_arr_const_i8_ptr]] %[[twelve]] Aligned 4
 ;
 ; CHECK-SPIRV: %[[arr2_i8_ptr:[0-9]+]] = OpBitcast %[[i8_ptr]] %[[arr2]]
 ; CHECK-SPIRV: %[[test_arr2_const_i8_ptr:[0-9]+]] = OpBitcast %[[const_i8_ptr]] %[[test_arr2]]
-; FIXME: check syntax of OpCopyMemorySized
-; CHECK-SPIRV: OpCopyMemorySized %[[arr2_i8_ptr]] %[[test_arr2_const_i8_ptr]] %[[twelve]] Aligned Nontemporal
+; CHECK-SPIRV: OpCopyMemorySized %[[arr2_i8_ptr]] %[[test_arr2_const_i8_ptr]] %[[twelve]] Aligned 4
 
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv32-unknown-unknown"


### PR DESCRIPTION
The patch adds basic support of llvm.memmove/memcpy intrinsics, fixes errors in SPIRV type detection/propagation exposed after their adding. Also the error in Function Control mask is fixed and 3 tests are corrected.

Memmove/memcpy tests pass compilation however they still fail due to missed OpBitcast instructions.  Also OpLifetimeStart/OpLifetimeStop instructions are missed in some of the tests.