### PR TITLE
[SPIR-V] fix errors found by spirv-val 2

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -160,7 +160,8 @@ public:
   // and map it to the given VReg by creating an ASSIGN_TYPE instruction.
   SPIRVType *assignTypeToVReg(const Type *Type, Register VReg,
                               MachineIRBuilder &MIRBuilder,
-                              AQ::AccessQualifier AccessQual = AQ::ReadWrite);
+                              AQ::AccessQualifier AccessQual = AQ::ReadWrite,
+                              bool EmitIR = true);
 
   // In cases where the SPIR-V type is already known, this function can be
   // used to map it to the given VReg via an ASSIGN_TYPE instruction.
@@ -302,7 +303,7 @@ public:
   Register buildConstantFP(APFloat Val, MachineIRBuilder &MIRBuilder,
                            SPIRVType *SpvType = nullptr);
   Register buildConstantIntVector(uint64_t Val, MachineIRBuilder &MIRBuilder,
-                                  SPIRVType *SpvType);
+                                  SPIRVType *SpvType, bool EmitIR = true);
   Register buildConstantSampler(Register Res, unsigned int AddrMode,
                                 unsigned int Param, unsigned int FilerMode,
                                 MachineIRBuilder &MIRBuilder,

--- a/llvm/test/CodeGen/SPIRV/uitofp-with-bool.ll
+++ b/llvm/test/CodeGen/SPIRV/uitofp-with-bool.ll
@@ -35,12 +35,12 @@
 ; SPV-DAG: %[[int_64:[0-9]+]] = OpTypeInt 64 0
 ; SPV-DAG: %[[zero_32:[0-9]+]] = OpConstant %[[int_32]] 0
 ; SPV-DAG: %[[one_32:[0-9]+]] = OpConstant %[[int_32]] 1
-; SPV-DAG: %[[zero_8:[0-9]+]] = OpConstant %[[int_8]] 0
+; SPV-DAG: %[[zero_8:[0-9]+]] = OpConstantNull %[[int_8]]
 ; SPV-DAG: %[[mone_8:[0-9]+]] = OpConstant %[[int_8]] 255
-; SPV-DAG: %[[zero_16:[0-9]+]] = OpConstant %[[int_16]] 0
+; SPV-DAG: %[[zero_16:[0-9]+]] = OpConstantNull %[[int_16]]
 ; SPV-DAG: %[[mone_16:[0-9]+]] = OpConstant %[[int_16]] 65535
 ; SPV-DAG: %[[mone_32:[0-9]+]] = OpConstant %[[int_32]] 4294967295
-; SPV-DAG: %[[zero_64:[0-9]+]] = OpConstant %[[int_64]] 0 0
+; SPV-DAG: %[[zero_64:[0-9]+]] = OpConstantNull %[[int_64]]
 ; SPV-DAG: %[[mone_64:[0-9]+]] = OpConstant %[[int_64]] 4294967295 4294967295
 ; SPV-DAG: %[[one_8:[0-9]+]] = OpConstant %[[int_8]] 1
 ; SPV-DAG: %[[one_16:[0-9]+]] = OpConstant %[[int_16]] 1


### PR DESCRIPTION
The change extends constant building in GR for use in SPIRVInstructionSelector.cpp. One test (uitofp-with-bool.ll) was corrected and passed with the patch. Also 8 more LIT tests pass spirv-val.