### PR TITLE
[SPIR-V] format code and fix var names in MCTargetDesc

### DIFF
--- a/llvm/lib/MC/SPIRVObjectWriter.cpp
+++ b/llvm/lib/MC/SPIRVObjectWriter.cpp
@@ -42,8 +42,8 @@ private:
 void SPIRVObjectWriter::writeHeader(const MCAssembler &Asm) {
   uint32_t MagicNumber = 0x07230203;
 
-  // TODO: set the version on a min-necessary basis (just like the translator does)
-  //       requires some refactoring of MCAssembler::VersionInfoType
+  // TODO: set the version on a min-necessary basis (just like the translator
+  // does) requires some refactoring of MCAssembler::VersionInfoType.
   uint32_t Major = 1;
   uint32_t Minor = 0;
   uint32_t VersionNumber = 0 | (Major << 16) | (Minor << 8);

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/CMakeLists.txt
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/CMakeLists.txt
@@ -10,8 +10,8 @@ add_llvm_component_library(LLVMSPIRVDesc
   ../SPIRVExtInsts.cpp
 
   LINK_COMPONENTS
-  MC 
-  SPIRVInfo 
+  MC
+  SPIRVInfo
   Support
 
   ADD_TO_COMPONENT

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVAsmBackend.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVAsmBackend.cpp
@@ -47,7 +47,6 @@ public:
   void relaxInstruction(MCInst &Inst,
                         const MCSubtargetInfo &STI) const override {}
 
-
   bool writeNopData(raw_ostream &OS, uint64_t Count) const override {
     return false;
   }

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.h
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.h
@@ -20,14 +20,14 @@
 namespace llvm {
 class SPIRVInstPrinter : public MCInstPrinter {
 private:
-  SmallDenseMap<unsigned, ExtInstSet> extInstSetIDs;
+  SmallDenseMap<unsigned, ExtInstSet> ExtInstSetIDs;
   void recordOpExtInstImport(const MCInst *MI);
 
 public:
   using MCInstPrinter::MCInstPrinter;
 
   void printInst(const MCInst *MI, uint64_t Address, StringRef Annot,
-                         const MCSubtargetInfo &STI, raw_ostream &OS) override;
+                 const MCSubtargetInfo &STI, raw_ostream &OS) override;
   void printOperand(const MCInst *MI, unsigned OpNo, raw_ostream &O,
                     const char *Modifier = nullptr);
 
@@ -35,10 +35,10 @@ public:
 
   void printOpDecorate(const MCInst *MI, raw_ostream &O);
   void printOpExtInst(const MCInst *MI, raw_ostream &O);
-  void printRemainingVariableOps(const MCInst *MI, unsigned startIndex,
-                                 raw_ostream &O, bool skipFirstSpace = false,
-                                 bool skipImmediates = false);
-  void printOpConstantVarOps(const MCInst *MI, unsigned startIndex,
+  void printRemainingVariableOps(const MCInst *MI, unsigned StartIndex,
+                                 raw_ostream &O, bool SkipFirstSpace = false,
+                                 bool SkipImmediates = false);
+  void printOpConstantVarOps(const MCInst *MI, unsigned StartIndex,
                              raw_ostream &O);
 
   void printExtInst(const MCInst *MI, unsigned OpNo, raw_ostream &O);

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCTargetDesc.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCTargetDesc.cpp
@@ -10,9 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "SPIRVMCAsmInfo.h"
 #include "SPIRVMCTargetDesc.h"
 #include "SPIRVInstPrinter.h"
+#include "SPIRVMCAsmInfo.h"
 #include "SPIRVTargetStreamer.h"
 #include "TargetInfo/SPIRVTargetInfo.h"
 #include "llvm/MC/MCInstrAnalysis.h"

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVTargetStreamer.h
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVTargetStreamer.h
@@ -15,14 +15,13 @@ namespace llvm {
 
 class MCSection;
 
-class SPIRVTargetStreamer : public MCTargetStreamer{
+class SPIRVTargetStreamer : public MCTargetStreamer {
 public:
   SPIRVTargetStreamer(MCStreamer &S);
   ~SPIRVTargetStreamer() override;
 
   void changeSection(const MCSection *CurSection, MCSection *Section,
-                     const MCExpr *SubSection, raw_ostream &OS) override {};
-
+                     const MCExpr *SubSection, raw_ostream &OS) override{};
 };
 } // namespace llvm
 


### PR DESCRIPTION
It's the second patch to prepare MCTargetDesc for LLVM merge. Files were processed by clang-format and var names were capitalized.