### PR TITLE
[SPIR-V] correct InstructionSelector, TypeRegistry and other files

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVIRTranslator.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVIRTranslator.cpp
@@ -283,13 +283,13 @@ static void addConstantsToTrack(MachineFunction &MF,
             RegsAlreadyAddedToDT[&MI] = Reg;
             // This MI is unused and will be removed. If the MI uses
             // const_composite, it will be unused and should be removed too.
-            assert (MI.getOperand(2).isReg() && "Reg operand is expected");
+            assert(MI.getOperand(2).isReg() && "Reg operand is expected");
             MachineInstr *SrcMI = MRI.getVRegDef(MI.getOperand(2).getReg());
-            if (SrcMI && SrcMI->getOpcode() ==
-                TargetOpcode::G_INTRINSIC_W_SIDE_EFFECTS &&
+            if (SrcMI &&
+                SrcMI->getOpcode() ==
+                    TargetOpcode::G_INTRINSIC_W_SIDE_EFFECTS &&
                 SrcMI->getIntrinsicID() == Intrinsic::spv_const_composite)
               ToEraseComposites.push_back(SrcMI);
-
           }
         }
       }
@@ -348,10 +348,10 @@ bool SPIRVIRTranslator::runOnMachineFunction(MachineFunction &MF) {
   TR->setCurrentFunc(MF);
 
   // Run the regular IRTranslator
-  bool success = IRTranslator::runOnMachineFunction(MF);
+  bool Success = IRTranslator::runOnMachineFunction(MF);
   addConstantsToTrack(MF, DT);
   foldConstantsIntoIntrinsics(MF);
   TR->generateAssignInstrs(MF);
 
-  return success;
+  return Success;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -22,22 +22,13 @@
 #include "SPIRVSubtarget.h"
 #include "SPIRVTargetMachine.h"
 #include "SPIRVTypeRegistry.h"
-
-#include "llvm/IR/IntrinsicsSPIRV.h"
-
 #include "llvm/ADT/APFloat.h"
 #include "llvm/CodeGen/GlobalISel/InstructionSelector.h"
 #include "llvm/CodeGen/GlobalISel/InstructionSelectorImpl.h"
-#include "llvm/CodeGen/GlobalISel/Utils.h"
-#include "llvm/CodeGen/MachineBasicBlock.h"
-#include "llvm/CodeGen/MachineFunction.h"
-#include "llvm/CodeGen/MachineInstr.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
-#include "llvm/CodeGen/MachineOperand.h"
 #include "llvm/CodeGen/MachineRegisterInfo.h"
-#include "llvm/IR/Type.h"
+#include "llvm/IR/IntrinsicsSPIRV.h"
 #include "llvm/Support/Debug.h"
-#include "llvm/Support/raw_ostream.h"
 
 #define DEBUG_TYPE "spirv-isel"
 
@@ -85,10 +76,10 @@ private:
 
   // All instruction-specific selection that didn't happen in "select()".
   // Is basically a large Switch/Case delegating to all other select method.
-  bool spvSelect(Register resVReg, const SPIRVType *resType,
+  bool spvSelect(Register ResVReg, const SPIRVType *ResType,
                  const MachineInstr &I, MachineIRBuilder &MIRBuilder) const;
 
-  bool selectGlobalValue(Register resVReg, const MachineInstr &I,
+  bool selectGlobalValue(Register ResVReg, const MachineInstr &I,
                          MachineIRBuilder &MIRBuilder,
                          const MachineInstr *Init = nullptr) const;
 
@@ -99,7 +90,7 @@ private:
                   const MachineInstr &I, MachineIRBuilder &MIRBuilder,
                   unsigned Opcode) const;
 
-  bool selectLoad(Register resVReg, const SPIRVType *resType,
+  bool selectLoad(Register ResVReg, const SPIRVType *ResType,
                   const MachineInstr &I, MachineIRBuilder &MIRBuilder) const;
 
   bool selectStore(const MachineInstr &I, MachineIRBuilder &MIRBuilder) const;
@@ -107,50 +98,49 @@ private:
   bool selectMemOperation(Register ResVReg, const MachineInstr &I,
                           MachineIRBuilder &MIRBuilder) const;
 
-  bool selectAtomicRMW(Register resVReg, const SPIRVType *resType,
+  bool selectAtomicRMW(Register ResVReg, const SPIRVType *ResType,
                        const MachineInstr &I, MachineIRBuilder &MIRBuilder,
-                       unsigned newOpcode) const;
+                       unsigned NewOpcode) const;
 
-  bool selectAtomicCmpXchg(Register resVReg, const SPIRVType *resType,
+  bool selectAtomicCmpXchg(Register ResVReg, const SPIRVType *ResType,
                            const MachineInstr &I, MachineIRBuilder &MIRBuilder,
-                           bool withSuccess) const;
+                           bool WithSuccess) const;
 
   bool selectFence(const MachineInstr &I, MachineIRBuilder &MIRBuilder) const;
 
-  bool selectAddrSpaceCast(Register resVReg, const SPIRVType *resType,
+  bool selectAddrSpaceCast(Register ResVReg, const SPIRVType *ResType,
                            const MachineInstr &I,
                            MachineIRBuilder &MIRBuilder) const;
 
 #if 0
-  bool selectOverflowOp(Register resVReg, const SPIRVType *resType,
+  bool selectOverflowOp(Register ResVReg, const SPIRVType *ResType,
                         const MachineInstr &I, MachineIRBuilder &MIRBuilder,
-                        unsigned newOpcode) const;
+                        unsigned NewOpcode) const;
 #endif
 
-  bool selectBitreverse(Register resVReg, const SPIRVType *resType,
+  bool selectBitreverse(Register ResVReg, const SPIRVType *ResType,
                         const MachineInstr &I,
                         MachineIRBuilder &MIRBuilder) const;
 
-  bool selectConstVector(Register resVReg, const SPIRVType *resType,
+  bool selectConstVector(Register ResVReg, const SPIRVType *ResType,
                          const MachineInstr &I,
                          MachineIRBuilder &MIRBuilder) const;
 
-  bool selectCmp(Register resVReg, const SPIRVType *resType,
+  bool selectCmp(Register ResVReg, const SPIRVType *ResType,
                  unsigned scalarTypeOpcode, unsigned comparisonOpcode,
-                 const MachineInstr &I, MachineIRBuilder &MIRBuilder,
-                 bool convertToUInt = false) const;
+                 const MachineInstr &I, MachineIRBuilder &MIRBuilder) const;
 
-  bool selectICmp(Register resVReg, const SPIRVType *resType,
+  bool selectICmp(Register ResVReg, const SPIRVType *ResType,
                   const MachineInstr &I, MachineIRBuilder &MIRBuilder) const;
-  bool selectFCmp(Register resVReg, const SPIRVType *resType,
+  bool selectFCmp(Register ResVReg, const SPIRVType *ResType,
                   const MachineInstr &I, MachineIRBuilder &MIRBuilder) const;
 
   void renderImm32(MachineInstrBuilder &MIB, const MachineInstr &I,
-                          int OpIdx) const;
+                   int OpIdx) const;
   void renderFImm32(MachineInstrBuilder &MIB, const MachineInstr &I,
-                          int OpIdx) const;
+                    int OpIdx) const;
 
-  bool selectConst(Register resVReg, const SPIRVType *resType, const APInt &imm,
+  bool selectConst(Register ResVReg, const SPIRVType *ResType, const APInt &Imm,
                    MachineIRBuilder &MIRBuilder) const;
 
   bool selectSelect(Register ResVReg, const SPIRVType *ResType,
@@ -159,65 +149,65 @@ private:
   bool selectIToF(Register ResVReg, const SPIRVType *ResType,
                   const MachineInstr &I, bool IsSigned,
                   MachineIRBuilder &MIRBuilder, unsigned Opcode) const;
-  bool selectExt(Register resVReg, const SPIRVType *resType,
-                 const MachineInstr &I, bool isSigned,
+  bool selectExt(Register ResVReg, const SPIRVType *ResType,
+                 const MachineInstr &I, bool IsSigned,
                  MachineIRBuilder &MIRBuilder) const;
 
-  bool selectTrunc(Register resVReg, const SPIRVType *resType,
+  bool selectTrunc(Register ResVReg, const SPIRVType *ResType,
                    const MachineInstr &I, MachineIRBuilder &MIRBuilder) const;
 
-  bool selectIntToBool(Register intReg, Register resVReg,
+  bool selectIntToBool(Register IntReg, Register ResVReg,
                        const SPIRVType *intTy, const SPIRVType *boolTy,
                        MachineIRBuilder &MIRBuilder) const;
 
-  bool selectOpUndef(Register resVReg, const SPIRVType *resType,
+  bool selectOpUndef(Register ResVReg, const SPIRVType *ResType,
                      MachineIRBuilder &MIRBuilder) const;
-  bool selectIntrinsic(Register resVReg, const SPIRVType *resType,
+  bool selectIntrinsic(Register ResVReg, const SPIRVType *ResType,
                        const MachineInstr &I,
                        MachineIRBuilder &MIRBuilder) const;
-  bool selectExtractVal(Register resVReg, const SPIRVType *resType,
+  bool selectExtractVal(Register ResVReg, const SPIRVType *ResType,
                         const MachineInstr &I,
                         MachineIRBuilder &MIRBuilder) const;
-  bool selectInsertVal(Register resVReg, const SPIRVType *resType,
+  bool selectInsertVal(Register ResVReg, const SPIRVType *ResType,
                        const MachineInstr &I,
                        MachineIRBuilder &MIRBuilder) const;
-  bool selectExtractElt(Register resVReg, const SPIRVType *resType,
+  bool selectExtractElt(Register ResVReg, const SPIRVType *ResType,
                         const MachineInstr &I,
                         MachineIRBuilder &MIRBuilder) const;
-  bool selectInsertElt(Register resVReg, const SPIRVType *resType,
+  bool selectInsertElt(Register ResVReg, const SPIRVType *ResType,
                        const MachineInstr &I,
                        MachineIRBuilder &MIRBuilder) const;
-  bool selectGEP(Register resVReg, const SPIRVType *resType,
+  bool selectGEP(Register ResVReg, const SPIRVType *ResType,
                  const MachineInstr &I, MachineIRBuilder &MIRBuilder) const;
 
-  bool selectFrameIndex(Register resVReg, const SPIRVType *resType,
+  bool selectFrameIndex(Register ResVReg, const SPIRVType *ResType,
                         MachineIRBuilder &MIRBuilder) const;
 
   bool selectBranch(const MachineInstr &I, MachineIRBuilder &MIRBuilder) const;
   bool selectBranchCond(const MachineInstr &I,
                         MachineIRBuilder &MIRBuilder) const;
 
-  bool selectPhi(Register resVReg, const SPIRVType *resType,
+  bool selectPhi(Register ResVReg, const SPIRVType *ResType,
                  const MachineInstr &I, MachineIRBuilder &MIRBuilder) const;
 
-  bool selectExtInst(Register resVReg, const SPIRVType *resType,
+  bool selectExtInst(Register ResVReg, const SPIRVType *ResType,
                      const MachineInstr &I, MachineIRBuilder &MIRBuilder,
-                     CL::OpenCL_std clInst) const;
-  bool selectExtInst(Register resVReg, const SPIRVType *resType,
+                     CL::OpenCL_std CLInst) const;
+  bool selectExtInst(Register ResVReg, const SPIRVType *ResType,
                      const MachineInstr &I, MachineIRBuilder &MIRBuilder,
-                     OpenCL_std::OpenCL_std clInst,
-                     GL::GLSL_std_450 glInst) const;
+                     OpenCL_std::OpenCL_std CLInst,
+                     GL::GLSL_std_450 GLInst) const;
 
-  bool selectExtInst(Register resVReg, const SPIRVType *resType,
+  bool selectExtInst(Register ResVReg, const SPIRVType *ResType,
                      const MachineInstr &I, MachineIRBuilder &MIRBuilder,
-                     const ExtInstList &extInsts) const;
+                     const ExtInstList &ExtInsts) const;
 
-  Register buildI32Constant(uint32_t val, MachineIRBuilder &MIRBuilder,
-                            const SPIRVType *resType = nullptr) const;
+  Register buildI32Constant(uint32_t Val, MachineIRBuilder &MIRBuilder,
+                            const SPIRVType *ResType = nullptr) const;
 
-  Register buildZerosVal(const SPIRVType *resType,
+  Register buildZerosVal(const SPIRVType *ResType,
                          MachineIRBuilder &MIRBuilder) const;
-  Register buildOnesVal(bool allOnes, const SPIRVType *resType,
+  Register buildOnesVal(bool AllOnes, const SPIRVType *ResType,
                         MachineIRBuilder &MIRBuilder) const;
 };
 
@@ -282,13 +272,13 @@ bool SPIRVInstructionSelector::select(MachineInstr &I) {
 
   // Common code for getting return reg+type, and removing selected instr
   // from parent occurs here. Instr-specific selection happens in spvSelect().
-  bool hasDefs = I.getNumDefs() > 0;
-  Register resVReg = hasDefs ? I.getOperand(0).getReg() : Register(0);
-  SPIRVType *resType = hasDefs ? TR.getSPIRVTypeForVReg(resVReg) : nullptr;
-  assert(!hasDefs || resType || I.getOpcode() == TargetOpcode::G_GLOBAL_VALUE);
-  if (spvSelect(resVReg, resType, I, MIRBuilder)) {
-    if (hasDefs) { // Make all vregs 32 bits (for SPIR-V IDs)
-      MIRBuilder.getMRI()->setType(resVReg, LLT::scalar(32));
+  bool HasDefs = I.getNumDefs() > 0;
+  Register ResVReg = HasDefs ? I.getOperand(0).getReg() : Register(0);
+  SPIRVType *ResType = HasDefs ? TR.getSPIRVTypeForVReg(ResVReg) : nullptr;
+  assert(!HasDefs || ResType || I.getOpcode() == TargetOpcode::G_GLOBAL_VALUE);
+  if (spvSelect(ResVReg, ResType, I, MIRBuilder)) {
+    if (HasDefs) { // Make all vregs 32 bits (for SPIR-V IDs)
+      MIRBuilder.getMRI()->setType(ResVReg, LLT::scalar(32));
     }
     I.removeFromParent();
     return true;
@@ -296,8 +286,8 @@ bool SPIRVInstructionSelector::select(MachineInstr &I) {
   return false;
 }
 
-bool SPIRVInstructionSelector::spvSelect(Register resVReg,
-                                         const SPIRVType *resType,
+bool SPIRVInstructionSelector::spvSelect(Register ResVReg,
+                                         const SPIRVType *ResType,
                                          const MachineInstr &I,
                                          MachineIRBuilder &MIRBuilder) const {
   using namespace SPIRV;
@@ -309,25 +299,25 @@ bool SPIRVInstructionSelector::spvSelect(Register resVReg,
   const unsigned Opcode = I.getOpcode();
   switch (Opcode) {
   case TargetOpcode::G_CONSTANT:
-    return selectConst(resVReg, resType, I.getOperand(1).getCImm()->getValue(),
+    return selectConst(ResVReg, ResType, I.getOperand(1).getCImm()->getValue(),
                        MIRBuilder);
   case TargetOpcode::G_GLOBAL_VALUE:
-    return selectGlobalValue(resVReg, I, MIRBuilder);
+    return selectGlobalValue(ResVReg, I, MIRBuilder);
   case TargetOpcode::G_IMPLICIT_DEF:
-    return selectOpUndef(resVReg, resType, MIRBuilder);
+    return selectOpUndef(ResVReg, ResType, MIRBuilder);
 
   case TargetOpcode::G_INTRINSIC_W_SIDE_EFFECTS:
-    return selectIntrinsic(resVReg, resType, I, MIRBuilder);
+    return selectIntrinsic(ResVReg, ResType, I, MIRBuilder);
   case TargetOpcode::G_BITREVERSE:
-    return selectBitreverse(resVReg, resType, I, MIRBuilder);
+    return selectBitreverse(ResVReg, ResType, I, MIRBuilder);
 
   case TargetOpcode::G_BUILD_VECTOR:
-    return selectConstVector(resVReg, resType, I, MIRBuilder);
+    return selectConstVector(ResVReg, ResType, I, MIRBuilder);
 
   case TargetOpcode::G_SHUFFLE_VECTOR: {
     auto MIB = MIRBuilder.buildInstr(SPIRV::OpVectorShuffle)
-                   .addDef(resVReg)
-                   .addUse(TR.getSPIRVTypeID(resType))
+                   .addDef(ResVReg)
+                   .addUse(TR.getSPIRVTypeID(ResType))
                    .addUse(I.getOperand(1).getReg())
                    .addUse(I.getOperand(2).getReg());
     for (auto V : I.getOperand(3).getShuffleMask())
@@ -337,18 +327,18 @@ bool SPIRVInstructionSelector::spvSelect(Register resVReg,
   }
   case TargetOpcode::G_MEMMOVE:
   case TargetOpcode::G_MEMCPY:
-    return selectMemOperation(resVReg, I, MIRBuilder);
+    return selectMemOperation(ResVReg, I, MIRBuilder);
 
   case TargetOpcode::G_ICMP:
-    return selectICmp(resVReg, resType, I, MIRBuilder);
+    return selectICmp(ResVReg, ResType, I, MIRBuilder);
   case TargetOpcode::G_FCMP:
-    return selectFCmp(resVReg, resType, I, MIRBuilder);
+    return selectFCmp(ResVReg, ResType, I, MIRBuilder);
 
   case TargetOpcode::G_FRAME_INDEX:
-    return selectFrameIndex(resVReg, resType, MIRBuilder);
+    return selectFrameIndex(ResVReg, ResType, MIRBuilder);
 
   case TargetOpcode::G_LOAD:
-    return selectLoad(resVReg, resType, I, MIRBuilder);
+    return selectLoad(ResVReg, ResType, I, MIRBuilder);
   case TargetOpcode::G_STORE:
     return selectStore(I, MIRBuilder);
 
@@ -358,161 +348,161 @@ bool SPIRVInstructionSelector::spvSelect(Register resVReg,
     return selectBranchCond(I, MIRBuilder);
 
   case TargetOpcode::G_PHI:
-    return selectPhi(resVReg, resType, I, MIRBuilder);
+    return selectPhi(ResVReg, ResType, I, MIRBuilder);
 
   case TargetOpcode::G_FPTOSI:
-    return selectUnOp(resVReg, resType, I, MIRBuilder, OpConvertFToS);
+    return selectUnOp(ResVReg, ResType, I, MIRBuilder, OpConvertFToS);
   case TargetOpcode::G_FPTOUI:
-    return selectUnOp(resVReg, resType, I, MIRBuilder, OpConvertFToU);
+    return selectUnOp(ResVReg, ResType, I, MIRBuilder, OpConvertFToU);
 
   case TargetOpcode::G_SITOFP:
-    return selectIToF(resVReg, resType, I, true, MIRBuilder, OpConvertSToF);
+    return selectIToF(ResVReg, ResType, I, true, MIRBuilder, OpConvertSToF);
   case TargetOpcode::G_UITOFP:
-    return selectIToF(resVReg, resType, I, false, MIRBuilder, OpConvertUToF);
+    return selectIToF(ResVReg, ResType, I, false, MIRBuilder, OpConvertUToF);
 
   case TargetOpcode::G_CTPOP:
-    return selectUnOp(resVReg, resType, I, MIRBuilder, OpBitCount);
+    return selectUnOp(ResVReg, ResType, I, MIRBuilder, OpBitCount);
 
-  // even SPIRV-LLVM translator doens't support overflow intrinsics
-  // so we don't even have a reliable tests for this functionality
+    // even SPIRV-LLVM translator doens't support overflow intrinsics
+    // so we don't even have a reliable tests for this functionality
 #if 0
   case TargetOpcode::G_UADDO:
-    return selectOverflowOp(resVReg, resType, I, MIRBuilder, OpIAddCarry);
+    return selectOverflowOp(ResVReg, ResType, I, MIRBuilder, OpIAddCarry);
   case TargetOpcode::G_USUBO:
-    return selectOverflowOp(resVReg, resType, I, MIRBuilder, OpISubBorrow);
+    return selectOverflowOp(ResVReg, ResType, I, MIRBuilder, OpISubBorrow);
   case TargetOpcode::G_UMULO:
-    return selectOverflowOp(resVReg, resType, I, MIRBuilder, OpSMulExtended);
+    return selectOverflowOp(ResVReg, ResType, I, MIRBuilder, OpSMulExtended);
   case TargetOpcode::G_SMULO:
-    return selectOverflowOp(resVReg, resType, I, MIRBuilder, OpUMulExtended);
+    return selectOverflowOp(ResVReg, ResType, I, MIRBuilder, OpUMulExtended);
 #endif
 
   case TargetOpcode::G_SMIN:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::s_min, GL::SMin);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::s_min, GL::SMin);
   case TargetOpcode::G_UMIN:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::u_min, GL::UMin);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::u_min, GL::UMin);
 
   case TargetOpcode::G_SMAX:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::s_max, GL::SMax);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::s_max, GL::SMax);
   case TargetOpcode::G_UMAX:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::u_max, GL::UMax);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::u_max, GL::UMax);
 
   case TargetOpcode::G_FMA:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::fma, GL::Fma);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::fma, GL::Fma);
 
   case TargetOpcode::G_FPOW:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::pow, GL::Pow);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::pow, GL::Pow);
   case TargetOpcode::G_FPOWI:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::pown);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::pown);
 
   case TargetOpcode::G_FEXP:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::exp, GL::Exp);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::exp, GL::Exp);
   case TargetOpcode::G_FEXP2:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::exp2, GL::Exp2);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::exp2, GL::Exp2);
 
   case TargetOpcode::G_FLOG:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::log, GL::Log);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::log, GL::Log);
   case TargetOpcode::G_FLOG2:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::log2, GL::Log2);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::log2, GL::Log2);
   case TargetOpcode::G_FLOG10:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::log10);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::log10);
 
   case TargetOpcode::G_FABS:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::fabs, GL::FAbs);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::fabs, GL::FAbs);
   case TargetOpcode::G_ABS:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::s_abs, GL::SAbs);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::s_abs, GL::SAbs);
 
   case TargetOpcode::G_FMINNUM:
   case TargetOpcode::G_FMINIMUM:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::fmin, GL::FMin);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::fmin, GL::FMin);
   case TargetOpcode::G_FMAXNUM:
   case TargetOpcode::G_FMAXIMUM:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::fmax, GL::FMax);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::fmax, GL::FMax);
 
   case TargetOpcode::G_FCOPYSIGN:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::copysign);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::copysign);
 
   case TargetOpcode::G_FCEIL:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::ceil, GL::Ceil);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::ceil, GL::Ceil);
   case TargetOpcode::G_FFLOOR:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::floor, GL::Floor);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::floor, GL::Floor);
 
   case TargetOpcode::G_FCOS:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::cos, GL::Cos);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::cos, GL::Cos);
   case TargetOpcode::G_FSIN:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::sin, GL::Sin);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::sin, GL::Sin);
 
   case TargetOpcode::G_FSQRT:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::sqrt, GL::Sqrt);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::sqrt, GL::Sqrt);
 
   case TargetOpcode::G_CTTZ:
   case TargetOpcode::G_CTTZ_ZERO_UNDEF:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::ctz);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::ctz);
   case TargetOpcode::G_CTLZ:
   case TargetOpcode::G_CTLZ_ZERO_UNDEF:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::clz);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::clz);
 
   case TargetOpcode::G_INTRINSIC_ROUND:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::round, GL::Round);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::round, GL::Round);
   case TargetOpcode::G_INTRINSIC_ROUNDEVEN:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::rint,
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::rint,
                          GL::RoundEven);
   case TargetOpcode::G_INTRINSIC_TRUNC:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::trunc, GL::Trunc);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::trunc, GL::Trunc);
   case TargetOpcode::G_FRINT:
   case TargetOpcode::G_FNEARBYINT:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::rint,
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::rint,
                          GL::RoundEven);
 
   case TargetOpcode::G_SMULH:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::s_mul_hi);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::s_mul_hi);
   case TargetOpcode::G_UMULH:
