### PR TITLE
[SPIR-V] support __spirv builtin functions

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
@@ -556,6 +556,8 @@ static void hoistMetaInstrWithGlobalRegs(MachineInstr &MI,
       // Add dummy regs to stop addUse crashing if Reg > max regs in func so far
       addDummyVRegsUpToIndex(op.getReg().virtRegIndex(), MetaMRI);
       MIB.addUse(op.getReg());
+    } else if (op.isFPImm()) {
+      MIB.addFPImm(op.getFPImm());
     } else {
       errs() << MI << "\n";
       llvm_unreachable("Unexpected operand type when copying spirv meta instr");
@@ -577,6 +579,10 @@ extractInstructionsWithGlobalRegsToMetablockForMBB(MachineBasicBlock &MBB,
       toRemove.push_back(&MI);
     } else if (TII->isDecorationInstr(MI)) {
       hoistMetaInstrWithGlobalRegs(MI, MIRBuilder, MB_Annotations);
+      toRemove.push_back(&MI);
+    } else if (TII->isConstantInstr(MI)) {
+      // Now OpSpecConstant*s are not in DT, but they need to be hoisted anyway.
+      hoistMetaInstrWithGlobalRegs(MI, MIRBuilder, MB_TypeConstVars);
       toRemove.push_back(&MI);
     }
   }

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
@@ -556,8 +556,6 @@ static void hoistMetaInstrWithGlobalRegs(MachineInstr &MI,
       // Add dummy regs to stop addUse crashing if Reg > max regs in func so far
       addDummyVRegsUpToIndex(op.getReg().virtRegIndex(), MetaMRI);
       MIB.addUse(op.getReg());
-    } else if (op.isFPImm()) {
-      MIB.addFPImm(op.getFPImm());
     } else {
       errs() << MI << "\n";
       llvm_unreachable("Unexpected operand type when copying spirv meta instr");

--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
@@ -243,8 +243,8 @@ def OpConstantNull: Op<46, (outs ID:$dst), (ins TYPE:$src_ty), "$dst = OpConstan
                       [(set ID:$dst, (assigntype ConstPseudoNull, TYPE:$src_ty))]>;
 //def OpConstantNull: Op<46, (outs ID:$res), (ins TYPE:$ty), "$res = OpConstantNull $ty">;
 
-def OpSpecConstantTrue: Op<48, (outs ID:$r), (ins TYPE:$t), "$r= OpSpecConstantTrue $t">;
-def OpSpecConstantFalse: Op<49, (outs ID:$r), (ins TYPE:$t), "$r= OpSpecConstantFalse $t">;
+def OpSpecConstantTrue: Op<48, (outs ID:$r), (ins TYPE:$t), "$r = OpSpecConstantTrue $t">;
+def OpSpecConstantFalse: Op<49, (outs ID:$r), (ins TYPE:$t), "$r = OpSpecConstantFalse $t">;
 def OpSpecConstant: Op<50, (outs ID:$res), (ins TYPE:$type, i32imm:$imm, variable_ops),
                   "$res = OpSpecConstant $type $imm">;
 def OpSpecConstantComposite: Op<51, (outs ID:$res), (ins TYPE:$type, variable_ops),

--- a/llvm/lib/Target/SPIRV/SPIRVStrings.h
+++ b/llvm/lib/Target/SPIRV/SPIRVStrings.h
@@ -36,6 +36,10 @@ void addStringImm(const llvm::StringRef &str, llvm::IRBuilder<> &B,
 // the reverse of the logic in addStringImm
 std::string getStringImm(const llvm::MachineInstr &MI, unsigned int startIndex);
 
+// Add the given numerical immediate to MIB.
+void addNumImm(const llvm::APInt &Imm, llvm::MachineInstrBuilder &MIB,
+               bool IsFloat = false);
+
 // Add an OpName instruction for the given target register
 void buildOpName(llvm::Register target, const llvm::StringRef &name,
                  llvm::MachineIRBuilder &MIRBuilder);

--- a/llvm/test/CodeGen/SPIRV/transcoding/spec_const.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/spec_const.ll
@@ -2,6 +2,7 @@
 
 ; CHECK-SPIRV-NOT: OpCapability Matrix
 ; CHECK-SPIRV-NOT: OpCapability Shader
+; CHECK-SPIRV: OpCapability Float16Buffer
 
 ; CHECK-SPIRV-DAG: OpDecorate %[[SC0:[0-9]+]] SpecId 0
 ; CHECK-SPIRV-DAG: OpDecorate %[[SC1:[0-9]+]] SpecId 1

--- a/llvm/test/CodeGen/SPIRV/transcoding/spec_const.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/spec_const.ll
@@ -2,7 +2,6 @@
 
 ; CHECK-SPIRV-NOT: OpCapability Matrix
 ; CHECK-SPIRV-NOT: OpCapability Shader
-; CHECK-SPIRV: OpCapability Kernel
 
 ; CHECK-SPIRV-DAG: OpDecorate %[[SC0:[0-9]+]] SpecId 0
 ; CHECK-SPIRV-DAG: OpDecorate %[[SC1:[0-9]+]] SpecId 1


### PR DESCRIPTION
The change adds support for __spirv_* builtin functions. Also several issues are fixed.

SPIRVGlobalTypesAndRegNumPass.cpp: support hoisting of SpecConstant*
SPIRVInstrInfo.td: fix typo in SpecConstantTrue/False
SPIRVInstructionSelector.cpp: rename and move transformConst to SPIRVStrings* to use in SPIRVOpenCLBIFs.cpp; correct selectIntToBool as it's done in the translator 
SPIRVOpenCLBIFs.cpp: support relational __spirv*, __spirv_SpecConstant, __spirv_Select, correct genOpenCLRelational

As a result 7 LIT tests pass (relationals.ll, transcoding/spec_const.ll, spec_const_decoration.ll, SpecConstants/bool-spirv-specconstant.ll, select.ll, TruncToBool.ll, FOrdGreaterThanEqual_bool.ll)