### PR TITLE
[SPIR-V] support llvm arithmetic intrinsics, fix tests

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -92,9 +92,12 @@ private:
                          MachineIRBuilder &MIRBuilder,
                          const MachineInstr *Init = nullptr) const;
 
-  bool selectUnOp(Register resVReg, const SPIRVType *resType,
+  bool selectUnOpWithSrc(Register ResVReg, const SPIRVType *ResType,
+                         const MachineInstr &I, Register SrcReg,
+                         MachineIRBuilder &MIRBuilder, unsigned Opcode) const;
+  bool selectUnOp(Register ResVReg, const SPIRVType *ResType,
                   const MachineInstr &I, MachineIRBuilder &MIRBuilder,
-                  unsigned newOpcode) const;
+                  unsigned Opcode) const;
 
   bool selectLoad(Register resVReg, const SPIRVType *resType,
                   const MachineInstr &I, MachineIRBuilder &MIRBuilder) const;
@@ -147,6 +150,12 @@ private:
   bool selectConst(Register resVReg, const SPIRVType *resType, const APInt &imm,
                    MachineIRBuilder &MIRBuilder) const;
 
+  bool selectSelect(Register ResVReg, const SPIRVType *ResType,
+                    const MachineInstr &I, bool IsSigned,
+                    MachineIRBuilder &MIRBuilder) const;
+  bool selectIToF(Register ResVReg, const SPIRVType *ResType,
+                  const MachineInstr &I, bool IsSigned,
+                  MachineIRBuilder &MIRBuilder, unsigned Opcode) const;
   bool selectExt(Register resVReg, const SPIRVType *resType,
                  const MachineInstr &I, bool isSigned,
                  MachineIRBuilder &MIRBuilder) const;
@@ -351,9 +360,9 @@ bool SPIRVInstructionSelector::spvSelect(Register resVReg,
     return selectUnOp(resVReg, resType, I, MIRBuilder, OpConvertFToU);
 
   case TargetOpcode::G_SITOFP:
-    return selectUnOp(resVReg, resType, I, MIRBuilder, OpConvertSToF);
+    return selectIToF(resVReg, resType, I, true, MIRBuilder, OpConvertSToF);
   case TargetOpcode::G_UITOFP:
-    return selectUnOp(resVReg, resType, I, MIRBuilder, OpConvertUToF);
+    return selectIToF(resVReg, resType, I, false, MIRBuilder, OpConvertUToF);
 
   case TargetOpcode::G_CTPOP:
     return selectUnOp(resVReg, resType, I, MIRBuilder, OpBitCount);
@@ -386,6 +395,8 @@ bool SPIRVInstructionSelector::spvSelect(Register resVReg,
 
   case TargetOpcode::G_FPOW:
     return selectExtInst(resVReg, resType, I, MIRBuilder, CL::pow, GL::Pow);
+  case TargetOpcode::G_FPOWI:
+    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::pown);
 
   case TargetOpcode::G_FEXP:
     return selectExtInst(resVReg, resType, I, MIRBuilder, CL::exp, GL::Exp);
@@ -401,11 +412,18 @@ bool SPIRVInstructionSelector::spvSelect(Register resVReg,
 
   case TargetOpcode::G_FABS:
     return selectExtInst(resVReg, resType, I, MIRBuilder, CL::fabs, GL::FAbs);
+  case TargetOpcode::G_ABS:
+    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::s_abs, GL::SAbs);
 
   case TargetOpcode::G_FMINNUM:
+  case TargetOpcode::G_FMINIMUM:
     return selectExtInst(resVReg, resType, I, MIRBuilder, CL::fmin, GL::FMin);
   case TargetOpcode::G_FMAXNUM:
+  case TargetOpcode::G_FMAXIMUM:
     return selectExtInst(resVReg, resType, I, MIRBuilder, CL::fmax, GL::FMax);
+
+  case TargetOpcode::G_FCOPYSIGN:
+    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::copysign);
 
   case TargetOpcode::G_FCEIL:
     return selectExtInst(resVReg, resType, I, MIRBuilder, CL::ceil, GL::Ceil);