-    return selectExtInst(resVReg, resType, I, MIRBuilder, CL::u_mul_hi);
+    return selectExtInst(ResVReg, ResType, I, MIRBuilder, CL::u_mul_hi);
 
   case TargetOpcode::G_SEXT:
-    return selectExt(resVReg, resType, I, true, MIRBuilder);
+    return selectExt(ResVReg, ResType, I, true, MIRBuilder);
   case TargetOpcode::G_ANYEXT:
   case TargetOpcode::G_ZEXT:
-    return selectExt(resVReg, resType, I, false, MIRBuilder);
+    return selectExt(ResVReg, ResType, I, false, MIRBuilder);
   case TargetOpcode::G_TRUNC:
-    return selectTrunc(resVReg, resType, I, MIRBuilder);
+    return selectTrunc(ResVReg, ResType, I, MIRBuilder);
   case TargetOpcode::G_FPTRUNC:
   case TargetOpcode::G_FPEXT:
-    return selectUnOp(resVReg, resType, I, MIRBuilder, OpFConvert);
+    return selectUnOp(ResVReg, ResType, I, MIRBuilder, OpFConvert);
 
   case TargetOpcode::G_PTRTOINT:
-    return selectUnOp(resVReg, resType, I, MIRBuilder, OpConvertPtrToU);
+    return selectUnOp(ResVReg, ResType, I, MIRBuilder, OpConvertPtrToU);
   case TargetOpcode::G_INTTOPTR:
-    return selectUnOp(resVReg, resType, I, MIRBuilder, OpConvertUToPtr);
+    return selectUnOp(ResVReg, ResType, I, MIRBuilder, OpConvertUToPtr);
   case TargetOpcode::G_BITCAST:
-    return selectUnOp(resVReg, resType, I, MIRBuilder, OpBitcast);
+    return selectUnOp(ResVReg, ResType, I, MIRBuilder, OpBitcast);
   case TargetOpcode::G_ADDRSPACE_CAST:
-    return selectAddrSpaceCast(resVReg, resType, I, MIRBuilder);
+    return selectAddrSpaceCast(ResVReg, ResType, I, MIRBuilder);
 
   case TargetOpcode::G_ATOMICRMW_OR:
-    return selectAtomicRMW(resVReg, resType, I, MIRBuilder, OpAtomicOr);
+    return selectAtomicRMW(ResVReg, ResType, I, MIRBuilder, OpAtomicOr);
   case TargetOpcode::G_ATOMICRMW_ADD:
-    return selectAtomicRMW(resVReg, resType, I, MIRBuilder, OpAtomicIAdd);
+    return selectAtomicRMW(ResVReg, ResType, I, MIRBuilder, OpAtomicIAdd);
   case TargetOpcode::G_ATOMICRMW_AND:
-    return selectAtomicRMW(resVReg, resType, I, MIRBuilder, OpAtomicAnd);
+    return selectAtomicRMW(ResVReg, ResType, I, MIRBuilder, OpAtomicAnd);
   case TargetOpcode::G_ATOMICRMW_MAX:
-    return selectAtomicRMW(resVReg, resType, I, MIRBuilder, OpAtomicSMax);
+    return selectAtomicRMW(ResVReg, ResType, I, MIRBuilder, OpAtomicSMax);
   case TargetOpcode::G_ATOMICRMW_MIN:
-    return selectAtomicRMW(resVReg, resType, I, MIRBuilder, OpAtomicSMin);
+    return selectAtomicRMW(ResVReg, ResType, I, MIRBuilder, OpAtomicSMin);
   case TargetOpcode::G_ATOMICRMW_SUB:
-    return selectAtomicRMW(resVReg, resType, I, MIRBuilder, OpAtomicISub);
+    return selectAtomicRMW(ResVReg, ResType, I, MIRBuilder, OpAtomicISub);
   case TargetOpcode::G_ATOMICRMW_XOR:
-    return selectAtomicRMW(resVReg, resType, I, MIRBuilder, OpAtomicXor);
+    return selectAtomicRMW(ResVReg, ResType, I, MIRBuilder, OpAtomicXor);
   case TargetOpcode::G_ATOMICRMW_UMAX:
-    return selectAtomicRMW(resVReg, resType, I, MIRBuilder, OpAtomicUMax);
+    return selectAtomicRMW(ResVReg, ResType, I, MIRBuilder, OpAtomicUMax);
   case TargetOpcode::G_ATOMICRMW_UMIN:
-    return selectAtomicRMW(resVReg, resType, I, MIRBuilder, OpAtomicUMin);
+    return selectAtomicRMW(ResVReg, ResType, I, MIRBuilder, OpAtomicUMin);
   case TargetOpcode::G_ATOMICRMW_XCHG:
-    return selectAtomicRMW(resVReg, resType, I, MIRBuilder, OpAtomicExchange);
+    return selectAtomicRMW(ResVReg, ResType, I, MIRBuilder, OpAtomicExchange);
 
   case TargetOpcode::G_ATOMIC_CMPXCHG_WITH_SUCCESS:
-    return selectAtomicCmpXchg(resVReg, resType, I, MIRBuilder, true);
+    return selectAtomicCmpXchg(ResVReg, ResType, I, MIRBuilder, true);
   case TargetOpcode::G_ATOMIC_CMPXCHG:
-    return selectAtomicCmpXchg(resVReg, resType, I, MIRBuilder, false);
+    return selectAtomicCmpXchg(ResVReg, ResType, I, MIRBuilder, false);
 
   case TargetOpcode::G_FENCE:
     return selectFence(I, MIRBuilder);
@@ -522,43 +512,43 @@ bool SPIRVInstructionSelector::spvSelect(Register resVReg,
   }
 }
 
