### PR TITLE
First approach to topologically sort types/constants/etc

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -18,6 +18,7 @@
 
 #include "SPIRVDuplicatesTracker.h"
 #include "SPIRVEnums.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 
 namespace AQ = AccessQualifier;
@@ -34,8 +35,10 @@ class SPIRVGlobalRegistry {
   // type-declaring ones)
   DenseMap<MachineFunction *, DenseMap<Register, SPIRVType *>> VRegToTypeMap;
 
+public:
   SPIRVGeneralDuplicatesTracker DT;
 
+private:
   DenseMap<SPIRVType *, const Type *> SPIRVToLLVMType;
 
   using SPIRVInstrGroup = DenseMap<MachineFunction *, const MachineInstr *>;
@@ -139,7 +142,7 @@ public:
   }
 
   template <typename T>
-  const MapVector<const T *, MapVector<MachineFunction *, Register>> &
+  const DenseMap<const T *, DTSortableEntry> &
   getAllUses() {
     return DT.get<T>()->getAllUses();
   }


### PR DESCRIPTION
This is still a very experimental change, code quality to be improved, currently there're many problems regarding incapsulation especially. This is uploaded to start discussing the problem and elaborate on the best approach.

In general this is needed to ensure proper ordering which was previously ensure by using MapVector and hoping everything's added to it in the correct order (not always true).

Currently it breaks ~15 LITs due to the unstable (correct from the spec PoV though) types/consts declaration order. Also fixes transcoding/extract_insert_value.ll which had a wrong ordering before which wasn't covered with LIT checks