@@ -429,6 +447,9 @@ bool SPIRVInstructionSelector::spvSelect(Register resVReg,
 
   case TargetOpcode::G_INTRINSIC_ROUND:
     return selectExtInst(resVReg, resType, I, MIRBuilder, CL::round, GL::Round);
+  case TargetOpcode::G_INTRINSIC_ROUNDEVEN:
+    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::rint,
+                         GL::RoundEven);
   case TargetOpcode::G_INTRINSIC_TRUNC:
     return selectExtInst(resVReg, resType, I, MIRBuilder, CL::trunc, GL::Trunc);
   case TargetOpcode::G_FRINT:
@@ -587,17 +608,22 @@ static void handleIntegerWrapFlags(const MachineInstr &I, Register Target,
     buildOpDecorate(Target, MIRBuilder, Decoration::NoUnsignedWrap, {});
 }
 
-bool SPIRVInstructionSelector::selectUnOp(Register resVReg,
-                                          const SPIRVType *resType,
-                                          const MachineInstr &I,
-                                          MachineIRBuilder &MIRBuilder,
-                                          unsigned newOpcode) const {
-  handleIntegerWrapFlags(I, resVReg, newOpcode, STI, MIRBuilder, TR);
-  return MIRBuilder.buildInstr(newOpcode)
-      .addDef(resVReg)
-      .addUse(TR.getSPIRVTypeID(resType))
-      .addUse(I.getOperand(1).getReg())
+bool SPIRVInstructionSelector::selectUnOpWithSrc(Register ResVReg,
+    const SPIRVType *ResType, const MachineInstr &I, Register SrcReg,
+    MachineIRBuilder &MIRBuilder, unsigned Opcode) const {
+  handleIntegerWrapFlags(I, ResVReg, Opcode, STI, MIRBuilder, TR);
+  return MIRBuilder.buildInstr(Opcode)
+      .addDef(ResVReg)
+      .addUse(TR.getSPIRVTypeID(ResType))
+      .addUse(SrcReg)
       .constrainAllUses(TII, TRI, RBI);
+}
+
+bool SPIRVInstructionSelector::selectUnOp(Register ResVReg,
+    const SPIRVType *ResType, const MachineInstr &I,
+    MachineIRBuilder &MIRBuilder, unsigned Opcode) const {
+  return selectUnOpWithSrc(ResVReg, ResType, I, I.getOperand(1).getReg(),
+                           MIRBuilder, Opcode);
 }
 
 static MemorySemantics::MemorySemantics getMemSemantics(AtomicOrdering ord) {
@@ -1194,25 +1220,50 @@ SPIRVInstructionSelector::buildOnesVal(bool allOnes, const SPIRVType *resType,
   }
 }
 
+bool SPIRVInstructionSelector::selectSelect(Register ResVReg,
+    const SPIRVType *ResType, const MachineInstr &I, bool IsSigned,
+    MachineIRBuilder &MIRBuilder) const {
+  // To extend a bool, we need to use OpSelect between constants
+  using namespace SPIRV;
+  Register ZeroReg = buildZerosVal(ResType, MIRBuilder);
+  Register OneReg = buildOnesVal(IsSigned, ResType, MIRBuilder);
+  bool IsScalarBool = TR.isScalarOfType(I.getOperand(1).getReg(), OpTypeBool);
+  return MIRBuilder.buildInstr(IsScalarBool ? OpSelectSISCond : OpSelectSIVCond)
+        .addDef(ResVReg)
+        .addUse(TR.getSPIRVTypeID(ResType))
+        .addUse(I.getOperand(1).getReg())
+        .addUse(OneReg)
+        .addUse(ZeroReg)
+        .constrainAllUses(TII, TRI, RBI);
+}
+
+bool SPIRVInstructionSelector::selectIToF(Register ResVReg,
+    const SPIRVType *ResType, const MachineInstr &I, bool IsSigned,
+    MachineIRBuilder &MIRBuilder, unsigned Opcode) const {
+  Register SrcReg = I.getOperand(1).getReg();
+  // We can convert bool value directly to float type without OpConvert*ToF,
+  // however the translator generates OpSelect+OpConvert*ToF, so we do the same.
+  if (TR.isScalarOrVectorOfType(I.getOperand(1).getReg(), SPIRV::OpTypeBool)) {
+    auto BitWidth = TR.getScalarOrVectorBitWidth(ResType);
+    SPIRVType *TmpType = TR.getOrCreateSPIRVIntegerType(BitWidth, MIRBuilder);
+    if (ResType->getOpcode() == SPIRV::OpTypeVector) {
+      const unsigned NumElts = ResType->getOperand(2).getImm();
+      TmpType = TR.getOrCreateSPIRVVectorType(TmpType, NumElts, MIRBuilder);
+    }
+    auto MRI = MIRBuilder.getMRI();
+    SrcReg = MRI->createVirtualRegister(&SPIRV::IDRegClass);
+    selectSelect(SrcReg, TmpType, I, false, MIRBuilder);
+  }
+  return selectUnOpWithSrc(ResVReg, ResType, I, SrcReg, MIRBuilder, Opcode);
+}
+
 bool SPIRVInstructionSelector::selectExt(Register resVReg,
                                          const SPIRVType *resType,
                                          const MachineInstr &I, bool isSigned,
                                          MachineIRBuilder &MIRBuilder) const {
   using namespace SPIRV;
   if (TR.isScalarOrVectorOfType(I.getOperand(1).getReg(), OpTypeBool)) {
-    // To extend a bool, we need to use OpSelect between constants
-    Register zeroReg = buildZerosVal(resType, MIRBuilder);
-    Register oneReg = buildOnesVal(isSigned, resType, MIRBuilder);
-    return MIRBuilder
-        .buildInstr(TR.isScalarOfType(I.getOperand(1).getReg(), OpTypeBool)
-                        ? OpSelectSISCond
-                        : OpSelectSIVCond)
-        .addDef(resVReg)
-        .addUse(TR.getSPIRVTypeID(resType))
-        .addUse(I.getOperand(1).getReg())
-        .addUse(oneReg)
-        .addUse(zeroReg)
-        .constrainAllUses(TII, TRI, RBI);
+    return selectSelect(resVReg, resType, I, isSigned, MIRBuilder);
   } else {
     return selectUnOp(resVReg, resType, I, MIRBuilder,
                       isSigned ? OpSConvert : OpUConvert);

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -167,9 +167,9 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
 
   getActionDefinitionsBuilder({G_SITOFP, G_UITOFP})
       .legalForCartesianProduct(allFloatScalarsAndVectors,
-                                allIntScalarsAndVectors);
+                                allScalarsAndVectors);
 
-  getActionDefinitionsBuilder({G_SMIN, G_SMAX, G_UMIN, G_UMAX})
+  getActionDefinitionsBuilder({G_SMIN, G_SMAX, G_UMIN, G_UMAX, G_ABS})
       .legalFor(allIntScalarsAndVectors);
 
   getActionDefinitionsBuilder(G_CTPOP).legalForCartesianProduct(
@@ -279,8 +279,17 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
   getActionDefinitionsBuilder({G_FPOW, G_FEXP, G_FEXP2, G_FLOG, G_FLOG2, G_FABS,
                                G_FMINNUM, G_FMAXNUM, G_FCEIL, G_FCOS, G_FSIN,
                                G_FSQRT, G_FFLOOR, G_FRINT, G_FNEARBYINT,
-                               G_INTRINSIC_ROUND, G_INTRINSIC_TRUNC})
+                               G_INTRINSIC_ROUND, G_INTRINSIC_TRUNC,
+                               G_FMINIMUM, G_FMAXIMUM, G_INTRINSIC_ROUNDEVEN})
       .legalFor(allFloatScalarsAndVectors);
+
+  getActionDefinitionsBuilder(G_FCOPYSIGN)
+      .legalForCartesianProduct(allFloatScalarsAndVectors,
+                                allFloatScalarsAndVectors);
+
+  getActionDefinitionsBuilder(G_FPOWI)
+      .legalForCartesianProduct(allFloatScalarsAndVectors,
+                                allIntScalarsAndVectors);
 
   if (ST.canUseExtInstSet(ExtInstSet::OpenCL_std)) {
     getActionDefinitionsBuilder(G_FLOG10).legalFor(allFloatScalarsAndVectors);

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/abs.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/abs.ll
@@ -7,11 +7,17 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spirv64-unknown-linux"
 
+@ga = addrspace(1) global i32 undef, align 4
+@gb = addrspace(1) global <4 x i32> undef, align 4
+
 ; Function Attrs: norecurse nounwind readnone
 define dso_local spir_kernel void @test(i32 %a, <4 x i32> %b) local_unnamed_addr #0 !kernel_arg_buffer_location !5 {
 entry:
   %0 = tail call i32 @llvm.abs.i32(i32 %a, i1 0) #2
+  store i32 %0, i32 addrspace(1)* @ga, align 4
   %1 = tail call <4 x i32> @llvm.abs.v4i32(<4 x i32> %b, i1 0) #2
+  store <4 x i32> %1, <4 x i32> addrspace(1)* @gb, align 4
+
   ret void
 }
 

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/ctpop.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/ctpop.ll
@@ -10,14 +10,27 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spirv64-unknown-linux"
 
+@g1 = addrspace(1) global i8 undef, align 4
+@g2 = addrspace(1) global i16 undef, align 4
+@g3 = addrspace(1) global i32 undef, align 4
+@g4 = addrspace(1) global i64 undef, align 8
+@g5 = addrspace(1) global <2 x i32> undef, align 4
+
+
 ; Function Attrs: norecurse nounwind readnone
 define dso_local spir_kernel void @test(i8 %x8, i16 %x16, i32 %x32, i64 %x64, <2 x i32> %x2i32) local_unnamed_addr #0 !kernel_arg_buffer_location !5 {
 entry:
   %0 = tail call i8 @llvm.ctpop.i8(i8 %x8) #2
+  store i8 %0, i8 addrspace(1)* @g1, align 4
   %1 = tail call i16 @llvm.ctpop.i16(i16 %x16) #2
+  store i16 %1, i16 addrspace(1)* @g2, align 4
   %2 = tail call i32 @llvm.ctpop.i32(i32 %x32) #2
+  store i32 %2, i32 addrspace(1)* @g3, align 4
   %3 = tail call i64 @llvm.ctpop.i64(i64 %x64) #2
+  store i64 %3, i64 addrspace(1)* @g4, align 8
   %4 = tail call <2 x i32> @llvm.ctpop.v2i32(<2 x i32> %x2i32) #2
+  store <2 x i32> %4, <2 x i32> addrspace(1)* @g5, align 4
+
   ret void
 }
 

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/fmuladd.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/fmuladd.ll
@@ -11,11 +11,16 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spirv64-unknown-unknown"
 