-bool SPIRVInstructionSelector::selectExtInst(Register resVReg,
-                                             const SPIRVType *resType,
+bool SPIRVInstructionSelector::selectExtInst(Register ResVReg,
+                                             const SPIRVType *ResType,
                                              const MachineInstr &I,
                                              MachineIRBuilder &MIRBuilder,
-                                             CL::OpenCL_std clInst) const {
-  return selectExtInst(resVReg, resType, I, MIRBuilder,
-                       {{ExtInstSet::OpenCL_std, clInst}});
+                                             CL::OpenCL_std CLInst) const {
+  return selectExtInst(ResVReg, ResType, I, MIRBuilder,
+                       {{ExtInstSet::OpenCL_std, CLInst}});
 }
 
-bool SPIRVInstructionSelector::selectExtInst(Register resVReg,
-                                             const SPIRVType *resType,
+bool SPIRVInstructionSelector::selectExtInst(Register ResVReg,
+                                             const SPIRVType *ResType,
                                              const MachineInstr &I,
                                              MachineIRBuilder &MIRBuilder,
-                                             CL::OpenCL_std clInst,
-                                             GL::GLSL_std_450 glInst) const {
-  ExtInstList extInsts = {{ExtInstSet::OpenCL_std, clInst},
-                          {ExtInstSet::GLSL_std_450, glInst}};
-  return selectExtInst(resVReg, resType, I, MIRBuilder, extInsts);
+                                             CL::OpenCL_std CLInst,
+                                             GL::GLSL_std_450 GLInst) const {
+  ExtInstList ExtInsts = {{ExtInstSet::OpenCL_std, CLInst},
+                          {ExtInstSet::GLSL_std_450, GLInst}};
+  return selectExtInst(ResVReg, ResType, I, MIRBuilder, ExtInsts);
 }
 
-bool SPIRVInstructionSelector::selectExtInst(Register resVReg,
-                                             const SPIRVType *resType,
+bool SPIRVInstructionSelector::selectExtInst(Register ResVReg,
+                                             const SPIRVType *ResType,
                                              const MachineInstr &I,
                                              MachineIRBuilder &MIRBuilder,
-                                             const ExtInstList &insts) const {
+                                             const ExtInstList &Insts) const {
 
-  for (const auto &ex : insts) {
-    ExtInstSet set = ex.first;
-    uint32_t opCode = ex.second;
-    if (STI.canUseExtInstSet(set)) {
+  for (const auto &Ex : Insts) {
+    ExtInstSet Set = Ex.first;
+    uint32_t Opcode = Ex.second;
+    if (STI.canUseExtInstSet(Set)) {
       auto MIB = MIRBuilder.buildInstr(SPIRV::OpExtInst)
-                     .addDef(resVReg)
-                     .addUse(TR.getSPIRVTypeID(resType))
-                     .addImm(static_cast<uint32_t>(set))
-                     .addImm(opCode);
-      const unsigned numOps = I.getNumOperands();
-      for (unsigned i = 1; i < numOps; ++i) {
+                     .addDef(ResVReg)
+                     .addUse(TR.getSPIRVTypeID(ResType))
+                     .addImm(static_cast<uint32_t>(Set))
+                     .addImm(Opcode);
+      const unsigned NumOps = I.getNumOperands();
+      for (unsigned i = 1; i < NumOps; ++i) {
         MIB.add(I.getOperand(i));
       }
       return MIB.constrainAllUses(TII, TRI, RBI);
@@ -567,9 +557,9 @@ bool SPIRVInstructionSelector::selectExtInst(Register resVReg,
   return false;
 }
 
-static bool canUseNSW(unsigned opCode) {
+static bool canUseNSW(unsigned Opcode) {
   using namespace SPIRV;
-  switch (opCode) {
+  switch (Opcode) {
   case OpIAddS:
   case OpIAddV:
   case OpISubS:
@@ -585,9 +575,9 @@ static bool canUseNSW(unsigned opCode) {
   }
 }
 
-static bool canUseNUW(unsigned opCode) {
+static bool canUseNUW(unsigned Opcode) {
   using namespace SPIRV;
-  switch (opCode) {
+  switch (Opcode) {
   case OpIAddS:
   case OpIAddV:
   case OpISubS:
@@ -610,13 +600,13 @@ static void handleIntegerWrapFlags(const MachineInstr &I, Register Target,
     buildOpDecorate(Target, MIRBuilder, Decoration::NoSignedWrap, {});
 
   if (I.getFlag(MachineInstr::MIFlag::NoUWrap) && canUseNUW(NewOpcode) &&
-       canUseDecoration(Decoration::NoUnsignedWrap, ST))
+      canUseDecoration(Decoration::NoUnsignedWrap, ST))
     buildOpDecorate(Target, MIRBuilder, Decoration::NoUnsignedWrap, {});
 }
 
-bool SPIRVInstructionSelector::selectUnOpWithSrc(Register ResVReg,
-    const SPIRVType *ResType, const MachineInstr &I, Register SrcReg,
-    MachineIRBuilder &MIRBuilder, unsigned Opcode) const {
+bool SPIRVInstructionSelector::selectUnOpWithSrc(
+    Register ResVReg, const SPIRVType *ResType, const MachineInstr &I,
+    Register SrcReg, MachineIRBuilder &MIRBuilder, unsigned Opcode) const {
   handleIntegerWrapFlags(I, ResVReg, Opcode, STI, MIRBuilder, TR);
   return MIRBuilder.buildInstr(Opcode)
       .addDef(ResVReg)
@@ -626,14 +616,16 @@ bool SPIRVInstructionSelector::selectUnOpWithSrc(Register ResVReg,
 }
 
 bool SPIRVInstructionSelector::selectUnOp(Register ResVReg,
-    const SPIRVType *ResType, const MachineInstr &I,
-    MachineIRBuilder &MIRBuilder, unsigned Opcode) const {
+                                          const SPIRVType *ResType,
+                                          const MachineInstr &I,
+                                          MachineIRBuilder &MIRBuilder,
+                                          unsigned Opcode) const {
   return selectUnOpWithSrc(ResVReg, ResType, I, I.getOperand(1).getReg(),
                            MIRBuilder, Opcode);
 }
 
-static MemorySemantics::MemorySemantics getMemSemantics(AtomicOrdering ord) {
-  switch (ord) {
+static MemorySemantics::MemorySemantics getMemSemantics(AtomicOrdering Ord) {
+  switch (Ord) {
   case AtomicOrdering::Acquire:
     return MemorySemantics::Acquire;
   case AtomicOrdering::Release:
@@ -650,59 +642,60 @@ static MemorySemantics::MemorySemantics getMemSemantics(AtomicOrdering ord) {
   }
 }
 
-static Scope::Scope getScope(SyncScope::ID ord) {
-  switch (ord) {
+static Scope::Scope getScope(SyncScope::ID Ord) {
+  switch (Ord) {
   case SyncScope::SingleThread:
     return Scope::Invocation;
   case SyncScope::System:
     return Scope::Device;
   default:
-    llvm_unreachable("Unsupported synchronization scope ID.");
+    llvm_unreachable("Unsupported synchronization Scope ID.");
   }
 }
 
-static void addMemoryOperands(MachineMemOperand *MemOp, MachineInstrBuilder &MIB) {
-  uint32_t spvMemOp = MemoryOperand::None;
+static void addMemoryOperands(MachineMemOperand *MemOp,
+                              MachineInstrBuilder &MIB) {
+  uint32_t SpvMemOp = MemoryOperand::None;
   if (MemOp->isVolatile())
-    spvMemOp |= MemoryOperand::Volatile;
+    SpvMemOp |= MemoryOperand::Volatile;
   if (MemOp->isNonTemporal())
-    spvMemOp |= MemoryOperand::Nontemporal;
+    SpvMemOp |= MemoryOperand::Nontemporal;
   if (MemOp->getAlign().value())
-    spvMemOp |= MemoryOperand::Aligned;
+    SpvMemOp |= MemoryOperand::Aligned;
 
-  if (spvMemOp != MemoryOperand::None) {
-    MIB.addImm(spvMemOp);
-    if (spvMemOp & MemoryOperand::Aligned)
+  if (SpvMemOp != MemoryOperand::None) {
+    MIB.addImm(SpvMemOp);
+    if (SpvMemOp & MemoryOperand::Aligned)
       MIB.addImm(MemOp->getAlign().value());
   }
 }
 
 static void addMemoryOperands(uint64_t Flags, MachineInstrBuilder &MIB) {
-  uint32_t spvMemOp = MemoryOperand::None;
+  uint32_t SpvMemOp = MemoryOperand::None;
   if (Flags & MachineMemOperand::Flags::MOVolatile)
-    spvMemOp |= MemoryOperand::Volatile;
+    SpvMemOp |= MemoryOperand::Volatile;
   if (Flags & MachineMemOperand::Flags::MONonTemporal)
-    spvMemOp |= MemoryOperand::Nontemporal;
+    SpvMemOp |= MemoryOperand::Nontemporal;
   // if (MemOp->getAlign().value())
-  //   spvMemOp |= MemoryOperand::Aligned;
+  //   SpvMemOp |= MemoryOperand::Aligned;
 
-  if (spvMemOp != MemoryOperand::None) {
-    MIB.addImm(spvMemOp);
-    // if (spvMemOp & MemoryOperand::Aligned)
+  if (SpvMemOp != MemoryOperand::None) {
+    MIB.addImm(SpvMemOp);
+    // if (SpvMemOp & MemoryOperand::Aligned)
     //   MIB.addImm(MemOp->getAlign().value());
   }
 }
 
-bool SPIRVInstructionSelector::selectLoad(Register resVReg,
-                                          const SPIRVType *resType,
+bool SPIRVInstructionSelector::selectLoad(Register ResVReg,
+                                          const SPIRVType *ResType,
                                           const MachineInstr &I,
                                           MachineIRBuilder &MIRBuilder) const {
   unsigned OpOffset =
       I.getOpcode() == TargetOpcode::G_INTRINSIC_W_SIDE_EFFECTS ? 1 : 0;
   auto Ptr = I.getOperand(1 + OpOffset).getReg();
   auto MIB = MIRBuilder.buildInstr(SPIRV::OpLoad)
-                 .addDef(resVReg)
-                 .addUse(TR.getSPIRVTypeID(resType))
+                 .addDef(ResVReg)
+                 .addUse(TR.getSPIRVTypeID(ResType))
                  .addUse(Ptr);
   if (!I.getNumMemOperands()) {
     assert(I.getOpcode() == TargetOpcode::G_INTRINSIC_W_SIDE_EFFECTS);
@@ -731,8 +724,9 @@ bool SPIRVInstructionSelector::selectStore(const MachineInstr &I,
   return MIB.constrainAllUses(TII, TRI, RBI);
 }
 
-bool SPIRVInstructionSelector::selectMemOperation(Register ResVReg,
-    const MachineInstr &I, MachineIRBuilder &MIRBuilder) const {
+bool SPIRVInstructionSelector::selectMemOperation(
+    Register ResVReg, const MachineInstr &I,
+    MachineIRBuilder &MIRBuilder) const {
   auto MIB = MIRBuilder.buildInstr(SPIRV::OpCopyMemorySized)
                  .addDef(I.getOperand(0).getReg())
                  .addUse(I.getOperand(1).getReg())
@@ -748,107 +742,107 @@ bool SPIRVInstructionSelector::selectMemOperation(Register ResVReg,
   return Result;
 }
 
-bool SPIRVInstructionSelector::selectAtomicRMW(Register resVReg,
-                                               const SPIRVType *resType,
+bool SPIRVInstructionSelector::selectAtomicRMW(Register ResVReg,
+                                               const SPIRVType *ResType,
                                                const MachineInstr &I,
                                                MachineIRBuilder &MIRBuilder,
-                                               unsigned newOpcode) const {
-
+                                               unsigned NewOpcode) const {
   assert(I.hasOneMemOperand());
-  auto memOp = *I.memoperands_begin();
-  auto scope = getScope(memOp->getSyncScopeID());
-  Register scopeReg = buildI32Constant(scope, MIRBuilder);
+  auto MemOp = *I.memoperands_begin();
+  auto Scope = getScope(MemOp->getSyncScopeID());
+  Register ScopeReg = buildI32Constant(Scope, MIRBuilder);
 
-  auto ptr = I.getOperand(1).getReg();
+  auto Ptr = I.getOperand(1).getReg();
   // Changed as it's implemented in the translator. See test/atomicrmw.ll
-  //auto scSem = getMemSemanticsForStorageClass(TR.getPointerStorageClass(ptr));
+  // auto ScSem =
+  // getMemSemanticsForStorageClass(TR.getPointerStorageClass(Ptr));
 
-  auto memSem = getMemSemantics(memOp->getSuccessOrdering());
-  Register memSemReg = buildI32Constant(memSem /*| scSem*/, MIRBuilder);
+  auto MemSem = getMemSemantics(MemOp->getSuccessOrdering());
+  Register MemSemReg = buildI32Constant(MemSem /*| ScSem*/, MIRBuilder);
 
-  return MIRBuilder.buildInstr(newOpcode)
-      .addDef(resVReg)
-      .addUse(TR.getSPIRVTypeID(resType))
-      .addUse(ptr)
-      .addUse(scopeReg)
-      .addUse(memSemReg)
+  return MIRBuilder.buildInstr(NewOpcode)
+      .addDef(ResVReg)
+      .addUse(TR.getSPIRVTypeID(ResType))
+      .addUse(Ptr)
+      .addUse(ScopeReg)
+      .addUse(MemSemReg)
       .addUse(I.getOperand(2).getReg())
       .constrainAllUses(TII, TRI, RBI);
 }
 
 bool SPIRVInstructionSelector::selectFence(const MachineInstr &I,
                                            MachineIRBuilder &MIRBuilder) const {
-  auto memSem = getMemSemantics(AtomicOrdering(I.getOperand(0).getImm()));
-  Register memSemReg = buildI32Constant(memSem, MIRBuilder);
+  auto MemSem = getMemSemantics(AtomicOrdering(I.getOperand(0).getImm()));
+  Register MemSemReg = buildI32Constant(MemSem, MIRBuilder);
 
-  auto scope = getScope(SyncScope::ID(I.getOperand(1).getImm()));
-  Register scopeReg = buildI32Constant(scope, MIRBuilder);
+  auto Scope = getScope(SyncScope::ID(I.getOperand(1).getImm()));
+  Register ScopeReg = buildI32Constant(Scope, MIRBuilder);
 
   return MIRBuilder.buildInstr(SPIRV::OpMemoryBarrier)
-      .addUse(scopeReg)
-      .addUse(memSemReg)
+      .addUse(ScopeReg)
+      .addUse(MemSemReg)
       .constrainAllUses(TII, TRI, RBI);
 }
 
-bool SPIRVInstructionSelector::selectAtomicCmpXchg(Register resVReg,
-                                                   const SPIRVType *resType,
+bool SPIRVInstructionSelector::selectAtomicCmpXchg(Register ResVReg,
+                                                   const SPIRVType *ResType,
                                                    const MachineInstr &I,
                                                    MachineIRBuilder &MIRBuilder,
-                                                   bool withSuccess) const {
+                                                   bool WithSuccess) const {
   auto MRI = MIRBuilder.getMRI();
   assert(I.hasOneMemOperand());
-  auto memOp = *I.memoperands_begin();
-  auto scope = getScope(memOp->getSyncScopeID());
-  Register scopeReg = buildI32Constant(scope, MIRBuilder);
+  auto MemOp = *I.memoperands_begin();
+  auto Scope = getScope(MemOp->getSyncScopeID());
+  Register ScopeReg = buildI32Constant(Scope, MIRBuilder);
 
-  auto ptr = I.getOperand(2).getReg();
-  auto cmp = I.getOperand(3).getReg();
-  auto val = I.getOperand(4).getReg();
+  auto Ptr = I.getOperand(2).getReg();
+  auto Cmp = I.getOperand(3).getReg();
+  auto Val = I.getOperand(4).getReg();
 
-  auto spvValTy = TR.getSPIRVTypeForVReg(val);
-  auto scSem = getMemSemanticsForStorageClass(TR.getPointerStorageClass(ptr));
+  auto SpvValTy = TR.getSPIRVTypeForVReg(Val);
+  auto ScSem = getMemSemanticsForStorageClass(TR.getPointerStorageClass(Ptr));
 
-  auto memSemEq = getMemSemantics(memOp->getSuccessOrdering()) | scSem;
-  Register memSemEqReg = buildI32Constant(memSemEq, MIRBuilder);
+  auto MemSemEq = getMemSemantics(MemOp->getSuccessOrdering()) | ScSem;
+  Register MemSemEqReg = buildI32Constant(MemSemEq, MIRBuilder);
 
-  auto memSemNeq = getMemSemantics(memOp->getFailureOrdering()) | scSem;
-  Register memSemNeqReg = memSemEq == memSemNeq
-                              ? memSemEqReg
-                              : buildI32Constant(memSemNeq, MIRBuilder);
+  auto MemSemNeq = getMemSemantics(MemOp->getFailureOrdering()) | ScSem;
+  Register MemSemNeqReg = MemSemEq == MemSemNeq
+                              ? MemSemEqReg
+                              : buildI32Constant(MemSemNeq, MIRBuilder);
 
-  auto tmpReg = withSuccess ? MRI->createGenericVirtualRegister(LLT::scalar(32))
-                            : resVReg;
-  bool success = MIRBuilder.buildInstr(SPIRV::OpAtomicCompareExchange)
-                     .addDef(tmpReg)
-                     .addUse(TR.getSPIRVTypeID(spvValTy))
-                     .addUse(ptr)
-                     .addUse(scopeReg)
-                     .addUse(memSemEqReg)
-                     .addUse(memSemNeqReg)
-                     .addUse(val)
-                     .addUse(cmp)
+  auto TmpReg = WithSuccess ? MRI->createGenericVirtualRegister(LLT::scalar(32))
+                            : ResVReg;
+  bool Success = MIRBuilder.buildInstr(SPIRV::OpAtomicCompareExchange)
+                     .addDef(TmpReg)
+                     .addUse(TR.getSPIRVTypeID(SpvValTy))
+                     .addUse(Ptr)
+                     .addUse(ScopeReg)
+                     .addUse(MemSemEqReg)
+                     .addUse(MemSemNeqReg)
+                     .addUse(Val)
+                     .addUse(Cmp)
                      .constrainAllUses(TII, TRI, RBI);
-  if (!withSuccess) // If we just need the old val, not {oldVal, success}
-    return success;
-  assert(resType->getOpcode() == SPIRV::OpTypeStruct);
-  auto boolReg = MRI->createGenericVirtualRegister(LLT::scalar(1));
-  Register boolTyID = resType->getOperand(2).getReg();
-  success &= MIRBuilder.buildInstr(SPIRV::OpIEqual)
-                 .addDef(boolReg)
-                 .addUse(boolTyID)
-                 .addUse(tmpReg)
-                 .addUse(cmp)
+  if (!WithSuccess) // If we just need the old Val, not {oldVal, Success}
+    return Success;
+  assert(ResType->getOpcode() == SPIRV::OpTypeStruct);
+  auto BoolReg = MRI->createGenericVirtualRegister(LLT::scalar(1));
+  Register BoolTyID = ResType->getOperand(2).getReg();
+  Success &= MIRBuilder.buildInstr(SPIRV::OpIEqual)
+                 .addDef(BoolReg)
+                 .addUse(BoolTyID)
+                 .addUse(TmpReg)
+                 .addUse(Cmp)
                  .constrainAllUses(TII, TRI, RBI);
-  return success && MIRBuilder.buildInstr(SPIRV::OpCompositeConstruct)
-                        .addDef(resVReg)
-                        .addUse(TR.getSPIRVTypeID(resType))
-                        .addUse(tmpReg)
-                        .addUse(boolReg)
+  return Success && MIRBuilder.buildInstr(SPIRV::OpCompositeConstruct)
+                        .addDef(ResVReg)
+                        .addUse(TR.getSPIRVTypeID(ResType))
+                        .addUse(TmpReg)
+                        .addUse(BoolReg)
                         .constrainAllUses(TII, TRI, RBI);
 }
 
-static bool isGenericCastablePtr(StorageClass::StorageClass sc) {
-  switch (sc) {
+static bool isGenericCastablePtr(StorageClass::StorageClass Sc) {
+  switch (Sc) {
   case StorageClass::Workgroup:
   case StorageClass::CrossWorkgroup:
   case StorageClass::Function:
@@ -864,62 +858,62 @@ static bool isGenericCastablePtr(StorageClass::StorageClass sc) {
 // Workgroup to Function by going via a Generic pointer as an intermediary. All
 // other combinations can only be done by a bitcast, and are probably not safe.
 bool SPIRVInstructionSelector::selectAddrSpaceCast(
-    Register resVReg, const SPIRVType *resType, const MachineInstr &I,
+    Register ResVReg, const SPIRVType *ResType, const MachineInstr &I,
     MachineIRBuilder &MIRBuilder) const {
   using namespace SPIRV;
   namespace SC = StorageClass;
-  auto srcPtr = I.getOperand(1).getReg();
-  auto srcPtrTy = TR.getSPIRVTypeForVReg(srcPtr);
-  auto srcSC = TR.getPointerStorageClass(srcPtr);
-  auto dstSC = TR.getPointerStorageClass(resVReg);
+  auto SrcPtr = I.getOperand(1).getReg();
+  auto SrcPtrTy = TR.getSPIRVTypeForVReg(SrcPtr);
+  auto SrcSC = TR.getPointerStorageClass(SrcPtr);
+  auto DstSC = TR.getPointerStorageClass(ResVReg);
 
-  if (dstSC == SC::Generic && isGenericCastablePtr(srcSC)) {
+  if (DstSC == SC::Generic && isGenericCastablePtr(SrcSC)) {
     // We're casting from an eligable pointer to Generic
-    return selectUnOp(resVReg, resType, I, MIRBuilder, OpPtrCastToGeneric);
-  } else if (srcSC == SC::Generic && isGenericCastablePtr(dstSC)) {
+    return selectUnOp(ResVReg, ResType, I, MIRBuilder, OpPtrCastToGeneric);
+  } else if (SrcSC == SC::Generic && isGenericCastablePtr(DstSC)) {
     // We're casting from Generic to an eligable pointer
-    return selectUnOp(resVReg, resType, I, MIRBuilder, OpGenericCastToPtr);
-  } else if (isGenericCastablePtr(srcSC) && isGenericCastablePtr(dstSC)) {
+    return selectUnOp(ResVReg, ResType, I, MIRBuilder, OpGenericCastToPtr);
+  } else if (isGenericCastablePtr(SrcSC) && isGenericCastablePtr(DstSC)) {
     // We're casting between 2 eligable pointers using Generic as an
     // intermediary
-    auto tmp = MIRBuilder.getMRI()->createVirtualRegister(&IDRegClass);
-    auto genericPtrTy = TR.getOrCreateSPIRVPointerType(srcPtrTy, MIRBuilder,
+    auto Tmp = MIRBuilder.getMRI()->createVirtualRegister(&IDRegClass);
+    auto GenericPtrTy = TR.getOrCreateSPIRVPointerType(SrcPtrTy, MIRBuilder,
                                                        StorageClass::Generic);
-    bool success = MIRBuilder.buildInstr(OpPtrCastToGeneric)
-                       .addDef(tmp)
-                       .addUse(TR.getSPIRVTypeID(genericPtrTy))
-                       .addUse(srcPtr)
+    bool Success = MIRBuilder.buildInstr(OpPtrCastToGeneric)
+                       .addDef(Tmp)
+                       .addUse(TR.getSPIRVTypeID(GenericPtrTy))
+                       .addUse(SrcPtr)
                        .constrainAllUses(TII, TRI, RBI);
-    return success && MIRBuilder.buildInstr(OpGenericCastToPtr)
-                          .addDef(resVReg)
-                          .addUse(TR.getSPIRVTypeID(resType))
-                          .addUse(tmp)
+    return Success && MIRBuilder.buildInstr(OpGenericCastToPtr)
+                          .addDef(ResVReg)
+                          .addUse(TR.getSPIRVTypeID(ResType))
+                          .addUse(Tmp)
                           .constrainAllUses(TII, TRI, RBI);
   } else {
     // TODO Should this case just be disallowed completely?
     // We're casting 2 other arbitrary address spaces, so have to bitcast
-    return selectUnOp(resVReg, resType, I, MIRBuilder, OpBitcast);
+    return selectUnOp(ResVReg, ResType, I, MIRBuilder, OpBitcast);
   }
 }
 
 #if 0
-bool SPIRVInstructionSelector::selectOverflowOp(Register resVReg,
-                                                const SPIRVType *resType,
+bool SPIRVInstructionSelector::selectOverflowOp(Register ResVReg,
+                                                const SPIRVType *ResType,
                                                 const MachineInstr &I,
                                                 MachineIRBuilder &MIRBuilder,
-                                                unsigned newOpcode) const {
+                                                unsigned NewOpcode) const {
   using namespace SPIRV;
   auto MRI = MIRBuilder.getMRI();
 
-  auto elem0TyReg = resType->getOperand(1).getReg();
+  auto elem0TyReg = ResType->getOperand(1).getReg();
   SPIRVType *elem0Ty = TR.getSPIRVTypeForVReg(elem0TyReg);
   assert(TR.isScalarOrVectorOfType(elem0TyReg, OpTypeInt));
 
-  auto tmpReg = MRI->createGenericVirtualRegister(LLT::scalar(32));
+  auto TmpReg = MRI->createGenericVirtualRegister(LLT::scalar(32));
   auto tmpStructTy = TR.getPairStruct(elem0Ty, elem0Ty, MIRBuilder);
 
-  bool success = MIRBuilder.buildInstr(newOpcode)
-                     .addDef(tmpReg)
+  bool Success = MIRBuilder.buildInstr(NewOpcode)
+                     .addDef(TmpReg)
                      .addUse(TR.getSPIRVTypeID(tmpStructTy))
                      .addUse(I.getOperand(2).getReg())
                      .addUse(I.getOperand(3).getReg())
@@ -927,34 +921,34 @@ bool SPIRVInstructionSelector::selectOverflowOp(Register resVReg,
 
   // Need to build an {int, bool} struct from the {int, int} TR. result
   auto elem0Reg = MRI->createGenericVirtualRegister(LLT::scalar(32));
-  success &= MIRBuilder.buildInstr(OpCompositeExtract)
+  Success &= MIRBuilder.buildInstr(OpCompositeExtract)
                  .addDef(elem0Reg)
                  .addUse(TR.getSPIRVTypeID(elem0Ty))
-                 .addUse(tmpReg)
+                 .addUse(TmpReg)
                  .addImm(0)
                  .constrainAllUses(TII, TRI, RBI);
   auto elem1Reg = MRI->createGenericVirtualRegister(LLT::scalar(32));
-  success &= MIRBuilder.buildInstr(OpCompositeExtract)
+  Success &= MIRBuilder.buildInstr(OpCompositeExtract)
                  .addDef(elem1Reg)
                  .addUse(TR.getSPIRVTypeID(elem0Ty))
-                 .addUse(tmpReg)
+                 .addUse(TmpReg)
                  .addImm(1)
                  .constrainAllUses(TII, TRI, RBI);
-  auto boolReg = MRI->createGenericVirtualRegister(LLT::scalar(1));
-  auto boolTy = TR.getSPIRVTypeForVReg(resType->getOperand(2).getReg());
-  success &= selectIntToBool(elem1Reg, boolReg, elem0Ty, boolTy, MIRBuilder);
-  return success && MIRBuilder.buildInstr(OpCompositeConstruct)
-                        .addDef(resVReg)
-                        .addUse(TR.getSPIRVTypeID(resType))
+  auto BoolReg = MRI->createGenericVirtualRegister(LLT::scalar(1));
+  auto boolTy = TR.getSPIRVTypeForVReg(ResType->getOperand(2).getReg());
+  Success &= selectIntToBool(elem1Reg, BoolReg, elem0Ty, boolTy, MIRBuilder);
+  return Success && MIRBuilder.buildInstr(OpCompositeConstruct)
+                        .addDef(ResVReg)
+                        .addUse(TR.getSPIRVTypeID(ResType))
                         .addUse(elem0Reg)
-                        .addUse(boolReg)
+                        .addUse(BoolReg)
                         .constrainAllUses(TII, TRI, RBI);
 }
 #endif
 
-static unsigned int getFCmpOpcode(unsigned predNum) {
-  auto pred = static_cast<CmpInst::Predicate>(predNum);
-  switch (pred) {
+static unsigned int getFCmpOpcode(unsigned PredNum) {
+  auto Pred = static_cast<CmpInst::Predicate>(PredNum);
+  switch (Pred) {
   case CmpInst::FCMP_OEQ:
     return SPIRV::OpFOrdEqual;
   case CmpInst::FCMP_OGE:
@@ -985,13 +979,13 @@ static unsigned int getFCmpOpcode(unsigned predNum) {
     return SPIRV::OpUnordered;
   default:
     report_fatal_error("Unknown predicate type for FCmp: " +
-                       CmpInst::getPredicateName(pred));
+                       CmpInst::getPredicateName(Pred));
   }
 }
 
-static unsigned int getICmpOpcode(unsigned predNum) {
-  auto pred = static_cast<CmpInst::Predicate>(predNum);
-  switch (pred) {
+static unsigned int getICmpOpcode(unsigned PredNum) {
+  auto Pred = static_cast<CmpInst::Predicate>(PredNum);
+  switch (Pred) {
   case CmpInst::ICMP_EQ:
     return SPIRV::OpIEqual;
   case CmpInst::ICMP_NE:
@@ -1014,50 +1008,48 @@ static unsigned int getICmpOpcode(unsigned predNum) {
     return SPIRV::OpULessThan;
   default:
     report_fatal_error("Unknown predicate type for ICmp: " +
-                       CmpInst::getPredicateName(pred));
+                       CmpInst::getPredicateName(Pred));
   }
 }
 
 // Return <CmpOpcode, needsConvertedToInt>
-static std::pair<unsigned int, bool> getPtrCmpOpcode(unsigned pred) {
-  switch (static_cast<CmpInst::Predicate>(pred)) {
+static std::pair<unsigned int, bool> getPtrCmpOpcode(unsigned Pred) {
+  switch (static_cast<CmpInst::Predicate>(Pred)) {
   case CmpInst::ICMP_EQ:
     return {SPIRV::OpPtrEqual, false};
   case CmpInst::ICMP_NE:
     return {SPIRV::OpPtrNotEqual, false};
   default:
-    return {getICmpOpcode(pred), true};
+    return {getICmpOpcode(Pred), true};
   }
 }
 
 // Return the logical operation, or abort if none exists
-static unsigned int getBoolCmpOpcode(unsigned predNum) {
-  auto pred = static_cast<CmpInst::Predicate>(predNum);
-  switch (pred) {
+static unsigned int getBoolCmpOpcode(unsigned PredNum) {
+  auto Pred = static_cast<CmpInst::Predicate>(PredNum);
+  switch (Pred) {
   case CmpInst::ICMP_EQ:
     return SPIRV::OpLogicalEqual;
   case CmpInst::ICMP_NE:
     return SPIRV::OpLogicalNotEqual;
   default:
     report_fatal_error("Unknown predicate type for Bool comparison: " +
-                       CmpInst::getPredicateName(pred));
+                       CmpInst::getPredicateName(Pred));
   }
 }
 
-bool SPIRVInstructionSelector::selectBitreverse(Register resVReg,
-                                          const SPIRVType *resType,
-                                          const MachineInstr &I,
-                                          MachineIRBuilder &MIRBuilder) const {
-  Register src = I.getOperand(1).getReg();
+bool SPIRVInstructionSelector::selectBitreverse(
+    Register ResVReg, const SPIRVType *ResType, const MachineInstr &I,
+    MachineIRBuilder &MIRBuilder) const {
   return MIRBuilder.buildInstr(SPIRV::OpBitReverse)
-      .addDef(resVReg)
-      .addUse(TR.getSPIRVTypeID(resType))
-      .addUse(src)
+      .addDef(ResVReg)
+      .addUse(TR.getSPIRVTypeID(ResType))
+      .addUse(I.getOperand(1).getReg())
       .constrainAllUses(TII, TRI, RBI);
 }
 
 bool SPIRVInstructionSelector::selectConstVector(
-    Register resVReg, const SPIRVType *resType, const MachineInstr &I,
+    Register ResVReg, const SPIRVType *ResType, const MachineInstr &I,
     MachineIRBuilder &MIRBuilder) const {
   // TODO: only const case is supported for now
   assert(std::all_of(
@@ -1078,166 +1070,170 @@ bool SPIRVInstructionSelector::selectConstVector(
       }));
 
   auto MIB = MIRBuilder.buildInstr(SPIRV::OpConstantComposite)
-                 .addDef(resVReg)
-                 .addUse(TR.getSPIRVTypeID(resType));
+                 .addDef(ResVReg)
+                 .addUse(TR.getSPIRVTypeID(ResType));
   for (unsigned i = I.getNumExplicitDefs(); i < I.getNumExplicitOperands(); ++i)
     MIB.addUse(I.getOperand(i).getReg());
   return MIB.constrainAllUses(TII, TRI, RBI);
 }
 
-bool SPIRVInstructionSelector::selectCmp(Register resVReg,
-                                         const SPIRVType *resType,
-                                         unsigned scalarTyOpc, unsigned cmpOpc,
+bool SPIRVInstructionSelector::selectCmp(Register ResVReg,
+                                         const SPIRVType *ResType,
+                                         unsigned scalarTyOpc, unsigned CmpOpc,
                                          const MachineInstr &I,
-                                         MachineIRBuilder &MIRBuilder,
-                                         bool convertToUInt) const {
+                                         MachineIRBuilder &MIRBuilder) const {
   using namespace SPIRV;
 
-  Register cmp0 = I.getOperand(2).getReg();
-  Register cmp1 = I.getOperand(3).getReg();
-  SPIRVType *cmp0Type = TR.getSPIRVTypeForVReg(cmp0);
-  SPIRVType *cmp1Type = TR.getSPIRVTypeForVReg(cmp1);
-  assert(cmp0Type->getOpcode() == cmp1Type->getOpcode());
+  Register Cmp0 = I.getOperand(2).getReg();
+  Register Cmp1 = I.getOperand(3).getReg();
+  SPIRVType *Cmp0Type = TR.getSPIRVTypeForVReg(Cmp0);
+  SPIRVType *Cmp1Type = TR.getSPIRVTypeForVReg(Cmp1);
+  assert(Cmp0Type->getOpcode() == Cmp1Type->getOpcode());
 
-  if (cmp0Type->getOpcode() != OpTypePointer &&
-      (!TR.isScalarOrVectorOfType(cmp0, scalarTyOpc) ||
-       !TR.isScalarOrVectorOfType(cmp1, scalarTyOpc)))
+  if (Cmp0Type->getOpcode() != OpTypePointer &&
+      (!TR.isScalarOrVectorOfType(Cmp0, scalarTyOpc) ||
+       !TR.isScalarOrVectorOfType(Cmp1, scalarTyOpc)))
     llvm_unreachable("Incompatible type for comparison");
 
-  return MIRBuilder.buildInstr(cmpOpc)
-      .addDef(resVReg)
-      .addUse(TR.getSPIRVTypeID(resType))
-      .addUse(cmp0)
-      .addUse(cmp1)
+  return MIRBuilder.buildInstr(CmpOpc)
+      .addDef(ResVReg)
+      .addUse(TR.getSPIRVTypeID(ResType))
+      .addUse(Cmp0)
+      .addUse(Cmp1)
       .constrainAllUses(TII, TRI, RBI);
 }
 
-bool SPIRVInstructionSelector::selectICmp(Register resVReg,
-                                          const SPIRVType *resType,
+bool SPIRVInstructionSelector::selectICmp(Register ResVReg,
+                                          const SPIRVType *ResType,
                                           const MachineInstr &I,
                                           MachineIRBuilder &MIRBuilder) const {
 
-  auto pred = I.getOperand(1).getPredicate();
-  unsigned cmpOpc = getICmpOpcode(pred);
-  unsigned typeOpc = SPIRV::OpTypeInt;
-  bool ptrToUInt = false;
+  auto Pred = I.getOperand(1).getPredicate();
+  unsigned CmpOpc = getICmpOpcode(Pred);
+  unsigned TypeOpc = SPIRV::OpTypeInt;
+  bool PtrToUInt = false;
 
-  Register cmpOperand = I.getOperand(2).getReg();
-  if (TR.isScalarOfType(cmpOperand, SPIRV::OpTypePointer)) {
+  Register CmpOperand = I.getOperand(2).getReg();
+  if (TR.isScalarOfType(CmpOperand, SPIRV::OpTypePointer)) {
     if (STI.canDirectlyComparePointers()) {
-      std::tie(cmpOpc, ptrToUInt) = getPtrCmpOpcode(pred);
+      std::tie(CmpOpc, PtrToUInt) = getPtrCmpOpcode(Pred);
     } else {
-      ptrToUInt = true;
+      PtrToUInt = true;
     }
-  } else if (TR.isScalarOrVectorOfType(cmpOperand, SPIRV::OpTypeBool)) {
-    typeOpc = SPIRV::OpTypeBool;
-    cmpOpc = getBoolCmpOpcode(pred);
+  } else if (TR.isScalarOrVectorOfType(CmpOperand, SPIRV::OpTypeBool)) {
+    TypeOpc = SPIRV::OpTypeBool;
+    CmpOpc = getBoolCmpOpcode(Pred);
   }
-  return selectCmp(resVReg, resType, typeOpc, cmpOpc, I, MIRBuilder, ptrToUInt);
+  return selectCmp(ResVReg, ResType, TypeOpc, CmpOpc, I, MIRBuilder);
 }
 
 void SPIRVInstructionSelector::renderFImm32(MachineInstrBuilder &MIB,
-                                                   const MachineInstr &I,
-                                                   int OpIdx) const {
+                                            const MachineInstr &I,
+                                            int OpIdx) const {
   assert(I.getOpcode() == TargetOpcode::G_FCONSTANT && OpIdx == -1 &&
          "Expected G_FCONSTANT");
   const ConstantFP *FPImm = I.getOperand(1).getFPImm();
   addNumImm(FPImm->getValueAPF().bitcastToAPInt(), MIB, true);
 }
 
-void SPIRVInstructionSelector::renderImm32(
-  MachineInstrBuilder &MIB, const MachineInstr &I, int OpIdx) const {
+void SPIRVInstructionSelector::renderImm32(MachineInstrBuilder &MIB,
+                                           const MachineInstr &I,
+                                           int OpIdx) const {
   assert(I.getOpcode() == TargetOpcode::G_CONSTANT && OpIdx == -1 &&
          "Expected G_CONSTANT");
   addNumImm(I.getOperand(1).getCImm()->getValue(), MIB);
 }
 
 Register
-SPIRVInstructionSelector::buildI32Constant(uint32_t val,
-    MachineIRBuilder &MIRBuilder, const SPIRVType *resType) const {
+SPIRVInstructionSelector::buildI32Constant(uint32_t Val,
+                                           MachineIRBuilder &MIRBuilder,
+                                           const SPIRVType *ResType) const {
   auto MRI = MIRBuilder.getMRI();
-  auto LLVMTy = IntegerType::get(MIRBuilder.getMF().getFunction().getContext(), 32);
-  auto spvI32Ty = resType ? resType : TR.getOrCreateSPIRVType(LLVMTy,
-                                                              MIRBuilder);
+  auto LLVMTy =
+      IntegerType::get(MIRBuilder.getMF().getFunction().getContext(), 32);
+  auto SpvI32Ty =
+      ResType ? ResType : TR.getOrCreateSPIRVType(LLVMTy, MIRBuilder);
   // Find a constant in DT or build a new one.
-  auto ConstInt = ConstantInt::get(LLVMTy, val);
-  Register newReg;
-  if (DT.find(ConstInt, &MIRBuilder.getMF(), newReg) == false) {
-    newReg = MRI->createGenericVirtualRegister(LLT::scalar(32));
-    DT.add(ConstInt, &MIRBuilder.getMF(), newReg);
+  auto ConstInt = ConstantInt::get(LLVMTy, Val);
+  Register NewReg;
+  if (DT.find(ConstInt, &MIRBuilder.getMF(), NewReg) == false) {
+    NewReg = MRI->createGenericVirtualRegister(LLT::scalar(32));
+    DT.add(ConstInt, &MIRBuilder.getMF(), NewReg);
     MachineInstr *MI;
-    if (val == 0)
+    if (Val == 0)
       MI = MIRBuilder.buildInstr(SPIRV::OpConstantNull)
-                 .addDef(newReg)
-                 .addUse(TR.getSPIRVTypeID(spvI32Ty));
+               .addDef(NewReg)
+               .addUse(TR.getSPIRVTypeID(SpvI32Ty));
     else
       MI = MIRBuilder.buildInstr(SPIRV::OpConstantI)
-                 .addDef(newReg)
-                 .addUse(TR.getSPIRVTypeID(spvI32Ty))
-                 .addImm(APInt(32, val).getZExtValue());
+               .addDef(NewReg)
+               .addUse(TR.getSPIRVTypeID(SpvI32Ty))
+               .addImm(APInt(32, Val).getZExtValue());
     constrainSelectedInstRegOperands(*MI, TII, TRI, RBI);
   }
-  return newReg;
+  return NewReg;
 }
 
-bool SPIRVInstructionSelector::selectFCmp(Register resVReg,
-                                          const SPIRVType *resType,
+bool SPIRVInstructionSelector::selectFCmp(Register ResVReg,
+                                          const SPIRVType *ResType,
                                           const MachineInstr &I,
                                           MachineIRBuilder &MIRBuilder) const {
-  unsigned int cmpOp = getFCmpOpcode(I.getOperand(1).getPredicate());
-  return selectCmp(resVReg, resType, SPIRV::OpTypeFloat, cmpOp, I, MIRBuilder);
+  unsigned int CmpOp = getFCmpOpcode(I.getOperand(1).getPredicate());
+  return selectCmp(ResVReg, ResType, SPIRV::OpTypeFloat, CmpOp, I, MIRBuilder);
 }
 
 Register
-SPIRVInstructionSelector::buildZerosVal(const SPIRVType *resType,
+SPIRVInstructionSelector::buildZerosVal(const SPIRVType *ResType,
                                         MachineIRBuilder &MIRBuilder) const {
-  return buildI32Constant(0, MIRBuilder, resType);
+  return buildI32Constant(0, MIRBuilder, ResType);
 }
 
 Register
-SPIRVInstructionSelector::buildOnesVal(bool allOnes, const SPIRVType *resType,
+SPIRVInstructionSelector::buildOnesVal(bool AllOnes, const SPIRVType *ResType,
                                        MachineIRBuilder &MIRBuilder) const {
   auto MRI = MIRBuilder.getMRI();
-  unsigned bitWidth = TR.getScalarOrVectorBitWidth(resType);
-  auto one = allOnes ? APInt::getAllOnesValue(bitWidth)
-                     : APInt::getOneBitSet(bitWidth, 0);
-  Register oneReg = buildI32Constant(one.getZExtValue(), MIRBuilder, resType);
-  if (resType->getOpcode() == SPIRV::OpTypeVector) {
-    const unsigned numEles = resType->getOperand(2).getImm();
-    Register oneVec = MRI->createVirtualRegister(&SPIRV::IDRegClass);
+  unsigned BitWidth = TR.getScalarOrVectorBitWidth(ResType);
+  auto One = AllOnes ? APInt::getAllOnesValue(BitWidth)
+                     : APInt::getOneBitSet(BitWidth, 0);
+  Register OneReg = buildI32Constant(One.getZExtValue(), MIRBuilder, ResType);
+  if (ResType->getOpcode() == SPIRV::OpTypeVector) {
+    const unsigned NumEles = ResType->getOperand(2).getImm();
+    Register OneVec = MRI->createVirtualRegister(&SPIRV::IDRegClass);
     auto MIB = MIRBuilder.buildInstr(SPIRV::OpConstantComposite)
-                   .addDef(oneVec)
-                   .addUse(TR.getSPIRVTypeID(resType));
-    for (unsigned i = 0; i < numEles; ++i) {
-      MIB.addUse(oneReg);
+                   .addDef(OneVec)
+                   .addUse(TR.getSPIRVTypeID(ResType));
+    for (unsigned i = 0; i < NumEles; ++i) {
+      MIB.addUse(OneReg);
     }
     TR.constrainRegOperands(MIB);
-    return oneVec;
+    return OneVec;
   } else {
-    return oneReg;
+    return OneReg;
   }
 }
 
-bool SPIRVInstructionSelector::selectSelect(Register ResVReg,
-    const SPIRVType *ResType, const MachineInstr &I, bool IsSigned,
-    MachineIRBuilder &MIRBuilder) const {
+bool SPIRVInstructionSelector::selectSelect(
+    Register ResVReg, const SPIRVType *ResType, const MachineInstr &I,
+    bool IsSigned, MachineIRBuilder &MIRBuilder) const {
   // To extend a bool, we need to use OpSelect between constants
   using namespace SPIRV;
   Register ZeroReg = buildZerosVal(ResType, MIRBuilder);
   Register OneReg = buildOnesVal(IsSigned, ResType, MIRBuilder);
   bool IsScalarBool = TR.isScalarOfType(I.getOperand(1).getReg(), OpTypeBool);
   return MIRBuilder.buildInstr(IsScalarBool ? OpSelectSISCond : OpSelectSIVCond)
-        .addDef(ResVReg)
-        .addUse(TR.getSPIRVTypeID(ResType))
-        .addUse(I.getOperand(1).getReg())
-        .addUse(OneReg)
-        .addUse(ZeroReg)
-        .constrainAllUses(TII, TRI, RBI);
+      .addDef(ResVReg)
+      .addUse(TR.getSPIRVTypeID(ResType))
+      .addUse(I.getOperand(1).getReg())
+      .addUse(OneReg)
+      .addUse(ZeroReg)
+      .constrainAllUses(TII, TRI, RBI);
 }
 
 bool SPIRVInstructionSelector::selectIToF(Register ResVReg,
-    const SPIRVType *ResType, const MachineInstr &I, bool IsSigned,
-    MachineIRBuilder &MIRBuilder, unsigned Opcode) const {
+                                          const SPIRVType *ResType,
+                                          const MachineInstr &I, bool IsSigned,
+                                          MachineIRBuilder &MIRBuilder,
+                                          unsigned Opcode) const {
   Register SrcReg = I.getOperand(1).getReg();
   // We can convert bool value directly to float type without OpConvert*ToF,
   // however the translator generates OpSelect+OpConvert*ToF, so we do the same.
@@ -1255,16 +1251,16 @@ bool SPIRVInstructionSelector::selectIToF(Register ResVReg,
   return selectUnOpWithSrc(ResVReg, ResType, I, SrcReg, MIRBuilder, Opcode);
 }
 
-bool SPIRVInstructionSelector::selectExt(Register resVReg,
-                                         const SPIRVType *resType,
-                                         const MachineInstr &I, bool isSigned,
+bool SPIRVInstructionSelector::selectExt(Register ResVReg,
+                                         const SPIRVType *ResType,
+                                         const MachineInstr &I, bool IsSigned,
                                          MachineIRBuilder &MIRBuilder) const {
   using namespace SPIRV;
   if (TR.isScalarOrVectorOfType(I.getOperand(1).getReg(), OpTypeBool)) {
-    return selectSelect(resVReg, resType, I, isSigned, MIRBuilder);
+    return selectSelect(ResVReg, ResType, I, IsSigned, MIRBuilder);
   } else {
-    return selectUnOp(resVReg, resType, I, MIRBuilder,
-                      isSigned ? OpSConvert : OpUConvert);
+    return selectUnOp(ResVReg, ResType, I, MIRBuilder,
+                      IsSigned ? OpSConvert : OpUConvert);
   }
 }
 
@@ -1292,47 +1288,49 @@ bool SPIRVInstructionSelector::selectIntToBool(
       .constrainAllUses(TII, TRI, RBI);
 }
 
-bool SPIRVInstructionSelector::selectTrunc(Register resVReg,
-                                           const SPIRVType *resType,
+bool SPIRVInstructionSelector::selectTrunc(Register ResVReg,
+                                           const SPIRVType *ResType,
                                            const MachineInstr &I,
                                            MachineIRBuilder &MIRBuilder) const {
   using namespace SPIRV;
-  if (TR.isScalarOrVectorOfType(resVReg, OpTypeBool)) {
-    auto intReg = I.getOperand(1).getReg();
-    auto argType = TR.getSPIRVTypeForVReg(intReg);
-    return selectIntToBool(intReg, resVReg, argType, resType, MIRBuilder);
+  if (TR.isScalarOrVectorOfType(ResVReg, OpTypeBool)) {
+    auto IntReg = I.getOperand(1).getReg();
+    auto ArgType = TR.getSPIRVTypeForVReg(IntReg);
+    return selectIntToBool(IntReg, ResVReg, ArgType, ResType, MIRBuilder);
   } else {
-    bool isSigned = TR.isScalarOrVectorSigned(resType);
-    return selectUnOp(resVReg, resType, I, MIRBuilder,
-                      isSigned ? OpSConvert : OpUConvert);
+    bool IsSigned = TR.isScalarOrVectorSigned(ResType);
+    return selectUnOp(ResVReg, ResType, I, MIRBuilder,
+                      IsSigned ? OpSConvert : OpUConvert);
   }
 }
 
-bool SPIRVInstructionSelector::selectConst(Register resVReg,
-                                           const SPIRVType *resType,
-                                           const APInt &imm,
+bool SPIRVInstructionSelector::selectConst(Register ResVReg,
+                                           const SPIRVType *ResType,
+                                           const APInt &Imm,
                                            MachineIRBuilder &MIRBuilder) const {
-  assert(resType->getOpcode() != SPIRV::OpTypePointer || imm.isNullValue());
-  if (resType->getOpcode() == SPIRV::OpTypePointer && imm.isNullValue())
+  assert(ResType->getOpcode() != SPIRV::OpTypePointer || Imm.isNullValue());
+  if (ResType->getOpcode() == SPIRV::OpTypePointer && Imm.isNullValue())
     return MIRBuilder.buildInstr(SPIRV::OpConstantNull)
-        .addDef(resVReg)
-        .addUse(TR.getSPIRVTypeID(resType))
+        .addDef(ResVReg)
+        .addUse(TR.getSPIRVTypeID(ResType))
         .constrainAllUses(TII, TRI, RBI);
   else {
-    auto MIB = MIRBuilder.buildInstr(SPIRV::OpConstantI).addDef(resVReg).addUse(TR.getSPIRVTypeID(resType));
+    auto MIB = MIRBuilder.buildInstr(SPIRV::OpConstantI)
+                   .addDef(ResVReg)
+                   .addUse(TR.getSPIRVTypeID(ResType));
     // <=32-bit integers should be caught by the sdag pattern
-    assert(imm.getBitWidth() > 32);
-    addNumImm(imm, MIB);
+    assert(Imm.getBitWidth() > 32);
+    addNumImm(Imm, MIB);
     return MIB.constrainAllUses(TII, TRI, RBI);
   }
 }
 
 bool SPIRVInstructionSelector::selectOpUndef(
-    Register resVReg, const SPIRVType *resType,
+    Register ResVReg, const SPIRVType *ResType,
     MachineIRBuilder &MIRBuilder) const {
   return MIRBuilder.buildInstr(SPIRV::OpUndef)
-      .addDef(resVReg)
-      .addUse(TR.getSPIRVTypeID(resType))
+      .addDef(ResVReg)
+      .addUse(TR.getSPIRVTypeID(ResType))
       .constrainAllUses(TII, TRI, RBI);
 }
 
@@ -1354,11 +1352,11 @@ static int64_t foldImm(const MachineOperand &MO) {
 }
 
 bool SPIRVInstructionSelector::selectInsertVal(
-    Register resVReg, const SPIRVType *resType, const MachineInstr &I,
+    Register ResVReg, const SPIRVType *ResType, const MachineInstr &I,
     MachineIRBuilder &MIRBuilder) const {
   return MIRBuilder.buildInstr(SPIRV::OpCompositeInsert)
-      .addDef(resVReg)
-      .addUse(TR.getSPIRVTypeID(resType))
+      .addDef(ResVReg)
+      .addUse(TR.getSPIRVTypeID(ResType))
       // object to insert
       .addUse(I.getOperand(3).getReg())
       // composite to insert into
@@ -1369,11 +1367,11 @@ bool SPIRVInstructionSelector::selectInsertVal(
 }
 
 bool SPIRVInstructionSelector::selectExtractVal(
-    Register resVReg, const SPIRVType *resType, const MachineInstr &I,
+    Register ResVReg, const SPIRVType *ResType, const MachineInstr &I,
     MachineIRBuilder &MIRBuilder) const {
   return MIRBuilder.buildInstr(SPIRV::OpCompositeExtract)
-      .addDef(resVReg)
-      .addUse(TR.getSPIRVTypeID(resType))
+      .addDef(ResVReg)
+      .addUse(TR.getSPIRVTypeID(ResType))
       .addUse(I.getOperand(2).getReg())
       // TODO: support arbitrary number of indices
       .addImm(foldImm(I.getOperand(3)))
@@ -1381,13 +1379,13 @@ bool SPIRVInstructionSelector::selectExtractVal(
 }
 
 bool SPIRVInstructionSelector::selectInsertElt(
-    Register resVReg, const SPIRVType *resType, const MachineInstr &I,
+    Register ResVReg, const SPIRVType *ResType, const MachineInstr &I,
     MachineIRBuilder &MIRBuilder) const {
   if (isImm(I.getOperand(4)))
-    return selectInsertVal(resVReg, resType, I, MIRBuilder);
+    return selectInsertVal(ResVReg, ResType, I, MIRBuilder);
   return MIRBuilder.buildInstr(SPIRV::OpVectorInsertDynamic)
-      .addDef(resVReg)
-      .addUse(TR.getSPIRVTypeID(resType))
+      .addDef(ResVReg)
+      .addUse(TR.getSPIRVTypeID(ResType))
       .addUse(I.getOperand(2).getReg())
       .addUse(I.getOperand(3).getReg())
       .addUse(I.getOperand(4).getReg())
@@ -1395,20 +1393,20 @@ bool SPIRVInstructionSelector::selectInsertElt(
 }
 
 bool SPIRVInstructionSelector::selectExtractElt(
-    Register resVReg, const SPIRVType *resType, const MachineInstr &I,
+    Register ResVReg, const SPIRVType *ResType, const MachineInstr &I,
     MachineIRBuilder &MIRBuilder) const {
   if (isImm(I.getOperand(3)))
-    return selectExtractVal(resVReg, resType, I, MIRBuilder);
+    return selectExtractVal(ResVReg, ResType, I, MIRBuilder);
   return MIRBuilder.buildInstr(SPIRV::OpVectorExtractDynamic)
-      .addDef(resVReg)
-      .addUse(TR.getSPIRVTypeID(resType))
+      .addDef(ResVReg)
+      .addUse(TR.getSPIRVTypeID(ResType))
       .addUse(I.getOperand(2).getReg())
       .addUse(I.getOperand(3).getReg())
       .constrainAllUses(TII, TRI, RBI);
 }
 
-bool SPIRVInstructionSelector::selectGEP(Register resVReg,
-                                         const SPIRVType *resType,
+bool SPIRVInstructionSelector::selectGEP(Register ResVReg,
+                                         const SPIRVType *ResType,
                                          const MachineInstr &I,
                                          MachineIRBuilder &MIRBuilder) const {
   // In general we should also support OpAccessChain instrs here (i.e. not
@@ -1417,8 +1415,8 @@ bool SPIRVInstructionSelector::selectGEP(Register resVReg,
   auto Opcode = I.getOperand(2).getImm() ? SPIRV::OpInBoundsPtrAccessChain
                                          : SPIRV::OpPtrAccessChain;
   auto &Res = MIRBuilder.buildInstr(Opcode)
-                  .addDef(resVReg)
-                  .addUse(TR.getSPIRVTypeID(resType))
+                  .addDef(ResVReg)
+                  .addUse(TR.getSPIRVTypeID(ResType))
                   // object to get a pointer to
                   .addUse(I.getOperand(3).getReg());
   // adding indices
@@ -1428,44 +1426,48 @@ bool SPIRVInstructionSelector::selectGEP(Register resVReg,
 }
 
 bool SPIRVInstructionSelector::selectIntrinsic(
-    Register resVReg, const SPIRVType *resType, const MachineInstr &I,
+    Register ResVReg, const SPIRVType *ResType, const MachineInstr &I,
     MachineIRBuilder &MIRBuilder) const {
   switch (I.getIntrinsicID()) {
   case Intrinsic::spv_load:
-    return selectLoad(resVReg, resType, I, MIRBuilder);
+    return selectLoad(ResVReg, ResType, I, MIRBuilder);
     break;
   case Intrinsic::spv_store:
     return selectStore(I, MIRBuilder);
     break;
   case Intrinsic::spv_extractv:
-    return selectExtractVal(resVReg, resType, I, MIRBuilder);
+    return selectExtractVal(ResVReg, ResType, I, MIRBuilder);
     break;
   case Intrinsic::spv_insertv:
-    return selectInsertVal(resVReg, resType, I, MIRBuilder);
+    return selectInsertVal(ResVReg, ResType, I, MIRBuilder);
     break;
   case Intrinsic::spv_extractelt:
-    return selectExtractElt(resVReg, resType, I, MIRBuilder);
+    return selectExtractElt(ResVReg, ResType, I, MIRBuilder);
     break;
   case Intrinsic::spv_insertelt:
-    return selectInsertElt(resVReg, resType, I, MIRBuilder);
+    return selectInsertElt(ResVReg, ResType, I, MIRBuilder);
     break;
   case Intrinsic::spv_gep:
-    return selectGEP(resVReg, resType, I, MIRBuilder);
+    return selectGEP(ResVReg, ResType, I, MIRBuilder);
     break;
   case Intrinsic::spv_unref_global:
   case Intrinsic::spv_init_global: {
     auto *MI = MIRBuilder.getMRI()->getVRegDef(I.getOperand(1).getReg());
-    MachineInstr *Init = I.getNumExplicitOperands() > 2 ? MIRBuilder.getMRI()->getVRegDef(I.getOperand(2).getReg()) : nullptr;
+    MachineInstr *Init =
+        I.getNumExplicitOperands() > 2
+            ? MIRBuilder.getMRI()->getVRegDef(I.getOperand(2).getReg())
+            : nullptr;
     assert(MI);
     return selectGlobalValue(MI->getOperand(0).getReg(), *MI, MIRBuilder, Init);
   } break;
   case Intrinsic::spv_const_composite: {
     // If no values are attached, the composite is null constant.
     auto IsNull = I.getNumExplicitDefs() + 1 == I.getNumExplicitOperands();
-    auto MIB = MIRBuilder.buildInstr(IsNull ? SPIRV::OpConstantNull
-                                            : SPIRV::OpConstantComposite)
-                   .addDef(resVReg)
-                   .addUse(TR.getSPIRVTypeID(resType));
+    auto MIB = MIRBuilder
+                   .buildInstr(IsNull ? SPIRV::OpConstantNull
+                                      : SPIRV::OpConstantComposite)
+                   .addDef(ResVReg)
+                   .addUse(TR.getSPIRVTypeID(ResType));
     // skip type MD node we already used when generated assign.type for this
     if (!IsNull) {
       for (unsigned i = I.getNumExplicitDefs() + 1;
@@ -1491,11 +1493,11 @@ bool SPIRVInstructionSelector::selectIntrinsic(
 }
 
 bool SPIRVInstructionSelector::selectFrameIndex(
-    Register resVReg, const SPIRVType *resType,
+    Register ResVReg, const SPIRVType *ResType,
     MachineIRBuilder &MIRBuilder) const {
   return MIRBuilder.buildInstr(SPIRV::OpVariable)
-      .addDef(resVReg)
-      .addUse(TR.getSPIRVTypeID(resType))
+      .addDef(ResVReg)
+      .addUse(TR.getSPIRVTypeID(ResType))
       .addImm(StorageClass::Function)
       .constrainAllUses(TII, TRI, RBI);
 }
@@ -1506,11 +1508,11 @@ bool SPIRVInstructionSelector::selectBranch(
   // both a G_BR and a G_BRCOND to create an OpBranchConditional. We hit G_BR
   // first, so can generate an OpBranchConditional here. If there is no
   // G_BRCOND, we just use OpBranch for a regular unconditional branch.
-  const MachineInstr *prevI = I.getPrevNode();
-  if (prevI != nullptr && prevI->getOpcode() == TargetOpcode::G_BRCOND) {
+  const MachineInstr *PrevI = I.getPrevNode();
+  if (PrevI != nullptr && PrevI->getOpcode() == TargetOpcode::G_BRCOND) {
     return MIRBuilder.buildInstr(SPIRV::OpBranchConditional)
-        .addUse(prevI->getOperand(0).getReg())
-        .addMBB(prevI->getOperand(1).getMBB())
+        .addUse(PrevI->getOperand(0).getReg())
+        .addMBB(PrevI->getOperand(1).getMBB())
         .addMBB(I.getOperand(0).getMBB())
         .constrainAllUses(TII, TRI, RBI);
   } else {
@@ -1532,33 +1534,33 @@ bool SPIRVInstructionSelector::selectBranchCond(
   // implicit fallthrough to the next basic block, so we need to create an
   // OpBranchConditional with an explicit "false" argument pointing to the next
   // basic block that LLVM would fall through to.
-  const MachineInstr *nextI = I.getNextNode();
+  const MachineInstr *NextI = I.getNextNode();
   // Check if this has already been successfully selected
-  if (nextI != nullptr && nextI->getOpcode() == SPIRV::OpBranchConditional) {
+  if (NextI != nullptr && NextI->getOpcode() == SPIRV::OpBranchConditional) {
     return true;
   } else {
     // Must be relying on implicit block fallthrough, so generate an
     // OpBranchConditional with the "next" basic block as the "false" target.
-    auto nextMBBNum = I.getParent()->getNextNode()->getNumber();
-    auto nextMBB = I.getMF()->getBlockNumbered(nextMBBNum);
+    auto NextMBBNum = I.getParent()->getNextNode()->getNumber();
+    auto NextMBB = I.getMF()->getBlockNumbered(NextMBBNum);
     return MIRBuilder.buildInstr(SPIRV::OpBranchConditional)
         .addUse(I.getOperand(0).getReg())
         .addMBB(I.getOperand(1).getMBB())
-        .addMBB(nextMBB)
+        .addMBB(NextMBB)
         .constrainAllUses(TII, TRI, RBI);
   }
 }
 
-bool SPIRVInstructionSelector::selectPhi(Register resVReg,
-                                         const SPIRVType *resType,
+bool SPIRVInstructionSelector::selectPhi(Register ResVReg,
+                                         const SPIRVType *ResType,
                                          const MachineInstr &I,
                                          MachineIRBuilder &MIRBuilder) const {
   auto MIB = MIRBuilder.buildInstr(SPIRV::OpPhi)
-                 .addDef(resVReg)
-                 .addUse(TR.getSPIRVTypeID(resType));
-  const unsigned int numOps = I.getNumOperands();
-  assert((numOps % 2 == 1) && "Require odd number of operands for G_PHI");
-  for (unsigned int i = 1; i < numOps; i += 2) {
+                 .addDef(ResVReg)
+                 .addUse(TR.getSPIRVTypeID(ResType));
+  const unsigned int NumOps = I.getNumOperands();
+  assert((NumOps % 2 == 1) && "Require odd number of operands for G_PHI");
+  for (unsigned int i = 1; i < NumOps; i += 2) {
     MIB.addUse(I.getOperand(i + 0).getReg());
     MIB.addMBB(I.getOperand(i + 1).getMBB());
   }
@@ -1585,12 +1587,14 @@ bool SPIRVInstructionSelector::selectGlobalValue(
   auto AddrSpace = GV->getAddressSpace();
   auto Storage = TR.addressSpaceToStorageClass(AddrSpace);
   bool HasLnkTy = GV->getLinkage() != GlobalValue::InternalLinkage &&
-      Storage != StorageClass::Function;
-  auto LnkType = (GV->isDeclaration() || GV->hasAvailableExternallyLinkage()) ?
-                 LinkageType::Import : LinkageType::Export;
+                  Storage != StorageClass::Function;
+  auto LnkType = (GV->isDeclaration() || GV->hasAvailableExternallyLinkage())
+                     ? LinkageType::Import
+                     : LinkageType::Export;
 
   auto Reg = TR.buildGlobalVariable(ResVReg, ResType, GlobalIdent, GV, Storage,
-    Init, GlobalVar && GlobalVar->isConstant(), HasLnkTy, LnkType, MIRBuilder);
+                                    Init, GlobalVar && GlobalVar->isConstant(),
+                                    HasLnkTy, LnkType, MIRBuilder);
   return Reg.isValid();
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.h
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.h
@@ -26,9 +26,10 @@ class SPIRVSubtarget;
 class SPIRVLegalizerInfo : public LegalizerInfo {
   const SPIRVSubtarget *ST;
   SPIRVTypeRegistry *TR;
+
 public:
   bool legalizeCustom(LegalizerHelper &Helper, MachineInstr &MI) const override;
   SPIRVLegalizerInfo(const SPIRVSubtarget &ST);
 };
 } // namespace llvm
-#endif
+#endif // LLVM_LIB_TARGET_SPIRV_SPIRVMACHINELEGALIZER_H

--- a/llvm/lib/Target/SPIRV/SPIRVStringReader.h
+++ b/llvm/lib/Target/SPIRV/SPIRVStringReader.h
@@ -22,20 +22,20 @@
 // Return a string representation of the operands from startIndex onwards.
 // Templated to allow both MachineInstr and MCInst to use the same logic.
 template <class InstType>
-std::string getSPIRVStringOperand(const InstType &MI, unsigned int startIndex) {
+std::string getSPIRVStringOperand(const InstType &MI, unsigned int StartIndex) {
   std::string s = ""; // Iteratively append to this string
 
-  const unsigned int numOps = MI.getNumOperands();
-  bool isFinished = false;
-  for (unsigned int i = startIndex; i < numOps && !isFinished; ++i) {
+  const unsigned int NumOps = MI.getNumOperands();
+  bool IsFinished = false;
+  for (unsigned int i = StartIndex; i < NumOps && !IsFinished; ++i) {
     const auto &Op = MI.getOperand(i);
     if (!Op.isImm()) // Stop if we hit a register operand
       break;
-    uint32_t imm = Op.getImm(); // Each i32 word is up to 4 characters
+    uint32_t Imm = Op.getImm(); // Each i32 word is up to 4 characters
     for (unsigned shiftAmount = 0; shiftAmount < 32; shiftAmount += 8) {
-      char c = (imm >> shiftAmount) & 0xff;
+      char c = (Imm >> shiftAmount) & 0xff;
       if (c == 0) { // Stop if we hit a null-terminator character
-        isFinished = true;
+        IsFinished = true;
         break;
       } else {
         s += c; // Otherwise, append the character to the result string

--- a/llvm/lib/Target/SPIRV/SPIRVStrings.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVStrings.cpp
@@ -23,48 +23,48 @@ using namespace llvm;
 // Add the given string as a series of integer operands, inserting null
 // terminators and padding to make sure the operands all have 32-bit
 // little-endian words
-void addStringImm(const StringRef &str, MachineInstrBuilder &MIB) {
+void addStringImm(const StringRef &Str, MachineInstrBuilder &MIB) {
   // Get length including padding and null terminator
-  const size_t len = str.size() + 1;
-  const size_t paddedLen = (len % 4 == 0) ? len : len + (4 - (len % 4));
-  for (unsigned i = 0; i < paddedLen; i += 4) {
-    uint32_t word = 0u; // Build up this 32-bit word from 4 8-bit chars
-    for (unsigned wordIndex = 0; wordIndex < 4; ++wordIndex) {
-      unsigned strIndex = i + wordIndex;
-      uint8_t charToAdd = 0; // Initilize char as padding/null
-      if (strIndex < (len - 1)) { // If it's within the string, get a real char
-        charToAdd = str[strIndex];
+  const size_t Len = Str.size() + 1;
+  const size_t PaddedLen = (Len % 4 == 0) ? Len : Len + (4 - (Len % 4));
+  for (unsigned i = 0; i < PaddedLen; i += 4) {
+    uint32_t Word = 0u; // Build up this 32-bit word from 4 8-bit chars
+    for (unsigned WordIndex = 0; WordIndex < 4; ++WordIndex) {
+      unsigned StrIndex = i + WordIndex;
+      uint8_t CharToAdd = 0;      // Initilize char as padding/null
+      if (StrIndex < (Len - 1)) { // If it's within the string, get a real char
+        CharToAdd = Str[StrIndex];
       }
-      word |= (charToAdd << (wordIndex * 8));
+      Word |= (CharToAdd << (WordIndex * 8));
     }
-    MIB.addImm(word); // Add an operand for the 32-bits of chars or padding
+    MIB.addImm(Word); // Add an operand for the 32-bits of chars or padding
   }
 }
 
-void addStringImm(const StringRef &str, IRBuilder<> &B,
+void addStringImm(const StringRef &Str, IRBuilder<> &B,
                   std::vector<Value *> &Args) {
   // Get length including padding and null terminator
-  const size_t len = str.size() + 1;
-  const size_t paddedLen = (len % 4 == 0) ? len : len + (4 - (len % 4));
-  for (unsigned i = 0; i < paddedLen; i += 4) {
-    uint32_t word = 0u; // Build up this 32-bit word from 4 8-bit chars
-    for (unsigned wordIndex = 0; wordIndex < 4; ++wordIndex) {
-      unsigned strIndex = i + wordIndex;
-      uint8_t charToAdd = 0;      // Initilize char as padding/null
-      if (strIndex < (len - 1)) { // If it's within the string, get a real char
-        charToAdd = str[strIndex];
+  const size_t Len = Str.size() + 1;
+  const size_t PaddedLen = (Len % 4 == 0) ? Len : Len + (4 - (Len % 4));
+  for (unsigned i = 0; i < PaddedLen; i += 4) {
+    uint32_t Word = 0u; // Build up this 32-bit word from 4 8-bit chars
+    for (unsigned WordIndex = 0; WordIndex < 4; ++WordIndex) {
+      unsigned StrIndex = i + WordIndex;
+      uint8_t CharToAdd = 0;      // Initilize char as padding/null
+      if (StrIndex < (Len - 1)) { // If it's within the string, get a real char
+        CharToAdd = Str[StrIndex];
       }
-      word |= (charToAdd << (wordIndex * 8));
+      Word |= (CharToAdd << (WordIndex * 8));
     }
     Args.push_back(
-        B.getInt32(word)); // Add an operand for the 32-bits of chars or padding
+        B.getInt32(Word)); // Add an operand for the 32-bits of chars or padding
   }
 }
 
 // Read the series of integer operands back as a null-terminated string using
 // the reverse of the logic in addStringImm
-std::string getStringImm(const MachineInstr &MI, unsigned int startIndex) {
-  return getSPIRVStringOperand(MI, startIndex);
+std::string getStringImm(const MachineInstr &MI, unsigned int StartIndex) {
+  return getSPIRVStringOperand(MI, StartIndex);
 }
 
 void addNumImm(const APInt &Imm, MachineInstrBuilder &MIB, bool IsFloat) {
@@ -93,20 +93,18 @@ void addNumImm(const APInt &Imm, MachineInstrBuilder &MIB, bool IsFloat) {
 }
 
 // Add an OpName instruction for the given target register
-void buildOpName(Register target, const StringRef &name,
+void buildOpName(Register Target, const StringRef &Name,
                  MachineIRBuilder &MIRBuilder) {
-  if (!name.empty()) {
-    auto MIB = MIRBuilder.buildInstr(SPIRV::OpName).addUse(target);
-    addStringImm(name, MIB);
+  if (!Name.empty()) {
+    auto MIB = MIRBuilder.buildInstr(SPIRV::OpName).addUse(Target);
+    addStringImm(Name, MIB);
   }
 }
 
 void buildOpDecorate(Register Reg, MachineIRBuilder &MIRBuilder,
-    Decoration::Decoration Dec, const std::vector<uint32_t> &DecArgs,
-    StringRef StrImm) {
-  auto MIB = MIRBuilder.buildInstr(SPIRV::OpDecorate)
-                 .addUse(Reg)
-                 .addImm(Dec);
+                     Decoration::Decoration Dec,
+                     const std::vector<uint32_t> &DecArgs, StringRef StrImm) {
+  auto MIB = MIRBuilder.buildInstr(SPIRV::OpDecorate).addUse(Reg).addImm(Dec);
   if (!StrImm.empty())
     addStringImm(StrImm, MIB);
   for (const auto &DecArg : DecArgs)

--- a/llvm/lib/Target/SPIRV/SPIRVStrings.h
+++ b/llvm/lib/Target/SPIRV/SPIRVStrings.h
@@ -28,24 +28,25 @@
 // Add the given string as a series of integer operand, inserting null
 // terminators and padding to make sure the operands all have 32-bit
 // little-endian words
-void addStringImm(const llvm::StringRef &str, llvm::MachineInstrBuilder &MIB);
-void addStringImm(const llvm::StringRef &str, llvm::IRBuilder<> &B,
+void addStringImm(const llvm::StringRef &Str, llvm::MachineInstrBuilder &MIB);
+void addStringImm(const llvm::StringRef &Str, llvm::IRBuilder<> &B,
                   std::vector<llvm::Value *> &Args);
 
 // Read the series of integer operands back as a null-terminated string using
 // the reverse of the logic in addStringImm
-std::string getStringImm(const llvm::MachineInstr &MI, unsigned int startIndex);
+std::string getStringImm(const llvm::MachineInstr &MI, unsigned int StartIndex);
 
 // Add the given numerical immediate to MIB.
 void addNumImm(const llvm::APInt &Imm, llvm::MachineInstrBuilder &MIB,
                bool IsFloat = false);
 
 // Add an OpName instruction for the given target register
-void buildOpName(llvm::Register target, const llvm::StringRef &name,
+void buildOpName(llvm::Register Target, const llvm::StringRef &Name,
                  llvm::MachineIRBuilder &MIRBuilder);
 
 // Add an OpDecorate instruction for the given Reg.
 void buildOpDecorate(llvm::Register Reg, llvm::MachineIRBuilder &MIRBuilder,
-    Decoration::Decoration Dec, const std::vector<uint32_t> &DecArgs,
-    llvm::StringRef StrImm = "");
+                     Decoration::Decoration Dec,
+                     const std::vector<uint32_t> &DecArgs,
+                     llvm::StringRef StrImm = "");
 #endif

--- a/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVTypeRegistry.h
@@ -16,15 +16,15 @@
 #ifndef LLVM_LIB_TARGET_SPIRV_SPIRVTYPEMANAGER_H
 #define LLVM_LIB_TARGET_SPIRV_SPIRVTYPEMANAGER_H
 
-#include "SPIRVEnums.h"
 #include "SPIRVDuplicatesTracker.h"
+#include "SPIRVEnums.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 
 #include <unordered_set>
 
 namespace AQ = AccessQualifier;
 
-const std::unordered_set<unsigned>& getTypeFoldingSupportingOpcs();
+const std::unordered_set<unsigned> &getTypeFoldingSupportingOpcs();
 bool isTypeFoldingSupported(unsigned Opcode);
 
 namespace llvm {
@@ -35,7 +35,8 @@ class SPIRVTypeRegistry {
   // Initialized upon VReg definition in IRTranslator.
   // Do not confuse this with DuplicatesTracker as DT maps Type* to <MF, Reg>
   // where Reg = OpType...
-  // while VRegToTypeMap tracks SPIR-V type assigned to other regs (i.e. not type-declaring ones)
+  // while VRegToTypeMap tracks SPIR-V type assigned to other regs (i.e. not
+  // type-declaring ones)
   DenseMap<MachineFunction *, DenseMap<Register, SPIRVType *>> VRegToTypeMap;
 
   SPIRVGeneralDuplicatesTracker &DT;
@@ -62,25 +63,26 @@ class SPIRVTypeRegistry {
 
   // Look for an equivalent of the newType in the map. Return the equivalent
   // if it's found, otherwise insert newType to the map and return the type.
-  const MachineInstr *checkSpecialInstrMap(const MachineInstr *newInstr,
-                                           SpecialInstrMapTy &instrMap);
+  const MachineInstr *checkSpecialInstrMap(const MachineInstr *NewInstr,
+                                           SpecialInstrMapTy &InstrMap);
 
   // Number of bits pointers and size_t integers require.
-  const unsigned int pointerSize;
+  const unsigned int PointerSize;
 
   // Add a new OpTypeXXX instruction without checking for duplicates
-  SPIRVType *createSPIRVType(const Type *type, MachineIRBuilder &MIRBuilder,
+  SPIRVType *createSPIRVType(const Type *Type, MachineIRBuilder &MIRBuilder,
                              AQ::AccessQualifier accessQual = AQ::ReadWrite,
                              bool EmitIR = true);
   // Set SPIRVType for GV, propagate it to GV's users, set register classes.
-  SPIRVType *propagateSPIRVType(MachineInstr* MI, MachineRegisterInfo &MRI,
+  SPIRVType *propagateSPIRVType(MachineInstr *MI, MachineRegisterInfo &MRI,
                                 MachineIRBuilder &MIB);
+
 public:
   // Insert ASSIGN_TYPE instuction between Reg and its definition, set
   // NewReg as a dst of the definition, assign SPIRVType to both registers.
   // If SpirvTy is provided, use it as SPIRVType in ASSIGN_TYPE, otherwise
   // create it from Ty.
-  Register insertAssignInstr(Register Reg, Type* Ty, SPIRVType *SpirvTy,
+  Register insertAssignInstr(Register Reg, Type *Ty, SPIRVType *SpirvTy,
                              MachineIRBuilder &MIB, MachineRegisterInfo &MRI);
 
   // This interface is for walking the map in GlobalTypesAndRegNumPass.
@@ -88,7 +90,8 @@ public:
     return SpecialTypesAndConstsMap;
   }
 
-  SPIRVTypeRegistry(SPIRVGeneralDuplicatesTracker &DT, unsigned int pointerSize);
+  SPIRVTypeRegistry(SPIRVGeneralDuplicatesTracker &DT,
+                    unsigned int PointerSize);
 
   MachineFunction *CurMF;
 
@@ -96,13 +99,13 @@ public:
 
   // Get or create a SPIR-V type corresponding the given LLVM IR type,
   // and map it to the given VReg by creating an ASSIGN_TYPE instruction.
-  SPIRVType *assignTypeToVReg(const Type *type, Register VReg,
+  SPIRVType *assignTypeToVReg(const Type *Type, Register VReg,
                               MachineIRBuilder &MIRBuilder,
-                              AQ::AccessQualifier accessQual = AQ::ReadWrite);
+                              AQ::AccessQualifier AccessQual = AQ::ReadWrite);
 
   // In cases where the SPIR-V type is already known, this function can be
   // used to map it to the given VReg via an ASSIGN_TYPE instruction.
-  void assignSPIRVTypeToVReg(SPIRVType *type, Register VReg,
+  void assignSPIRVTypeToVReg(SPIRVType *Type, Register VReg,
                              MachineIRBuilder &MIRBuilder);
 
   // Either generate a new OpTypeXXX instruction or return an existing one
@@ -111,7 +114,7 @@ public:
   // because this method may be called from InstructionSelector and we don't
   // want to emit extra IR instructions there
   SPIRVType *
-  getOrCreateSPIRVType(const Type *type, MachineIRBuilder &MIRBuilder,
+  getOrCreateSPIRVType(const Type *Type, MachineIRBuilder &MIRBuilder,
                        AQ::AccessQualifier accessQual = AQ ::ReadWrite,
                        bool EmitIR = true);
 
@@ -123,8 +126,8 @@ public:
 
   // Either generate a new OpTypeXXX instruction or return an existing one
   // corresponding to the given string containing the name of the builtin type.
-  SPIRVType *
-  getOrCreateSPIRVTypeByName(StringRef typeStr, MachineIRBuilder &MIRBuilder);
+  SPIRVType *getOrCreateSPIRVTypeByName(StringRef TypeStr,
+                                        MachineIRBuilder &MIRBuilder);
 
   // Return the SPIR-V type instruction corresponding to the given VReg, or
   // nullptr if no such type instruction exists.
@@ -136,115 +139,118 @@ public:
   }
 
   // Return the VReg holding the result of the given OpTypeXXX instruction
-  Register getSPIRVTypeID(const SPIRVType *spirvType) const {
-    assert(spirvType && "Attempting to get type id for nullptr type.");
-    return spirvType->defs().begin()->getReg();
+  Register getSPIRVTypeID(const SPIRVType *SpirvType) const {
+    assert(SpirvType && "Attempting to get type id for nullptr type.");
+    return SpirvType->defs().begin()->getReg();
   }
 
   void setCurrentFunc(MachineFunction &MF) { CurMF = &MF; }
 
   // Whether the given VReg has an OpTypeXXX instruction mapped to it with the
   // given opcode (e.g. OpTypeFloat).
-  bool isScalarOfType(Register vreg, unsigned int typeOpcode) const;
+  bool isScalarOfType(Register VReg, unsigned int TypeOpcode) const;
 
   // Return true if the given VReg's assigned SPIR-V type is either a scalar
   // matching the given opcode, or a vector with an element type matching that
   // opcode (e.g. OpTypeBool, or OpTypeVector %x 4, where %x is OpTypeBool).
-  bool isScalarOrVectorOfType(Register vreg, unsigned int typeOpcode) const;
+  bool isScalarOrVectorOfType(Register VReg, unsigned int TypeOpcode) const;
 
   // For vectors or scalars of ints or floats, return the scalar type's bitwidth
-  unsigned getScalarOrVectorBitWidth(const SPIRVType *type) const;
+  unsigned getScalarOrVectorBitWidth(const SPIRVType *Type) const;
 
   // For integer vectors or scalars, return whether the integers are signed
-  bool isScalarOrVectorSigned(const SPIRVType *type) const;
+  bool isScalarOrVectorSigned(const SPIRVType *Type) const;
 
   // Gets the storage class of the pointer type assigned to this vreg
-  StorageClass::StorageClass getPointerStorageClass(Register vreg) const;
+  StorageClass::StorageClass getPointerStorageClass(Register VReg) const;
 
   // Return the number of bits SPIR-V pointers and size_t variables require.
-  unsigned getPointerSize() const { return pointerSize; }
+  unsigned getPointerSize() const { return PointerSize; }
 
 private:
   // Internal methods for creating types which are unsafe in duplications
   // check sense hence can only be called within getOrCreateSPIRVType callstack
   SPIRVType *getSamplerType(MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *getSampledImageType(SPIRVType *imageType,
+  SPIRVType *getSampledImageType(SPIRVType *ImageType,
                                  MachineIRBuilder &MIRBuilder);
 
   SPIRVType *getOpTypeBool(MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *getOpTypeInt(uint32_t width, MachineIRBuilder &MIRBuilder,
-                          bool isSigned = false);
+  SPIRVType *getOpTypeInt(uint32_t Width, MachineIRBuilder &MIRBuilder,
+                          bool IsSigned = false);
 
-  SPIRVType *getOpTypeFloat(uint32_t width, MachineIRBuilder &MIRBuilder);
+  SPIRVType *getOpTypeFloat(uint32_t Width, MachineIRBuilder &MIRBuilder);
 
   SPIRVType *getOpTypeVoid(MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *getOpTypeVector(uint32_t numElems, SPIRVType *elemType,
+  SPIRVType *getOpTypeVector(uint32_t NumElems, SPIRVType *ElemType,
                              MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *getOpTypeArray(uint32_t numElems, SPIRVType *elemType,
-                            MachineIRBuilder &MIRBuilder,
-                            bool EmitIR = true);
+  SPIRVType *getOpTypeArray(uint32_t NumElems, SPIRVType *ElemType,
+                            MachineIRBuilder &MIRBuilder, bool EmitIR = true);
 
   SPIRVType *getOpTypeOpaque(const StructType *Ty,
                              MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *getOpTypeStruct(const StructType *Ty,
-                             MachineIRBuilder &MIRBuilder, bool EmitIR = true);
+  SPIRVType *getOpTypeStruct(const StructType *Ty, MachineIRBuilder &MIRBuilder,
+                             bool EmitIR = true);
 
-  SPIRVType *getOpTypePointer(StorageClass::StorageClass sc,
-                              SPIRVType *elemType,
+  SPIRVType *getOpTypePointer(StorageClass::StorageClass SC,
+                              SPIRVType *ElemType,
                               MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *getOpTypeFunction(SPIRVType *retType,
-                               const SmallVectorImpl<SPIRVType *> &argTypes,
+  SPIRVType *getOpTypeFunction(SPIRVType *RetType,
+                               const SmallVectorImpl<SPIRVType *> &ArgTypes,
                                MachineIRBuilder &MIRBuilder);
 
   SPIRVType *getOpTypeImage(MachineIRBuilder &MIRBuilder,
-                            SPIRVType *sampledType, Dim::Dim dim,
-                            uint32_t depth, uint32_t arrayed,
-                            uint32_t multisampled, uint32_t sampled,
-                            ImageFormat::ImageFormat imageFormat,
-                            AQ::AccessQualifier accessQualifier);
+                            SPIRVType *SampledType, Dim::Dim Dim,
+                            uint32_t Depth, uint32_t Arrayed,
+                            uint32_t Multisampled, uint32_t Sampled,
+                            ImageFormat::ImageFormat ImageFormat,
+                            AQ::AccessQualifier AccQual);
 
   SPIRVType *getOpTypePipe(MachineIRBuilder &MIRBuilder,
-                           AQ::AccessQualifier accessQualifier);
+                           AQ::AccessQualifier AccQual);
 
   SPIRVType *getOpTypeByOpcode(MachineIRBuilder &MIRBuilder,
-                               unsigned int opcode);
+                               unsigned int Opcode);
 
   SPIRVType *handleOpenCLBuiltin(const StructType *Ty,
                                  MachineIRBuilder &MIRBuilder,
-                                 AQ::AccessQualifier aq);
+                                 AQ::AccessQualifier AccQual);
 
-  SPIRVType *generateOpenCLOpaqueType(const StructType *Ty,
-                                      MachineIRBuilder &MIRBuilder,
-                                      AQ::AccessQualifier aq = AQ::ReadWrite);
+  SPIRVType *
+  generateOpenCLOpaqueType(const StructType *Ty, MachineIRBuilder &MIRBuilder,
+                           AQ::AccessQualifier AccQual = AQ::ReadWrite);
 
   SPIRVType *handleSPIRVBuiltin(const StructType *Ty,
                                 MachineIRBuilder &MIRBuilder,
-                                AQ::AccessQualifier aq);
+                                AQ::AccessQualifier AccQual);
 
-  SPIRVType *generateSPIRVOpaqueType(const StructType *Ty,
-                                     MachineIRBuilder &MIRBuilder,
-                                     AQ::AccessQualifier aq = AQ::ReadWrite);
+  SPIRVType *
+  generateSPIRVOpaqueType(const StructType *Ty, MachineIRBuilder &MIRBuilder,
+                          AQ::AccessQualifier AccQual = AQ::ReadWrite);
+
 public:
-  Register buildConstantInt(uint64_t val, MachineIRBuilder &MIRBuilder,
-                            SPIRVType *spvType = nullptr,
-                            bool EmitIR = true);
-  Register buildConstantFP(APFloat val, MachineIRBuilder &MIRBuilder,
-                           SPIRVType *spvType = nullptr);
-  Register buildConstantIntVector(uint64_t val, MachineIRBuilder &MIRBuilder,
-                           SPIRVType *spvType);
-  Register buildConstantSampler(Register res, unsigned int addrMode,
-      unsigned int param, unsigned int filerMode,
-      MachineIRBuilder &MIRBuilder, SPIRVType *spvType);
+  Register buildConstantInt(uint64_t Val, MachineIRBuilder &MIRBuilder,
+                            SPIRVType *SpvType = nullptr, bool EmitIR = true);
+  Register buildConstantFP(APFloat Val, MachineIRBuilder &MIRBuilder,
+                           SPIRVType *SpvType = nullptr);
+  Register buildConstantIntVector(uint64_t Val, MachineIRBuilder &MIRBuilder,
+                                  SPIRVType *SpvType);
+  Register buildConstantSampler(Register Res, unsigned int AddrMode,
+                                unsigned int Param, unsigned int FilerMode,
+                                MachineIRBuilder &MIRBuilder,
+                                SPIRVType *SpvType);
   Register buildGlobalVariable(Register Reg, SPIRVType *BaseType,
-      StringRef Name, const GlobalValue *GV, StorageClass::StorageClass Storage,
-      const MachineInstr *Init, bool IsConst,  bool HasLinkageTy,
-      LinkageType::LinkageType LinkageType, MachineIRBuilder &MIRBuilder);
+                               StringRef Name, const GlobalValue *GV,
+                               StorageClass::StorageClass Storage,
+                               const MachineInstr *Init, bool IsConst,
+                               bool HasLinkageTy,
+                               LinkageType::LinkageType LinkageType,
+                               MachineIRBuilder &MIRBuilder);
 
   // convenient helpers for getting types
   // w/ check for duplicates
@@ -257,18 +263,19 @@ public:
   SPIRVType *getOrCreateSPIRVPointerType(
       SPIRVType *BaseType, MachineIRBuilder &MIRBuilder,
       StorageClass::StorageClass SClass = StorageClass::Function);
-  SPIRVType *getOrCreateSPIRVSampledImageType(SPIRVType *imageType,
+  SPIRVType *getOrCreateSPIRVSampledImageType(SPIRVType *ImageType,
                                               MachineIRBuilder &MIRBuilder);
   // Convert a SPIR-V storage class to the corresponding LLVM IR address space.
-  unsigned int StorageClassToAddressSpace(StorageClass::StorageClass sc);
+  unsigned int StorageClassToAddressSpace(StorageClass::StorageClass SC);
 
   // Convert an LLVM IR address space to a SPIR-V storage class.
   StorageClass::StorageClass
-  addressSpaceToStorageClass(unsigned int addressSpace);
+  addressSpaceToStorageClass(unsigned int AddressSpace);
 
   // Utility method to constrain an instruction's operands to the correct
   // register classes, and return true if this worked.
-  bool constrainRegOperands(MachineInstrBuilder &MIB, MachineFunction *MF = nullptr) const;
+  bool constrainRegOperands(MachineInstrBuilder &MIB,
+                            MachineFunction *MF = nullptr) const;
 };
 } // end namespace llvm
 #endif // LLLVM_LIB_TARGET_SPIRV_SPIRVTYPEMANAGER_H


### PR DESCRIPTION
The patch corrects names and ran clang-format for the following files:
```
SPIRVGlobalTypesAndRegNumPass.cpp
SPIRVIRTranslator.cpp
SPIRVInstructionSelector.cpp
SPIRVLegalizerInfo.cpp
SPIRVLegalizerInfo.h
SPIRVStringReader.h
SPIRVStrings.cpp
SPIRVStrings.h
SPIRVTypeRegistry.cpp
SPIRVTypeRegistry.h
```
