### PR TITLE
[SPIR-V] move extraneous code from SPIRVTypeRegistry, rename it

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.h
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.h
@@ -13,22 +13,22 @@
 #ifndef LLVM_LIB_TARGET_SPIRV_SPIRVCALLLOWERING_H
 #define LLVM_LIB_TARGET_SPIRV_SPIRVCALLLOWERING_H
 
-#include "SPIRVDuplicatesTracker.h"
+#include "SPIRVGlobalRegistry.h"
 #include "llvm/CodeGen/GlobalISel/CallLowering.h"
 
 namespace llvm {
 
-class SPIRVTypeRegistry;
+class SPIRVGlobalRegistry;
 class SPIRVTargetLowering;
 
 class SPIRVCallLowering : public CallLowering {
 private:
   // Used to create and assign function, argument, and return type information
-  SPIRVTypeRegistry *TR;
+  SPIRVGlobalRegistry *GR;
   SPIRVGeneralDuplicatesTracker *DT;
 
 public:
-  SPIRVCallLowering(const SPIRVTargetLowering &TLI, SPIRVTypeRegistry *TR,
+  SPIRVCallLowering(const SPIRVTargetLowering &TLI, SPIRVGlobalRegistry *GR,
                     SPIRVGeneralDuplicatesTracker *DT);
 
   // Built OpReturn or OpReturnValue

--- a/llvm/lib/Target/SPIRV/SPIRVEnums.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEnums.cpp
@@ -74,26 +74,6 @@ GEN_ENUM_IMPL(GroupOperation)
 GEN_ENUM_IMPL(KernelEnqueueFlags)
 GEN_MASK_ENUM_IMPL(KernelProfilingInfo)
 
-namespace MS = MemorySemantics;
-namespace SC = StorageClass;
-MS::MemorySemantics getMemSemanticsForStorageClass(SC::StorageClass sc) {
-  switch (sc) {
-  case SC::StorageBuffer:
-  case SC::Uniform:
-    return MS::UniformMemory;
-  case SC::Workgroup:
-    return MS::WorkgroupMemory;
-  case SC::CrossWorkgroup:
-    return MS::CrossWorkgroupMemory;
-  case SC::AtomicCounter:
-    return MS::AtomicCounterMemory;
-  case SC::Image:
-    return MS::ImageMemory;
-  default:
-    return MS::None;
-  }
-}
-
 DEF_BUILTIN_LINK_STR_FUNC_BODY()
 
 GEN_EXTENSION_IMPL(Extension)

--- a/llvm/lib/Target/SPIRV/SPIRVEnums.h
+++ b/llvm/lib/Target/SPIRV/SPIRVEnums.h
@@ -82,15 +82,14 @@
 
 #define GEN_ENUM_HEADER(EnumName)                                              \
   DEF_ENUM(EnumName, DEF_##EnumName)                                           \
-  DEF_NAME_FUNC_HEADER(EnumName)                                               \
+  DEF_NAME_FUNC_HEADER(EnumName)
 
 // Use this for enums that can only take a single value
-#define GEN_ENUM_IMPL(EnumName)                                                \
-  DEF_NAME_FUNC_BODY(EnumName, DEF_##EnumName)                                 \
+#define GEN_ENUM_IMPL(EnumName) DEF_NAME_FUNC_BODY(EnumName, DEF_##EnumName)
 
 // Use this for bitmasks that can take multiple values e.g. DontInline|Const
 #define GEN_MASK_ENUM_IMPL(EnumName)                                           \
-  DEF_MASK_NAME_FUNC_BODY(EnumName, DEF_##EnumName)                            \
+  DEF_MASK_NAME_FUNC_BODY(EnumName, DEF_##EnumName)
 
 #define GEN_INSTR_PRINTER_IMPL(EnumName)                                       \
   void SPIRVInstPrinter::print##EnumName(const MCInst *MI, unsigned OpNo,      \
@@ -812,9 +811,6 @@ GEN_ENUM_HEADER(KernelEnqueueFlags)
   X(N, None, 0x0, {}, {}, 0, 0)                                                \
   X(N, CmdExecTime, 0x1, {Kernel}, {}, 0, 0)
 GEN_ENUM_HEADER(KernelProfilingInfo)
-
-MemorySemantics::MemorySemantics
-getMemSemanticsForStorageClass(StorageClass::StorageClass sc);
 
 const char *getLinkStrForBuiltIn(BuiltIn::BuiltIn builtIn);
 

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -1,4 +1,4 @@
-//===-- SPIRVTypeRegistry.h - SPIR-V Type Registry --------------*- C++ -*-===//
+//===-- SPIRVGlobalRegistry.h - SPIR-V Global Registry ----------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,10 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// SPIRVTypeRegistry is used to maintain rich type information required for
+// SPIRVGlobalRegistry is used to maintain rich type information required for
 // SPIR-V even after lowering from LLVM IR to GMIR. It can convert an llvm::Type
-// into an OpTypeXXX instruction, and map it to a virtual register using and
-// ASSIGN_TYPE pseudo instruction.
+// into an OpTypeXXX instruction, and map it to a virtual register. Also it
+// builds and supports consistency of constants and global variables.
 //
 //===----------------------------------------------------------------------===//
 
@@ -20,17 +20,12 @@
 #include "SPIRVEnums.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 
-#include <unordered_set>
-
 namespace AQ = AccessQualifier;
-
-const std::unordered_set<unsigned> &getTypeFoldingSupportingOpcs();
-bool isTypeFoldingSupported(unsigned Opcode);
 
 namespace llvm {
 using SPIRVType = const MachineInstr;
 
-class SPIRVTypeRegistry {
+class SPIRVGlobalRegistry {
   // Registers holding values which have types associated with them.
   // Initialized upon VReg definition in IRTranslator.
   // Do not confuse this with DuplicatesTracker as DT maps Type* to <MF, Reg>
@@ -73,29 +68,17 @@ class SPIRVTypeRegistry {
   SPIRVType *createSPIRVType(const Type *Type, MachineIRBuilder &MIRBuilder,
                              AQ::AccessQualifier accessQual = AQ::ReadWrite,
                              bool EmitIR = true);
-  // Set SPIRVType for GV, propagate it to GV's users, set register classes.
-  SPIRVType *propagateSPIRVType(MachineInstr *MI, MachineRegisterInfo &MRI,
-                                MachineIRBuilder &MIB);
 
 public:
-  // Insert ASSIGN_TYPE instuction between Reg and its definition, set
-  // NewReg as a dst of the definition, assign SPIRVType to both registers.
-  // If SpirvTy is provided, use it as SPIRVType in ASSIGN_TYPE, otherwise
-  // create it from Ty.
-  Register insertAssignInstr(Register Reg, Type *Ty, SPIRVType *SpirvTy,
-                             MachineIRBuilder &MIB, MachineRegisterInfo &MRI);
-
   // This interface is for walking the map in GlobalTypesAndRegNumPass.
   SpecialInstrMapTy &getSpecialTypesAndConstsMap() {
     return SpecialTypesAndConstsMap;
   }
 
-  SPIRVTypeRegistry(SPIRVGeneralDuplicatesTracker &DT,
-                    unsigned int PointerSize);
+  SPIRVGlobalRegistry(SPIRVGeneralDuplicatesTracker &DT,
+                      unsigned int PointerSize);
 
   MachineFunction *CurMF;
-
-  void generateAssignInstrs(MachineFunction &MF);
 
   // Get or create a SPIR-V type corresponding the given LLVM IR type,
   // and map it to the given VReg by creating an ASSIGN_TYPE instruction.
@@ -115,7 +98,7 @@ public:
   // want to emit extra IR instructions there
   SPIRVType *
   getOrCreateSPIRVType(const Type *Type, MachineIRBuilder &MIRBuilder,
-                       AQ::AccessQualifier accessQual = AQ ::ReadWrite,
+                       AQ::AccessQualifier accessQual = AQ::ReadWrite,
                        bool EmitIR = true);
 
   const Type *getTypeForSPIRVType(const SPIRVType *Ty) const {
@@ -252,8 +235,7 @@ public:
                                LinkageType::LinkageType LinkageType,
                                MachineIRBuilder &MIRBuilder);
 
-  // convenient helpers for getting types
-  // w/ check for duplicates
+  // Convenient helpers for getting types with check for duplicates.
   SPIRVType *getOrCreateSPIRVIntegerType(unsigned BitWidth,
                                          MachineIRBuilder &MIRBuilder);
   SPIRVType *getOrCreateSPIRVBoolType(MachineIRBuilder &MIRBuilder);
@@ -265,17 +247,6 @@ public:
       StorageClass::StorageClass SClass = StorageClass::Function);
   SPIRVType *getOrCreateSPIRVSampledImageType(SPIRVType *ImageType,
                                               MachineIRBuilder &MIRBuilder);
-  // Convert a SPIR-V storage class to the corresponding LLVM IR address space.
-  unsigned int StorageClassToAddressSpace(StorageClass::StorageClass SC);
-
-  // Convert an LLVM IR address space to a SPIR-V storage class.
-  StorageClass::StorageClass
-  addressSpaceToStorageClass(unsigned int AddressSpace);
-
-  // Utility method to constrain an instruction's operands to the correct
-  // register classes, and return true if this worked.
-  bool constrainRegOperands(MachineInstrBuilder &MIB,
-                            MachineFunction *MF = nullptr) const;
 };
 } // end namespace llvm
 #endif // LLLVM_LIB_TARGET_SPIRV_SPIRVTYPEMANAGER_H

--- a/llvm/lib/Target/SPIRV/SPIRVIRTranslator.h
+++ b/llvm/lib/Target/SPIRV/SPIRVIRTranslator.h
@@ -9,7 +9,7 @@
 // Overrides GlobalISel's IRTranslator to customize default lowering behavior.
 // This is mostly to stop aggregate types like Structs from getting expanded
 // into scalars, and to maintain type information required for SPIR-V using the
-// SPIRVTypeRegistry before it gets discarded as LLVM IR is lowered to GMIR.
+// SPIRVGlobalRegistry before it gets discarded as LLVM IR is lowered to GMIR.
 //
 //===----------------------------------------------------------------------===//
 
@@ -22,7 +22,7 @@
 namespace llvm {
 class SPIRVIRTranslator : public IRTranslator {
 private:
-  SPIRVTypeRegistry *TR;
+  SPIRVGlobalRegistry *GR;
   SPIRVGeneralDuplicatesTracker *DT;
 
   // Generate OpVariables with linkage data and their initializers if necessary

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.h
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.h
@@ -14,8 +14,9 @@
 #define LLVM_LIB_TARGET_SPIRV_SPIRVMACHINELEGALIZER_H
 
 #include "SPIRVGlobalRegistry.h"
-
 #include "llvm/CodeGen/GlobalISel/LegalizerInfo.h"
+
+bool isTypeFoldingSupported(unsigned Opcode);
 
 namespace llvm {
 
@@ -25,7 +26,7 @@ class SPIRVSubtarget;
 // This class provides the information for legalizing SPIR-V instructions.
 class SPIRVLegalizerInfo : public LegalizerInfo {
   const SPIRVSubtarget *ST;
-  SPIRVTypeRegistry *TR;
+  SPIRVGlobalRegistry *GR;
 
 public:
   bool legalizeCustom(LegalizerHelper &Helper, MachineInstr &MI) const override;

--- a/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.h
+++ b/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.h
@@ -25,7 +25,7 @@ bool generateOpenCLBuiltinCall(const StringRef demangledName,
                                MachineIRBuilder &MIRBuilder, Register OrigRet,
                                const Type *OrigRetTy,
                                const SmallVectorImpl<Register> &args,
-                               SPIRVTypeRegistry *TR);
+                               SPIRVGlobalRegistry *GR);
 bool getSpirvBuilInIdByName(StringRef Name, BuiltIn::BuiltIn &BI);
 } // end namespace llvm
 #endif

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
@@ -13,9 +13,9 @@
 #include "SPIRVSubtarget.h"
 #include "SPIRV.h"
 #include "SPIRVEnumRequirements.h"
+#include "SPIRVGlobalRegistry.h"
 #include "SPIRVLegalizerInfo.h"
 #include "SPIRVTargetMachine.h"
-#include "SPIRVGlobalRegistry.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Support/TargetRegistry.h"
 
@@ -77,8 +77,8 @@ SPIRVSubtarget::SPIRVSubtarget(const Triple &TT, const std::string &CPU,
       // .get() here is unsafe, works due to subtarget is destroyed
       // later than these objects
       // see comment in the SPIRVSubtarget.h
-      TR(new SPIRVTypeRegistry(*DT.get(), PointerSize)),
-      CallLoweringInfo(new SPIRVCallLowering(TLInfo, TR.get(), DT.get())),
+      GR(new SPIRVGlobalRegistry(*DT.get(), PointerSize)),
+      CallLoweringInfo(new SPIRVCallLowering(TLInfo, GR.get(), DT.get())),
       RegBankInfo(new SPIRVRegisterBankInfo()) {
 
   initAvailableExtensions(TT);

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.h
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.h
@@ -13,9 +13,15 @@
 #ifndef LLVM_LIB_TARGET_SPIRV_SPIRVSUBTARGET_H
 #define LLVM_LIB_TARGET_SPIRV_SPIRVSUBTARGET_H
 
+#include "SPIRVCallLowering.h"
+#include "SPIRVGlobalRegistry.h"
+#include "SPIRVEnums.h"
+#include "SPIRVExtInsts.h"
+#include "SPIRVExtensions.h"
 #include "SPIRVFrameLowering.h"
 #include "SPIRVISelLowering.h"
 #include "SPIRVInstrInfo.h"
+#include "SPIRVRegisterBankInfo.h"
 #include "llvm/CodeGen/GlobalISel/CallLowering.h"
 #include "llvm/CodeGen/GlobalISel/InstructionSelector.h"
 #include "llvm/CodeGen/GlobalISel/LegalizerInfo.h"
@@ -24,13 +30,6 @@
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/IR/DataLayout.h"
 #include "llvm/Target/TargetMachine.h"
-
-#include "SPIRVCallLowering.h"
-#include "SPIRVDuplicatesTracker.h"
-#include "SPIRVEnums.h"
-#include "SPIRVExtInsts.h"
-#include "SPIRVExtensions.h"
-#include "SPIRVRegisterBankInfo.h"
 
 #include <unordered_set>
 
@@ -41,7 +40,7 @@ namespace llvm {
 class StringRef;
 
 class SPIRVTargetMachine;
-class SPIRVTypeRegistry;
+class SPIRVGlobalRegistry;
 
 class SPIRVSubtarget : public SPIRVGenSubtargetInfo {
 private:
@@ -65,7 +64,7 @@ private:
   //      But they are shared with other classes, so if the SPIRVSubtarget
   //      moves, not relying on unique_ptr breaks things.
   std::unique_ptr<SPIRVGeneralDuplicatesTracker> DT;
-  std::unique_ptr<SPIRVTypeRegistry> TR;
+  std::unique_ptr<SPIRVGlobalRegistry> GR;
   std::unique_ptr<SPIRVCallLowering> CallLoweringInfo;
   std::unique_ptr<SPIRVRegisterBankInfo> RegBankInfo;
 
@@ -115,7 +114,7 @@ public:
   bool canUseExtension(Extension::Extension E) const;
   bool canUseExtInstSet(ExtInstSet E) const;
 
-  SPIRVTypeRegistry *getSPIRVTypeRegistry() const { return TR.get(); }
+  SPIRVGlobalRegistry *getSPIRVGlobalRegistry() const { return GR.get(); }
 
   SPIRVGeneralDuplicatesTracker *getSPIRVDuplicatesTracker() const {
     return DT.get();

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -207,7 +207,7 @@ bool SPIRVPassConfig::addRegBankSelect() {
 namespace {
 // A custom subclass of InstructionSelect, which is mostly the same except from
 // not requiring RegBankSelect to occur previously, and making sure a
-// SPIRVTypeRegistry is initialized before and reset after each run.
+// SPIRVGlobalRegistry is initialized before and reset after each run.
 class SPIRVInstructionSelect : public InstructionSelect {
 
   // We don't use register banks, so unset the requirement for them
@@ -216,11 +216,12 @@ class SPIRVInstructionSelect : public InstructionSelect {
         MachineFunctionProperties::Property::RegBankSelected);
   }
 
-  // Init a SPIRVTypeRegistry before and reset it after the default parent code
+  // Init a SPIRVGlobalRegistry before and reset it after the default
+  // parent code.
   bool runOnMachineFunction(MachineFunction &MF) override {
     const auto *ST = static_cast<const SPIRVSubtarget *>(&MF.getSubtarget());
-    auto *TR = ST->getSPIRVTypeRegistry();
-    TR->setCurrentFunc(MF);
+    auto *GR = ST->getSPIRVGlobalRegistry();
+    GR->setCurrentFunc(MF);
     auto &MRI = MF.getRegInfo();
 
     // we need to rewrite dst types for ASSIGN_TYPE instrs

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -1,4 +1,4 @@
-//===--- SPIRVStrings.cpp ---- String Utility Functions ---------*- C++ -*-===//
+//===--- SPIRVUtils.cpp ---- SPIR-V Utility Functions -----------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,11 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// The methods here are used to add these string literals as a series of 32-bit
-// integer operands with the correct format, and unpack them if necessary when
-// making string comparisons in compiler passes.
-//
-// SPIR-V requires null-terminated UTF-8 strings padded to 32-bit alignment.
+// This file contains miscellaneous utility functions.
 //
 //===----------------------------------------------------------------------===//
 
@@ -20,49 +16,46 @@
 
 using namespace llvm;
 
-// Add the given string as a series of integer operands, inserting null
-// terminators and padding to make sure the operands all have 32-bit
-// little-endian words
-void addStringImm(const StringRef &Str, MachineInstrBuilder &MIB) {
-  // Get length including padding and null terminator
-  const size_t Len = Str.size() + 1;
-  const size_t PaddedLen = (Len % 4 == 0) ? Len : Len + (4 - (Len % 4));
-  for (unsigned i = 0; i < PaddedLen; i += 4) {
-    uint32_t Word = 0u; // Build up this 32-bit word from 4 8-bit chars
-    for (unsigned WordIndex = 0; WordIndex < 4; ++WordIndex) {
-      unsigned StrIndex = i + WordIndex;
-      uint8_t CharToAdd = 0;      // Initilize char as padding/null
-      if (StrIndex < (Len - 1)) { // If it's within the string, get a real char
-        CharToAdd = Str[StrIndex];
-      }
-      Word |= (CharToAdd << (WordIndex * 8));
+// The following functions are used to add these string literals as a series of
+// 32-bit integer operands with the correct format, and unpack them if necessary
+// when making string comparisons in compiler passes.
+// SPIR-V requires null-terminated UTF-8 strings padded to 32-bit alignment.
+static uint32_t convertCharsToWord(const StringRef &Str, unsigned i) {
+  uint32_t Word = 0u; // Build up this 32-bit word from 4 8-bit chars
+  for (unsigned WordIndex = 0; WordIndex < 4; ++WordIndex) {
+    unsigned StrIndex = i + WordIndex;
+    uint8_t CharToAdd = 0;       // Initilize char as padding/null
+    if (StrIndex < Str.size()) { // If it's within the string, get a real char
+      CharToAdd = Str[StrIndex];
     }
-    MIB.addImm(Word); // Add an operand for the 32-bits of chars or padding
+    Word |= (CharToAdd << (WordIndex * 8));
+  }
+  return Word;
+}
+
+// Get length including padding and null terminator.
+static size_t getPaddedLen(const StringRef &Str) {
+  const size_t Len = Str.size() + 1;
+  return (Len % 4 == 0) ? Len : Len + (4 - (Len % 4));
+}
+
+void addStringImm(const StringRef &Str, MachineInstrBuilder &MIB) {
+  const size_t PaddedLen = getPaddedLen(Str);
+  for (unsigned i = 0; i < PaddedLen; i += 4) {
+    // Add an operand for the 32-bits of chars or padding
+    MIB.addImm(convertCharsToWord(Str, i));
   }
 }
 
 void addStringImm(const StringRef &Str, IRBuilder<> &B,
                   std::vector<Value *> &Args) {
-  // Get length including padding and null terminator
-  const size_t Len = Str.size() + 1;
-  const size_t PaddedLen = (Len % 4 == 0) ? Len : Len + (4 - (Len % 4));
+  const size_t PaddedLen = getPaddedLen(Str);
   for (unsigned i = 0; i < PaddedLen; i += 4) {
-    uint32_t Word = 0u; // Build up this 32-bit word from 4 8-bit chars
-    for (unsigned WordIndex = 0; WordIndex < 4; ++WordIndex) {
-      unsigned StrIndex = i + WordIndex;
-      uint8_t CharToAdd = 0;      // Initilize char as padding/null
-      if (StrIndex < (Len - 1)) { // If it's within the string, get a real char
-        CharToAdd = Str[StrIndex];
-      }
-      Word |= (CharToAdd << (WordIndex * 8));
-    }
-    Args.push_back(
-        B.getInt32(Word)); // Add an operand for the 32-bits of chars or padding
+    // Add a vector element for the 32-bits of chars or padding
+    Args.push_back(B.getInt32(convertCharsToWord(Str, i)));
   }
 }
 
-// Read the series of integer operands back as a null-terminated string using
-// the reverse of the logic in addStringImm
 std::string getStringImm(const MachineInstr &MI, unsigned int StartIndex) {
   return getSPIRVStringOperand(MI, StartIndex);
 }
@@ -92,7 +85,6 @@ void addNumImm(const APInt &Imm, MachineInstrBuilder &MIB, bool IsFloat) {
   }
 }
 
-// Add an OpName instruction for the given target register
 void buildOpName(Register Target, const StringRef &Name,
                  MachineIRBuilder &MIRBuilder) {
   if (!Name.empty()) {
@@ -109,4 +101,74 @@ void buildOpDecorate(Register Reg, MachineIRBuilder &MIRBuilder,
     addStringImm(StrImm, MIB);
   for (const auto &DecArg : DecArgs)
     MIB.addImm(DecArg);
+}
+
+// TODO: maybe the following two functions should be handled in the subtarget
+// to allow for different OpenCL vs Vulkan handling.
+unsigned int storageClassToAddressSpace(StorageClass::StorageClass SC) {
+  switch (SC) {
+  case StorageClass::Function:
+    return 0;
+  case StorageClass::CrossWorkgroup:
+    return 1;
+  case StorageClass::UniformConstant:
+    return 2;
+  case StorageClass::Workgroup:
+    return 3;
+  case StorageClass::Generic:
+    return 4;
+  case StorageClass::Input:
+    return 7;
+  default:
+    llvm_unreachable("Unable to get address space id");
+  }
+}
+
+StorageClass::StorageClass addressSpaceToStorageClass(unsigned int AddrSpace) {
+  switch (AddrSpace) {
+  case 0:
+    return StorageClass::Function;
+  case 1:
+    return StorageClass::CrossWorkgroup;
+  case 2:
+    return StorageClass::UniformConstant;
+  case 3:
+    return StorageClass::Workgroup;
+  case 4:
+    return StorageClass::Generic;
+  case 7:
+    return StorageClass::Input;
+  default:
+    llvm_unreachable("Unknown address space");
+  }
+}
+
+MemorySemantics::MemorySemantics
+getMemSemanticsForStorageClass(StorageClass::StorageClass sc) {
+  switch (sc) {
+  case StorageClass::StorageBuffer:
+  case StorageClass::Uniform:
+    return MemorySemantics::UniformMemory;
+  case StorageClass::Workgroup:
+    return MemorySemantics::WorkgroupMemory;
+  case StorageClass::CrossWorkgroup:
+    return MemorySemantics::CrossWorkgroupMemory;
+  case StorageClass::AtomicCounter:
+    return MemorySemantics::AtomicCounterMemory;
+  case StorageClass::Image:
+    return MemorySemantics::ImageMemory;
+  default:
+    return MemorySemantics::None;
+  }
+}
+
+bool constrainRegOperands(MachineInstrBuilder &MIB, MachineFunction *MF) {
+  if (!MF)
+    MF = MIB->getMF();
+  const auto &Subtarget = MF->getSubtarget();
+  const TargetInstrInfo *TII = Subtarget.getInstrInfo();
+  const TargetRegisterInfo *TRI = Subtarget.getRegisterInfo();
+  const RegisterBankInfo *RBI = Subtarget.getRegBankInfo();
+
+  return constrainSelectedInstRegOperands(*MIB, *TII, *TRI, *RBI);
 }

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -1,4 +1,4 @@
-//===--- SPIRVStrings.h ---- String Utility Functions -----------*- C++ -*-===//
+//===--- SPIRVUtils.h ---- SPIR-V Utility Functions -------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,16 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// The methods here are used to add these string literals as a series of 32-bit
-// integer operands with the correct format, and unpack them if necessary when
-// making string comparisons in compiler passes.
-//
-// SPIR-V requires null-terminated UTF-8 strings padded to 32-bit alignment.
+// This file contains miscellaneous utility functions.
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef LLVM_LIB_TARGET_SPIRV_SPIRVSTRINGS_H
-#define LLVM_LIB_TARGET_SPIRV_SPIRVSTRINGS_H
+#ifndef LLVM_LIB_TARGET_SPIRV_SPIRVUTILS_H
+#define LLVM_LIB_TARGET_SPIRV_SPIRVUTILS_H
 
 #include "SPIRVEnums.h"
 #include "llvm/ADT/StringRef.h"
@@ -27,20 +23,20 @@
 
 // Add the given string as a series of integer operand, inserting null
 // terminators and padding to make sure the operands all have 32-bit
-// little-endian words
+// little-endian words.
 void addStringImm(const llvm::StringRef &Str, llvm::MachineInstrBuilder &MIB);
 void addStringImm(const llvm::StringRef &Str, llvm::IRBuilder<> &B,
                   std::vector<llvm::Value *> &Args);
 
 // Read the series of integer operands back as a null-terminated string using
-// the reverse of the logic in addStringImm
+// the reverse of the logic in addStringImm.
 std::string getStringImm(const llvm::MachineInstr &MI, unsigned int StartIndex);
 
 // Add the given numerical immediate to MIB.
 void addNumImm(const llvm::APInt &Imm, llvm::MachineInstrBuilder &MIB,
                bool IsFloat = false);
 
-// Add an OpName instruction for the given target register
+// Add an OpName instruction for the given target register.
 void buildOpName(llvm::Register Target, const llvm::StringRef &Name,
                  llvm::MachineIRBuilder &MIRBuilder);
 
@@ -49,4 +45,18 @@ void buildOpDecorate(llvm::Register Reg, llvm::MachineIRBuilder &MIRBuilder,
                      Decoration::Decoration Dec,
                      const std::vector<uint32_t> &DecArgs,
                      llvm::StringRef StrImm = "");
-#endif
+
+// Convert a SPIR-V storage class to the corresponding LLVM IR address space.
+unsigned int storageClassToAddressSpace(StorageClass::StorageClass SC);
+
+// Convert an LLVM IR address space to a SPIR-V storage class.
+StorageClass::StorageClass addressSpaceToStorageClass(unsigned int AddrSpace);
+
+// Utility method to constrain an instruction's operands to the correct
+// register classes, and return true if this worked.
+bool constrainRegOperands(llvm::MachineInstrBuilder &MIB,
+                          llvm::MachineFunction *MF = nullptr);
+
+MemorySemantics::MemorySemantics
+getMemSemanticsForStorageClass(StorageClass::StorageClass sc);
+#endif // LLVM_LIB_TARGET_SPIRV_SPIRVUTILS_H


### PR DESCRIPTION
The patch renamed SPIRVTypeRegistry class to SPIRVGlobalRegistry and changed all "TRs" to "GRs". Also a noticeable part of TypeRegistry's code has been moved to more suitable places. "SPIRVDuplicatesTracker.h" includes were substituted by "SPIRVGlobalRegistry.h" where applicable. Some other minor changes were done.