+@ga = addrspace(1) global float undef, align 4
+@gb = addrspace(1) global double undef, align 4
+
 ; Function Attrs: nounwind
 define spir_func void @foo(float %a, float %b, float %c, double %x, double %y, double %z) #0 {
 entry:
   %0 = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
+  store float %0, float addrspace(1)* @ga, align 4
   %1 = call double @llvm.fmuladd.f64(double %x, double %y, double %z)
+  store double %1, double addrspace(1)* @gb, align 8
 ret void
 }
 

--- a/llvm/test/CodeGen/SPIRV/sitofp-with-bool.ll
+++ b/llvm/test/CodeGen/SPIRV/sitofp-with-bool.ll
@@ -1,9 +1,9 @@
 ; RUN: llc -O0 -global-isel %s -o - | FileCheck %s
 
 ; CHECK: %[[int_32:[0-9]+]] = OpTypeInt 32 0
-; CHECK: %[[zero:[0-9]+]] = OpConstant %{{[0-9]+}} 0
-; CHECK: %[[one:[0-9]+]] = OpConstant %{{[0-9]+}} 1
 ; CHECK: %[[bool:[0-9]+]] = OpTypeBool
+; CHECK: %[[zero:[0-9]+]] = OpConstant %[[int_32]] 0
+; CHECK: %[[one:[0-9]+]] = OpConstant %[[int_32]] 1
 
 ; CHECK: OpFunction
 ; CHECK: %[[A:[0-9]+]] = OpFunctionParameter %{{[0-9]+}}


### PR DESCRIPTION
The change add support for missed llvm arithmetic intrinsics. Also fix issues in several tests.

As a result 4 LIT tests passes (llvm-intrinsics/abs.ll, llvm-intrinsics/ctpop.ll, llvm-intrinsics/fp-intrinsics.ll, sitofp-with-bool.ll).