### PR TITLE
[SPIR-V] remove unnecessary unref variable support

### DIFF
--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCTargetDesc.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCTargetDesc.cpp
@@ -86,7 +86,7 @@ static MCInstrAnalysis *createSPIRVInstrAnalysis(const MCInstrInfo *Info) {
   return new SPIRVMCInstrAnalysis(Info);
 }
 
-extern "C" void LLVMInitializeSPIRVTargetMC() {
+extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeSPIRVTargetMC() {
   for (Target *T : {&getTheSPIRV32Target(), &getTheSPIRV64Target(),
                     &getTheSPIRVLogicalTarget()}) {
     RegisterMCAsmInfo<SPIRVMCAsmInfo> X(*T);

--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -136,7 +136,7 @@ void SPIRVAsmPrinter::emitInstruction(const MachineInstr *MI) {
 }
 
 // Force static initialization.
-extern "C" void LLVMInitializeSPIRVAsmPrinter() {
+extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeSPIRVAsmPrinter() {
   RegisterAsmPrinter<SPIRVAsmPrinter> X(getTheSPIRV32Target());
   RegisterAsmPrinter<SPIRVAsmPrinter> Y(getTheSPIRV64Target());
   RegisterAsmPrinter<SPIRVAsmPrinter> Z(getTheSPIRVLogicalTarget());

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
@@ -589,7 +589,7 @@ static void numberRegistersInMBB(MachineBasicBlock &MBB,
 // the result in GR's register alias table.
 static void numberRegistersGlobally(Module &M, MachineModuleInfo &MMI,
                                     SPIRVGlobalRegistry *GR) {
-  unsigned int RegBaseIndex = 0;
+  unsigned int RegBaseIndex = getMetaMF()->getRegInfo().getNumVirtRegs();;
   BEGIN_FOR_MF_IN_MODULE_EXCEPT_FIRST(M, MMI)
   for (MachineBasicBlock &MBB : *MF)
     numberRegistersInMBB(MBB, RegBaseIndex, MF->getRegInfo(), GR);

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
@@ -70,7 +70,6 @@ enum MetaBlockType {
   MB_Annotations,           // OpDecorate, OpMemberDecorate etc.
   MB_TypeConstVars,         // OpTypeXXX, OpConstantXXX, and global OpVariables
   MB_ExtFuncDecls,          // OpFunction etc. to declare for external funcs
-  MB_TmpGlobalData,         // Tmp data in global vars processing
   NUM_META_BLOCKS           // Total number of sections requiring basic blocks
 };
 
@@ -522,9 +521,6 @@ extractInstructionsWithGlobalRegsToMetablockForMBB(MachineBasicBlock &MBB,
 // Some global instructions make reference to function-local ID vregs, so cannot
 // be hoisted until these registers are globally numbered and can be correctly
 // referenced from the instructions' new global context.
-//
-// This pass extracts and deduplicates these instructions assuming global VReg
-// numbers rather than using function-local alias tables like before.
 static void
 extractInstructionsWithGlobalRegsToMetablock(Module &M, MachineModuleInfo &MMI,
                                              const SPIRVInstrInfo *TII,
@@ -533,9 +529,6 @@ extractInstructionsWithGlobalRegsToMetablock(Module &M, MachineModuleInfo &MMI,
   for (MachineBasicBlock &MBB : *MF)
     extractInstructionsWithGlobalRegsToMetablockForMBB(MBB, TII, GR);
   END_FOR_MF_IN_MODULE()
-
-  MachineBasicBlock *MBB = getMetaMBB(MB_TmpGlobalData);
-  extractInstructionsWithGlobalRegsToMetablockForMBB(*MBB, TII, GR);
 }
 
 // After all OpEntryPoint and OpVariable instructions have been globally
@@ -592,24 +585,14 @@ static void numberRegistersInMBB(MachineBasicBlock &MBB,
   }
 }
 
-// Starting with the metablock, number all registers in all functions
-// globally from 0 onwards. Local registers aliasing results of OpType,
-// OpConstant etc. that were extracted to the metablock are now assigned
-// the correct global registers instead of the function-local ones.
+// Number all registers in all functions globally from 0 onwards and store
+// the result in GR's register alias table.
 static void numberRegistersGlobally(Module &M, MachineModuleInfo &MMI,
                                     SPIRVGlobalRegistry *GR) {
-  // Use raw index 0 - inf, and convert with index2VirtReg later
   unsigned int RegBaseIndex = 0;
-  BEGIN_FOR_MF_IN_MODULE(M, MMI)
-  auto &MRI = MF->getRegInfo();
-  if (MFIndex == 0) {
-    RegBaseIndex = GR->getMetaMF()->getRegInfo().getNumVirtRegs();
-    MachineBasicBlock *MBB = getMetaMBB(MB_TmpGlobalData);
-    numberRegistersInMBB(*MBB, RegBaseIndex, MRI, GR);
-  } else {
-    for (MachineBasicBlock &MBB : *MF)
-      numberRegistersInMBB(MBB, RegBaseIndex, MRI, GR);
-  }
+  BEGIN_FOR_MF_IN_MODULE_EXCEPT_FIRST(M, MMI)
+  for (MachineBasicBlock &MBB : *MF)
+    numberRegistersInMBB(MBB, RegBaseIndex, MF->getRegInfo(), GR);
   END_FOR_MF_IN_MODULE()
 }
 
@@ -641,7 +624,7 @@ static void addExternalDeclarationsToIDMap(FuncNameToIDMap &FuncNameToOpID) {
 
 // Replace global value for the  Callee argument of OpFunctionCall with a
 // register number for the function ID now that all results of OpFunction are
-// globally numbered registers
+// globally numbered registers.
 static void assignFunctionCallIDs(Module &M, MachineModuleInfo &MMI,
                                   const SPIRVInstrInfo *TII,
                                   SPIRVGlobalRegistry *GR) {
@@ -728,66 +711,6 @@ static void addGlobalRequirements(const SPIRVRequirementHandler &Reqs,
   // TODO add a pseudo instr for version number
 }
 
-// Add all requirements needed for the given instruction.
-// Defined in SPIRVAddRequirementsPass.cpp
-extern void addInstrRequirements(const MachineInstr &MI,
-                                 SPIRVRequirementHandler &Reqs,
-                                 const SPIRVSubtarget &ST);
-
-// Process each unreferenced global variable so its type and initializer
-// will be emitted to MB_TmpGlobalData. Apply addInstrRequirements to it.
-// Substitute each created G_CONSTANT to OpConstantI.
-static void processGlobalUnrefVars(Module &M, MachineModuleInfo &MMI,
-                                   SPIRVRequirementHandler &Reqs,
-                                   SPIRVGlobalRegistry *GR,
-                                   const SPIRVSubtarget &ST) {
-  // Walk over each MF's DT and select all unreferenced global variables.
-  SmallVector<GlobalVariable *, 8> GlobalVarList;
-  auto Map = GR->getAllUses<GlobalValue>();
-  for (Module::global_iterator I = M.global_begin(), E = M.global_end();
-       I != E;) {
-    GlobalVariable *GV = &*I++;
-    auto AddrSpace = GV->getAddressSpace();
-    auto Storage = addressSpaceToStorageClass(AddrSpace);
-    if (Storage != StorageClass::Function) {
-      auto t = Map.find(GV);
-      if (t == Map.end())
-        // GV is not found in maps of all MFs so it's unreferenced.
-        GlobalVarList.push_back(GV);
-    }
-  }
-
-  // Walk over all created instructions and add requirement. Also convert all
-  // G_CONSTANTs (GR creates them) to OpConstantI.
-  // TODO: clean up this.
-  GR->setCurrentFunc(*getMetaMF());
-  setMetaBlock(MB_TmpGlobalData);
-  MachineBasicBlock *MBB = getMetaBlock();
-  for (MachineInstr &MI : *MBB) {
-    addInstrRequirements(MI, Reqs, ST);
-    auto Opcode = MI.getOpcode();
-    if (Opcode == TargetOpcode::G_CONSTANT ||
-        Opcode == TargetOpcode::G_FCONSTANT) {
-      Register Res = MI.getOperand(0).getReg();
-      APInt Imm;
-      if (Opcode == TargetOpcode::G_FCONSTANT) {
-        const auto FPImm = MI.getOperand(1).getFPImm();
-        Imm = FPImm->getValueAPF().bitcastToAPInt();
-      } else {
-        Imm = MI.getOperand(1).getCImm()->getValue();
-      }
-      SPIRVType *ResType = GR->getSPIRVTypeForVReg(Res);
-      auto MIB = buildInstrInCurrentMetaMBB(SPIRV::OpConstantI)
-                     .addDef(Res)
-                     .addUse(GR->getSPIRVTypeID(ResType))
-                     .addImm(Imm.getZExtValue());
-      // TODO: remove this call
-      constrainRegOperands(MIB);
-      GR->setSkipEmission(&MI);
-    }
-  }
-}
-
 // Add a meta function containing all OpType, OpConstant etc.
 // Extract all OpType, OpConst etc. into this meta block
 // Number registers globally, including references to global OpType etc.
@@ -804,9 +727,6 @@ bool SPIRVGlobalTypesAndRegNum::runOnModule(Module &M) {
   SPIRVRequirementHandler Reqs;
 
   addHeaderOps(M, Reqs, ST);
-
-  // Process global variables which are not referenced in all functions.
-  processGlobalUnrefVars(M, MMIWrapper.getMMI(), Reqs, GR, ST);
 
   addOpExtInstImports(M, MMIWrapper.getMMI(), TII, GR);
 
@@ -830,10 +750,6 @@ bool SPIRVGlobalTypesAndRegNum::runOnModule(Module &M) {
     Reqs.addCapability(Capability::Linkage);
 
   addGlobalRequirements(Reqs, ST);
-
-  // Check that all instructions have been moved from the TmpGlobalData block.
-  assert(getMetaMBB(MB_TmpGlobalData)->empty() &&
-         "TmpGlobalData block is expected to be empty");
 
   return false;
 }

--- a/llvm/test/CodeGen/SPIRV/opencl/basic/get_global_offset.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl/basic/get_global_offset.ll
@@ -1,0 +1,80 @@
+; RUN: llc -O0 %s -o - | FileCheck %s
+
+target triple = "spirv64-unknown-unknown"
+
+; CHECK: OpEntryPoint Kernel %[[test_func:[0-9]+]] "test"
+; CHECK: OpName %[[outOffsets:[0-9]+]] "outOffsets"
+; CHECK: OpName %[[test_func]] "test"
+; CHECK: OpName %[[f2_decl:[0-9]+]] "BuiltInGlobalOffset"
+; CHECK: OpDecorate %[[f2_decl]] LinkageAttributes "BuiltInGlobalOffset" Import
+; CHECK: %[[int_ty:[0-9]+]] = OpTypeInt 32 0
+; CHECK: %[[iptr_ty:[0-9]+]] = OpTypePointer CrossWorkgroup  %[[int_ty]]
+; CHECK: %[[void_ty:[0-9]+]] = OpTypeVoid
+; CHECK: %[[func_ty:[0-9]+]] = OpTypeFunction %[[void_ty]] %[[iptr_ty]]
+; CHECK: %[[int64_ty:[0-9]+]] = OpTypeInt 64 0
+; CHECK: %[[vec_ty:[0-9]+]] = OpTypeVector %[[int64_ty]] 3
+; CHECK: %[[func2_ty:[0-9]+]] = OpTypeFunction %7
+; TODO: add 64-bit constant defs
+; CHECK: %[[f2_decl]] = OpFunction %[[vec_ty]] Pure %[[func2_ty]]
+; CHECK: OpFunctionEnd
+; Check that the function register name does not match other registers
+; CHECK-NOT: %[[int_ty]] = OpFunction
+; CHECK-NOT: %[[iptr_ty]] = OpFunction
+; CHECK-NOT: %[[void_ty]] = OpFunction
+; CHECK-NOT: %[[func_ty]] = OpFunction
+; CHECK-NOT: %[[int64_ty]] = OpFunction
+; CHECK-NOT: %[[vec_ty]] = OpFunction
+; CHECK-NOT: %[[func2_ty]] = OpFunction
+; CHECK-NOT: %[[f2_decl]] = OpFunction
+; CHECK: %[[outOffsets]] = OpFunctionParameter %[[iptr_ty]]
+; Function Attrs: nounwind
+define spir_kernel void @test(i32 addrspace(1)* %outOffsets) #0 {
+entry:
+  %0 = call spir_func <3 x i64> @BuiltInGlobalOffset() #1
+  %call = extractelement <3 x i64> %0, i32 0
+  %conv = trunc i64 %call to i32
+; CHECK: %[[i1:[0-9]+]] = OpInBoundsPtrAccessChain %[[iptr_ty]] %[[outOffsets]]
+; CHECK: OpStore %[[i1:[0-9]+]] %[[#]] Aligned 4
+  %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %outOffsets, i64 0
+  store i32 %conv, i32 addrspace(1)* %arrayidx, align 4
+  %1 = call spir_func <3 x i64> @BuiltInGlobalOffset() #1
+  %call1 = extractelement <3 x i64> %1, i32 1
+  %conv2 = trunc i64 %call1 to i32
+; CHECK: %[[i2:[0-9]+]] = OpInBoundsPtrAccessChain %[[iptr_ty]] %[[outOffsets]]
+; CHECK: OpStore %[[i2:[0-9]+]] %[[#]] Aligned 4
+  %arrayidx3 = getelementptr inbounds i32, i32 addrspace(1)* %outOffsets, i64 1
+  store i32 %conv2, i32 addrspace(1)* %arrayidx3, align 4
+  %2 = call spir_func <3 x i64> @BuiltInGlobalOffset() #1
+  %call4 = extractelement <3 x i64> %2, i32 2
+  %conv5 = trunc i64 %call4 to i32
+; CHECK: %[[i3:[0-9]+]] = OpInBoundsPtrAccessChain %[[iptr_ty]] %[[outOffsets]]
+; CHECK: OpStore %[[i3:[0-9]+]] %[[#]] Aligned 4
+  %arrayidx6 = getelementptr inbounds i32, i32 addrspace(1)* %outOffsets, i64 2
+  store i32 %conv5, i32 addrspace(1)* %arrayidx6, align 4
+  ret void
+}
+
+; Function Attrs: nounwind readnone
+declare spir_func <3 x i64> @BuiltInGlobalOffset() #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readnone }
+
+!opencl.kernels = !{!0}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!166}
+!opencl.ocl.version = !{!166}
+!opencl.used.extensions = !{!167}
+!opencl.used.optional.core.features = !{!167}
+!opencl.compiler.options = !{!168}
+
+!0 = !{void (i32 addrspace(1)*)* @test, !1, !2, !3, !4, !5, !6}
+!1 = !{!"kernel_arg_addr_space", i32 1}
+!2 = !{!"kernel_arg_access_qual", !"none"}
+!3 = !{!"kernel_arg_type", !"int*"}
+!4 = !{!"kernel_arg_type_qual", !""}
+!5 = !{!"kernel_arg_base_type", !"int*"}
+!6 = !{!"kernel_arg_name", !"outOffsets"}
+!166 = !{i32 3, i32 0}
+!167 = !{}
+!168 = !{!"-cl-std=CL3.0"}

--- a/llvm/test/CodeGen/SPIRV/opencl/basic/progvar_prog_scope_init.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl/basic/progvar_prog_scope_init.ll
@@ -1,0 +1,131 @@
+; RUN: llc -O0 %s -o - | FileCheck %s
+
+target triple = "spirv64-unknown-unknown"
+
+; CHECK: OpEntryPoint Kernel %[[f1:[0-9]+]] "writer" %[[var:[0-9]+]]
+; CHECK: OpEntryPoint Kernel %[[f2:[0-9]+]] "reader" %[[var]]
+; CHECK: OpName %[[var]] "var"
+@var = addrspace(1) global i8 0, align 1
+@g_var = addrspace(1) global i8 1, align 1
+@a_var = addrspace(1) global [2 x i8] c"\01\01", align 1
+@p_var = addrspace(1) global i8 addrspace(1)* getelementptr inbounds ([2 x i8], [2 x i8] addrspace(1)* @a_var, i32 0, i64 1), align 8
+
+; Function Attrs: nounwind
+define spir_func zeroext i8 @from_buf(i8 zeroext %a) #0 {
+entry:
+  %tobool = icmp ne i8 %a, 0
+  %i1promo = zext i1 %tobool to i8
+  ret i8 %i1promo
+}
+
+; Function Attrs: nounwind
+define spir_func zeroext i8 @to_buf(i8 zeroext %a) #0 {
+entry:
+  %i1trunc = trunc i8 %a to i1
+  %frombool = select i1 %i1trunc, i8 1, i8 0
+  %0 = and i8 %frombool, 1
+  %tobool = icmp ne i8 %0, 0
+  %conv = select i1 %tobool, i8 1, i8 0
+  ret i8 %conv
+}
+
+; Function Attrs: nounwind
+define spir_kernel void @writer(i8 addrspace(1)* %src, i32 %idx) #0 {
+entry:
+  %arrayidx = getelementptr inbounds i8, i8 addrspace(1)* %src, i64 0
+  %0 = load i8, i8 addrspace(1)* %arrayidx, align 1
+  %call = call spir_func zeroext i8 @from_buf(i8 zeroext %0) #0
+  %i1trunc = trunc i8 %call to i1
+  %frombool = select i1 %i1trunc, i8 1, i8 0
+  store i8 %frombool, i8 addrspace(1)* @var, align 1
+  %arrayidx1 = getelementptr inbounds i8, i8 addrspace(1)* %src, i64 1
+  %1 = load i8, i8 addrspace(1)* %arrayidx1, align 1
+  %call2 = call spir_func zeroext i8 @from_buf(i8 zeroext %1) #0
+  %i1trunc1 = trunc i8 %call2 to i1
+  %frombool3 = select i1 %i1trunc1, i8 1, i8 0
+  store i8 %frombool3, i8 addrspace(1)* @g_var, align 1
+  %arrayidx4 = getelementptr inbounds i8, i8 addrspace(1)* %src, i64 2
+  %2 = load i8, i8 addrspace(1)* %arrayidx4, align 1
+  %call5 = call spir_func zeroext i8 @from_buf(i8 zeroext %2) #0
+  %i1trunc2 = trunc i8 %call5 to i1
+  %frombool6 = select i1 %i1trunc2, i8 1, i8 0
+  %3 = getelementptr inbounds [2 x i8], [2 x i8] addrspace(1)* @a_var, i64 0, i64 0
+  store i8 %frombool6, i8 addrspace(1)* %3, align 1
+  %arrayidx7 = getelementptr inbounds i8, i8 addrspace(1)* %src, i64 3
+  %4 = load i8, i8 addrspace(1)* %arrayidx7, align 1
+  %call8 = call spir_func zeroext i8 @from_buf(i8 zeroext %4) #0
+  %i1trunc3 = trunc i8 %call8 to i1
+  %frombool9 = select i1 %i1trunc3, i8 1, i8 0
+  %5 = getelementptr inbounds [2 x i8], [2 x i8] addrspace(1)* @a_var, i64 0, i64 1
+  store i8 %frombool9, i8 addrspace(1)* %5, align 1
+  %idx.ext = zext i32 %idx to i64
+  %add.ptr = getelementptr inbounds i8, i8 addrspace(1)* %3, i64 %idx.ext
+  store i8 addrspace(1)* %add.ptr, i8 addrspace(1)* addrspace(1)* @p_var, align 8
+  ret void
+}
+
+; Function Attrs: nounwind
+define spir_kernel void @reader(i8 addrspace(1)* %dest, i8 zeroext %ptr_write_val) #0 {
+entry:
+  %call = call spir_func zeroext i8 @from_buf(i8 zeroext %ptr_write_val) #0
+  %i1trunc = trunc i8 %call to i1
+  %0 = load i8 addrspace(1)*, i8 addrspace(1)* addrspace(1)* @p_var, align 8
+  %frombool = select i1 %i1trunc, i8 1, i8 0
+  store volatile i8 %frombool, i8 addrspace(1)* %0, align 1
+  %1 = load i8, i8 addrspace(1)* @var, align 1
+  %2 = and i8 %1, 1
+  %tobool = icmp ne i8 %2, 0
+  %i1promo = zext i1 %tobool to i8
+  %call1 = call spir_func zeroext i8 @to_buf(i8 zeroext %i1promo) #0
+  %arrayidx = getelementptr inbounds i8, i8 addrspace(1)* %dest, i64 0
+  store i8 %call1, i8 addrspace(1)* %arrayidx, align 1
+  %3 = load i8, i8 addrspace(1)* @g_var, align 1
+  %4 = and i8 %3, 1
+  %tobool2 = icmp ne i8 %4, 0
+  %i1promo1 = zext i1 %tobool2 to i8
+  %call3 = call spir_func zeroext i8 @to_buf(i8 zeroext %i1promo1) #0
+  %arrayidx4 = getelementptr inbounds i8, i8 addrspace(1)* %dest, i64 1
+  store i8 %call3, i8 addrspace(1)* %arrayidx4, align 1
+  %5 = getelementptr inbounds [2 x i8], [2 x i8] addrspace(1)* @a_var, i64 0, i64 0
+  %6 = load i8, i8 addrspace(1)* %5, align 1
+  %7 = and i8 %6, 1
+  %tobool5 = icmp ne i8 %7, 0
+  %i1promo2 = zext i1 %tobool5 to i8
+  %call6 = call spir_func zeroext i8 @to_buf(i8 zeroext %i1promo2) #0
+  %arrayidx7 = getelementptr inbounds i8, i8 addrspace(1)* %dest, i64 2
+  store i8 %call6, i8 addrspace(1)* %arrayidx7, align 1
+  %8 = getelementptr inbounds [2 x i8], [2 x i8] addrspace(1)* @a_var, i64 0, i64 1
+  %9 = load i8, i8 addrspace(1)* %8, align 1
+  %10 = and i8 %9, 1
+  %tobool8 = icmp ne i8 %10, 0
+  %i1promo3 = zext i1 %tobool8 to i8
+  %call9 = call spir_func zeroext i8 @to_buf(i8 zeroext %i1promo3) #0
+  %arrayidx10 = getelementptr inbounds i8, i8 addrspace(1)* %dest, i64 3
+  store i8 %call9, i8 addrspace(1)* %arrayidx10, align 1
+  ret void
+}
+
+attributes #0 = { nounwind }
+
+!opencl.kernels = !{!0, !7}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!172}
+!opencl.ocl.version = !{!172}
+!opencl.used.extensions = !{!173}
+!opencl.used.optional.core.features = !{!173}
+!opencl.compiler.options = !{!174}
+
+!0 = !{void (i8 addrspace(1)*, i32)* @writer, !1, !2, !3, !4, !5, !6}
+!1 = !{!"kernel_arg_addr_space", i32 1, i32 0}
+!2 = !{!"kernel_arg_access_qual", !"none", !"none"}
+!3 = !{!"kernel_arg_type", !"uchar*", !"uint"}
+!4 = !{!"kernel_arg_type_qual", !"", !""}
+!5 = !{!"kernel_arg_base_type", !"char*", !"int"}
+!6 = !{!"kernel_arg_name", !"src", !"idx"}
+!7 = !{void (i8 addrspace(1)*, i8)* @reader, !1, !2, !8, !4, !9, !10}
+!8 = !{!"kernel_arg_type", !"uchar*", !"uchar"}
+!9 = !{!"kernel_arg_base_type", !"char*", !"uchar"}
+!10 = !{!"kernel_arg_name", !"dest", !"ptr_write_val"}
+!172 = !{i32 2, i32 0}
+!173 = !{}
+!174 = !{!"-cl-std=CL2.0"}

--- a/llvm/test/CodeGen/SPIRV/opencl/basic/progvar_prog_scope_uninit.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl/basic/progvar_prog_scope_uninit.ll
@@ -1,0 +1,189 @@
+; RUN: llc -O0 %s -o - | FileCheck %s
+
+target triple = "spirv64-unknown-unknown"
+
+; CHECK: OpEntryPoint Kernel %[[f1:[0-9]+]] "global_check" %[[var:[0-9]+]]
+; CHECK: OpEntryPoint Kernel %[[f2:[0-9]+]] "writer" %[[var]]
+; CHECK: OpEntryPoint Kernel %[[f3:[0-9]+]] "reader" %[[var]]
+; CHECK: OpName %[[var]] "var"
+@var = addrspace(1) global <2 x i8> zeroinitializer, align 2
+@g_var = addrspace(1) global <2 x i8> zeroinitializer, align 2
+@a_var = addrspace(1) global [2 x <2 x i8>] zeroinitializer, align 2
+@p_var = addrspace(1) global <2 x i8> addrspace(1)* null, align 8
+
+; Function Attrs: nounwind
+define spir_func <2 x i8> @from_buf(<2 x i8> %a) #0 {
+entry:
+  ret <2 x i8> %a
+}
+
+; Function Attrs: nounwind
+define spir_func <2 x i8> @to_buf(<2 x i8> %a) #0 {
+entry:
+  ret <2 x i8> %a
+}
+
+; Function Attrs: nounwind
+define spir_kernel void @global_check(i32 addrspace(1)* %out) #0 {
+entry:
+  %0 = load <2 x i8>, <2 x i8> addrspace(1)* @var, align 2
+  %cmp = icmp eq <2 x i8> %0, zeroinitializer
+  %sext = select <2 x i1> %cmp, <2 x i8> <i8 -1, i8 -1>, <2 x i8> zeroinitializer
+  %cast = icmp slt <2 x i8> %sext, zeroinitializer
+  %i1promo = zext <2 x i1> %cast to <2 x i8>
+  %call1 = call spir_func i1 @OpAll_v2i8(<2 x i8> %i1promo) #0
+  %call = select i1 %call1, i32 1, i32 0
+  %1 = and i8 1, 1
+  %tobool = icmp ne i8 %1, 0
+  %conv = select i1 %tobool, i32 1, i32 0
+  %and = and i32 %conv, %call
+  %tobool1 = icmp ne i32 %and, 0
+  %frombool = select i1 %tobool1, i8 1, i8 0
+  %2 = load <2 x i8>, <2 x i8> addrspace(1)* @g_var, align 2
+  %cmp2 = icmp eq <2 x i8> %2, zeroinitializer
+  %sext3 = select <2 x i1> %cmp2, <2 x i8> <i8 -1, i8 -1>, <2 x i8> zeroinitializer
+  %cast2 = icmp slt <2 x i8> %sext3, zeroinitializer
+  %i1promo1 = zext <2 x i1> %cast2 to <2 x i8>
+  %call43 = call spir_func i1 @OpAll_v2i8(<2 x i8> %i1promo1) #0
+  %call4 = select i1 %call43, i32 1, i32 0
+  %3 = and i8 %frombool, 1
+  %tobool5 = icmp ne i8 %3, 0
+  %conv6 = select i1 %tobool5, i32 1, i32 0
+  %and7 = and i32 %conv6, %call4
+  %tobool8 = icmp ne i32 %and7, 0
+  %frombool9 = select i1 %tobool8, i8 1, i8 0
+  %4 = getelementptr inbounds [2 x <2 x i8>], [2 x <2 x i8>] addrspace(1)* @a_var, i64 0, i64 0
+  %5 = load <2 x i8>, <2 x i8> addrspace(1)* %4, align 2
+  %cmp10 = icmp eq <2 x i8> %5, zeroinitializer
+  %sext11 = select <2 x i1> %cmp10, <2 x i8> <i8 -1, i8 -1>, <2 x i8> zeroinitializer
+  %cast4 = icmp slt <2 x i8> %sext11, zeroinitializer
+  %i1promo2 = zext <2 x i1> %cast4 to <2 x i8>
+  %call125 = call spir_func i1 @OpAll_v2i8(<2 x i8> %i1promo2) #0
+  %call12 = select i1 %call125, i32 1, i32 0
+  %6 = and i8 %frombool9, 1
+  %tobool13 = icmp ne i8 %6, 0
+  %conv14 = select i1 %tobool13, i32 1, i32 0
+  %and15 = and i32 %conv14, %call12
+  %tobool16 = icmp ne i32 %and15, 0
+  %frombool17 = select i1 %tobool16, i8 1, i8 0
+  %7 = getelementptr inbounds [2 x <2 x i8>], [2 x <2 x i8>] addrspace(1)* @a_var, i64 0, i64 1
+  %8 = load <2 x i8>, <2 x i8> addrspace(1)* %7, align 2
+  %cmp18 = icmp eq <2 x i8> %8, zeroinitializer
+  %sext19 = select <2 x i1> %cmp18, <2 x i8> <i8 -1, i8 -1>, <2 x i8> zeroinitializer
+  %cast6 = icmp slt <2 x i8> %sext19, zeroinitializer
+  %i1promo3 = zext <2 x i1> %cast6 to <2 x i8>
+  %call207 = call spir_func i1 @OpAll_v2i8(<2 x i8> %i1promo3) #0
+  %call20 = select i1 %call207, i32 1, i32 0
+  %9 = and i8 %frombool17, 1
+  %tobool21 = icmp ne i8 %9, 0
+  %conv22 = select i1 %tobool21, i32 1, i32 0
+  %and23 = and i32 %conv22, %call20
+  %tobool24 = icmp ne i32 %and23, 0
+  %frombool25 = select i1 %tobool24, i8 1, i8 0
+  %10 = load <2 x i8> addrspace(1)*, <2 x i8> addrspace(1)* addrspace(1)* @p_var, align 8
+  %11 = ptrtoint <2 x i8> addrspace(1)* %10 to i64
+  %12 = ptrtoint <2 x i8> addrspace(1)* null to i64
+  %cmp26 = icmp eq i64 %11, %12
+  %conv27 = select i1 %cmp26, i32 1, i32 0
+  %13 = and i8 %frombool25, 1
+  %tobool28 = icmp ne i8 %13, 0
+  %conv29 = select i1 %tobool28, i32 1, i32 0
+  %and30 = and i32 %conv29, %conv27
+  %tobool31 = icmp ne i32 %and30, 0
+  %frombool32 = select i1 %tobool31, i8 1, i8 0
+  %14 = and i8 %frombool32, 1
+  %tobool33 = icmp ne i8 %14, 0
+  %15 = select i1 %tobool33, i64 1, i64 0
+  %cond = select i1 %tobool33, i32 1, i32 0
+  store i32 %cond, i32 addrspace(1)* %out, align 4
+  ret void
+}
+
+; Function Attrs: nounwind
+declare spir_func i1 @OpAll_v2i8(<2 x i8>) #0
+
+; Function Attrs: nounwind
+define spir_kernel void @writer(<2 x i8> addrspace(1)* %src, i32 %idx) #0 {
+entry:
+  %arrayidx = getelementptr inbounds <2 x i8>, <2 x i8> addrspace(1)* %src, i64 0
+  %0 = load <2 x i8>, <2 x i8> addrspace(1)* %arrayidx, align 2
+  %call = call spir_func <2 x i8> @from_buf(<2 x i8> %0) #0
+  store <2 x i8> %call, <2 x i8> addrspace(1)* @var, align 2
+  %arrayidx1 = getelementptr inbounds <2 x i8>, <2 x i8> addrspace(1)* %src, i64 1
+  %1 = load <2 x i8>, <2 x i8> addrspace(1)* %arrayidx1, align 2
+  %call2 = call spir_func <2 x i8> @from_buf(<2 x i8> %1) #0
+  store <2 x i8> %call2, <2 x i8> addrspace(1)* @g_var, align 2
+  %arrayidx3 = getelementptr inbounds <2 x i8>, <2 x i8> addrspace(1)* %src, i64 2
+  %2 = load <2 x i8>, <2 x i8> addrspace(1)* %arrayidx3, align 2
+  %call4 = call spir_func <2 x i8> @from_buf(<2 x i8> %2) #0
+  %3 = getelementptr inbounds [2 x <2 x i8>], [2 x <2 x i8>] addrspace(1)* @a_var, i64 0, i64 0
+  store <2 x i8> %call4, <2 x i8> addrspace(1)* %3, align 2
+  %arrayidx5 = getelementptr inbounds <2 x i8>, <2 x i8> addrspace(1)* %src, i64 3
+  %4 = load <2 x i8>, <2 x i8> addrspace(1)* %arrayidx5, align 2
+  %call6 = call spir_func <2 x i8> @from_buf(<2 x i8> %4) #0
+  %5 = getelementptr inbounds [2 x <2 x i8>], [2 x <2 x i8>] addrspace(1)* @a_var, i64 0, i64 1
+  store <2 x i8> %call6, <2 x i8> addrspace(1)* %5, align 2
+  %idx.ext = zext i32 %idx to i64
+  %add.ptr = getelementptr inbounds <2 x i8>, <2 x i8> addrspace(1)* %3, i64 %idx.ext
+  store <2 x i8> addrspace(1)* %add.ptr, <2 x i8> addrspace(1)* addrspace(1)* @p_var, align 8
+  ret void
+}
+
+; Function Attrs: nounwind
+define spir_kernel void @reader(<2 x i8> addrspace(1)* %dest, <2 x i8> %ptr_write_val) #0 {
+entry:
+  %call = call spir_func <2 x i8> @from_buf(<2 x i8> %ptr_write_val) #0
+  %0 = load <2 x i8> addrspace(1)*, <2 x i8> addrspace(1)* addrspace(1)* @p_var, align 8
+  store <2 x i8> %call, <2 x i8> addrspace(1)* %0, align 2
+  %1 = load <2 x i8>, <2 x i8> addrspace(1)* @var, align 2
+  %call1 = call spir_func <2 x i8> @to_buf(<2 x i8> %1) #0
+  %arrayidx = getelementptr inbounds <2 x i8>, <2 x i8> addrspace(1)* %dest, i64 0
+  store <2 x i8> %call1, <2 x i8> addrspace(1)* %arrayidx, align 2
+  %2 = load <2 x i8>, <2 x i8> addrspace(1)* @g_var, align 2
+  %call2 = call spir_func <2 x i8> @to_buf(<2 x i8> %2) #0
+  %arrayidx3 = getelementptr inbounds <2 x i8>, <2 x i8> addrspace(1)* %dest, i64 1
+  store <2 x i8> %call2, <2 x i8> addrspace(1)* %arrayidx3, align 2
+  %3 = getelementptr inbounds [2 x <2 x i8>], [2 x <2 x i8>] addrspace(1)* @a_var, i64 0, i64 0
+  %4 = load <2 x i8>, <2 x i8> addrspace(1)* %3, align 2
+  %call4 = call spir_func <2 x i8> @to_buf(<2 x i8> %4) #0
+  %arrayidx5 = getelementptr inbounds <2 x i8>, <2 x i8> addrspace(1)* %dest, i64 2
+  store <2 x i8> %call4, <2 x i8> addrspace(1)* %arrayidx5, align 2
+  %5 = getelementptr inbounds [2 x <2 x i8>], [2 x <2 x i8>] addrspace(1)* @a_var, i64 0, i64 1
+  %6 = load <2 x i8>, <2 x i8> addrspace(1)* %5, align 2
+  %call6 = call spir_func <2 x i8> @to_buf(<2 x i8> %6) #0
+  %arrayidx7 = getelementptr inbounds <2 x i8>, <2 x i8> addrspace(1)* %dest, i64 3
+  store <2 x i8> %call6, <2 x i8> addrspace(1)* %arrayidx7, align 2
+  ret void
+}
+
+attributes #0 = { nounwind }
+
+!opencl.kernels = !{!0, !7, !14}
+!opencl.enable.FP_CONTRACT = !{}
+!opencl.spir.version = !{!181}
+!opencl.ocl.version = !{!181}
+!opencl.used.extensions = !{!182}
+!opencl.used.optional.core.features = !{!182}
+!opencl.compiler.options = !{!183}
+
+!0 = !{void (i32 addrspace(1)*)* @global_check, !1, !2, !3, !4, !5, !6}
+!1 = !{!"kernel_arg_addr_space", i32 1}
+!2 = !{!"kernel_arg_access_qual", !"none"}
+!3 = !{!"kernel_arg_type", !"int*"}
+!4 = !{!"kernel_arg_type_qual", !""}
+!5 = !{!"kernel_arg_base_type", !"int*"}
+!6 = !{!"kernel_arg_name", !"out"}
+!7 = !{void (<2 x i8> addrspace(1)*, i32)* @writer, !8, !9, !10, !11, !12, !13}
+!8 = !{!"kernel_arg_addr_space", i32 1, i32 0}
+!9 = !{!"kernel_arg_access_qual", !"none", !"none"}
+!10 = !{!"kernel_arg_type", !"uchar2*", !"uint"}
+!11 = !{!"kernel_arg_type_qual", !"", !""}
+!12 = !{!"kernel_arg_base_type", !"char2*", !"int"}
+!13 = !{!"kernel_arg_name", !"src", !"idx"}
+!14 = !{void (<2 x i8> addrspace(1)*, <2 x i8>)* @reader, !8, !9, !15, !11, !16, !17}
+!15 = !{!"kernel_arg_type", !"uchar2*", !"uchar2"}
+!16 = !{!"kernel_arg_base_type", !"char2*", !"char2"}
+!17 = !{!"kernel_arg_name", !"dest", !"ptr_write_val"}
+!181 = !{i32 2, i32 0}
+!182 = !{}
+!183 = !{!"-cl-std=CL2.0"}


### PR DESCRIPTION
The patch removes unnecessary support of unreferenced variables in SPIRVGlobalTypesAndRegNumPass.cpp.
Also it adds LLVM_EXTERNAL_VISIBILITY on some functions to pass builds with shared libs.