### PR TITLE
[SPIR-V] fix several errors found by spirv-val

### DIFF
--- a/llvm/lib/MC/SPIRVObjectWriter.cpp
+++ b/llvm/lib/MC/SPIRVObjectWriter.cpp
@@ -45,7 +45,7 @@ void SPIRVObjectWriter::writeHeader(const MCAssembler &Asm) {
   // TODO: set the version on a min-necessary basis (just like the translator
   // does) requires some refactoring of MCAssembler::VersionInfoType.
   constexpr uint32_t Major = 1;
-  constexpr uint32_t Minor = 0;
+  constexpr uint32_t Minor = 4;
   constexpr uint32_t VersionNumber = 0 | (Major << 16) | (Minor << 8);
   // TODO: check if we could use anything other than 0 (spec allows)
   constexpr uint32_t GeneratorMagicNumber = 0;

--- a/llvm/lib/Target/SPIRV/SPIRVAddRequirementsPass.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAddRequirementsPass.cpp
@@ -238,6 +238,7 @@ void addInstrRequirements(const MachineInstr &MI,
     }
     break;
   }
+  case SPIRV::OpBitReverse:
   case SPIRV::OpTypeRuntimeArray:
     reqs.addCapability(Shader);
     break;

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -173,8 +173,12 @@ Register SPIRVGlobalRegistry::buildConstantIntVector(
 Register SPIRVGlobalRegistry::buildConstantSampler(
     Register ResReg, unsigned int AddrMode, unsigned int Param,
     unsigned int FilerMode, MachineIRBuilder &MIRBuilder, SPIRVType *SpvType) {
-  SPIRVType *SampTy =
-      getOrCreateSPIRVType(getTypeForSPIRVType(SpvType), MIRBuilder);
+  SPIRVType *SampTy;
+  if (SpvType)
+    SampTy = getOrCreateSPIRVType(getTypeForSPIRVType(SpvType), MIRBuilder);
+  else
+    SampTy = getOrCreateSPIRVTypeByName("opencl.sampler_t", MIRBuilder);
+
   auto Sampler =
       ResReg.isValid()
           ? ResReg
@@ -670,6 +674,8 @@ SPIRVGlobalRegistry::getOrCreateSPIRVTypeByName(StringRef TypeStr,
   } else if (TypeStr.startswith("half")) {
     Type = Type::getHalfTy(Ctx);
     TypeStr = TypeStr.substr(strlen("half"));
+  } else if (TypeStr.startswith("opencl.sampler_t")) {
+    Type = StructType::create(Ctx, "opencl.sampler_t");
   } else
     llvm_unreachable("Unable to recognize SPIRV type name.");
   if (TypeStr.startswith(" vector[")) {

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
@@ -156,8 +156,8 @@ static void addHeaderOps(Module &M, SPIRVRequirementHandler &Reqs,
     unsigned MinorNum = getMetadataUInt(VersionMD, 1);
     unsigned RevNum = getMetadataUInt(VersionMD, 2);
     OpenCLVersion = 0 | (MajorNum << 16) | (MinorNum << 8) | RevNum;
-    setMetaBlock(MB_DebugSourceAndStrings);
   }
+  setMetaBlock(MB_DebugSourceAndStrings);
 
   // Build the OpSource
   auto SrcLang = SourceLanguage::OpenCL_C;

--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
@@ -222,7 +222,7 @@ def ConstPseudoNull: IntImmLeaf<i64, [{ return Imm.isNullValue(); }]>;
 multiclass IntFPImm<bits<16> opCode, string name> {
   def I: Op<opCode, (outs ID:$dst), (ins TYPE:$type, ID:$src, variable_ops),
                   "$dst = "#name#" $type $src", [(set ID:$dst, (assigntype PseudoConstI:$src, TYPE:$type))]>;
-  def F: Op<opCode, (outs ID:$dst), (ins TYPE:$type, fID:$src),
+  def F: Op<opCode, (outs ID:$dst), (ins TYPE:$type, fID:$src, variable_ops),
                   "$dst = "#name#" $type $src", [(set ID:$dst, (assigntype PseudoConstF:$src, TYPE:$type))]>;
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
@@ -162,7 +162,7 @@ void SPIRVSubtarget::initAvailableCapabilities(const Triple &TT) {
   } else {
     // Add the min requirements for different OpenCL and SPIR-V versions
     addCaps(AvailableCaps, {Addresses, Float16Buffer, Int16, Int8, Kernel,
-                            Linkage, Vector16, Groups});
+                            Linkage, Vector16, Groups, GenericPointer, Shader});
     if (OpenCLFullProfile) {
       addCaps(AvailableCaps, {Int64, Int64Atomics});
     }

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -71,13 +71,10 @@ void addNumImm(const APInt &Imm, MachineInstrBuilder &MIB, bool IsFloat) {
     MIB.addImm(Imm.getZExtValue());
     break;
   case 64: {
-    if (!IsFloat) {
-      uint64_t FullImm = Imm.getZExtValue();
-      uint32_t LowBits = FullImm & 0xffffffff;
-      uint32_t HighBits = (FullImm >> 32) & 0xffffffff;
-      MIB.addImm(LowBits).addImm(HighBits);
-    } else
-      MIB.addImm(Imm.getZExtValue());
+    uint64_t FullImm = Imm.getZExtValue();
+    uint32_t LowBits = FullImm & 0xffffffff;
+    uint32_t HighBits = (FullImm >> 32) & 0xffffffff;
+    MIB.addImm(LowBits).addImm(HighBits);
     break;
   }
   default:


### PR DESCRIPTION
The change fixes several small errors which were found on LIT tests using spirv-val. It reduces number of LIT tests with validation issues from 79 to 35. Also one LIT test is expected to pass (transcoding/image_with_access_qualifiers.ll).