### PR TITLE
[SPIR-V] make local OpFunction register for OpFunctionCall

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVMCInstLower.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVMCInstLower.cpp
@@ -34,9 +34,7 @@ void SPIRVMCInstLower::Lower(const MachineInstr *MI, MCInst &OutMI,
       llvm_unreachable("unknown operand type");
     case MachineOperand::MO_Register: {
       Register NewReg = GR->getRegisterAlias(MF, MO.getReg());
-      // OpFunctionCall already contains global register with OpFunction id.
-      bool IsOldReg = (MI->getOpcode() == SPIRV::OpFunctionCall && i == 2) ||
-                      IsMetaFunc || !NewReg.isValid();
+      bool IsOldReg = IsMetaFunc || !NewReg.isValid();
       MCOp = MCOperand::createReg(IsOldReg ? MO.getReg() : NewReg);
       break;
     }


### PR DESCRIPTION
It's a simple fix to localize OpFunction register for use in OpFunctionCall instruction. Later we could implement more complex approach as @zuban32 suggested in #103 .