### PR TITLE
[SPIR-V] move GlobalTypesAndRegNumPass to AsmPrinter 5

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRV.h
+++ b/llvm/lib/Target/SPIRV/SPIRV.h
@@ -23,7 +23,6 @@ ModulePass *createSPIRVPreTranslationLegalizerPass(SPIRVTargetMachine *TM);
 FunctionPass *createSPIRVOCLRegularizerPass();
 FunctionPass *createSPIRVBasicBlockDominancePass();
 FunctionPass *createSPIRVAddRequirementsPass();
-ModulePass *createSPIRVGlobalTypesAndRegNumPass();
 ModulePass *createSPIRVLowerConstExprLegacyPass();
 MachineFunctionPass *createSPIRVGenerateDecorationsPass();
 FunctionPass *createSPIRVPreLegalizerPass();
@@ -35,7 +34,7 @@ createSPIRVInstructionSelector(const SPIRVTargetMachine &TM,
 
 void initializeSPIRVBasicBlockDominancePass(PassRegistry &);
 void initializeSPIRVAddRequirementsPass(PassRegistry &);
-void initializeSPIRVGlobalTypesAndRegNumPass(PassRegistry &);
+void initializeSPIRVModuleAnalysisPass(PassRegistry &);
 void initializeSPIRVGenerateDecorationsPass(PassRegistry &);
 void initializeSPIRVPreLegalizerPass(PassRegistry &);
 } // namespace llvm

--- a/llvm/lib/Target/SPIRV/SPIRVCapabilityUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVCapabilityUtils.h
@@ -39,6 +39,13 @@ private:
 
 public:
   SPIRVRequirementHandler() : minVersion(0), maxVersion(0) {}
+  void clear() {
+    minimalCaps.clear();
+    allCaps.clear();
+    allExtensions.clear();
+    minVersion = 0;
+    maxVersion = 0;
+  }
   uint32_t getMinVersion() const { return minVersion; }
   uint32_t getMaxVersion() const { return maxVersion; }
   const CapabilityList &getMinimalCapabilities() const { return minimalCaps; };

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -23,7 +23,7 @@
 
 using namespace llvm;
 SPIRVGlobalRegistry::SPIRVGlobalRegistry(unsigned int PointerSize)
-    : PointerSize(PointerSize), MaxID(0) {}
+    : PointerSize(PointerSize) {}
 
 SPIRVType *SPIRVGlobalRegistry::assignTypeToVReg(const Type *Type,
                                                  Register VReg,

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalTypesAndRegNumPass.cpp
@@ -1,4 +1,4 @@
-//===-- SPIRVGlobalTypesAndRegNum.cpp - Hoist Globals & Number VRegs - C++ ===//
+//===- SPIRVModuleAnalysis.cpp - analysis of global instrs & regs - C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,19 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This pass hoists all the required function-local instructions to global
-// scope, deduplicating them where necessary.
+// The analysis collects instructions that should be output at the module level
+// and performs the global register numbering.
 //
-// Before this pass, all SPIR-V instructions were local scope, and registers
-// were numbered function-locally. However, SPIR-V requires Type instructions,
-// global variables, capabilities, annotations etc. to be in global scope and
-// occur at the start of the file. This pass copies these as necessary to dummy
-// function which represents the global scope. The original local instructions
-// are left to keep MIR consistent. They will not be emitted to asm/object file.
-//
-// This pass also re-numbers the registers globally, and saves global aliases of
-// local registers to the global registry. AsmPrinter uses these aliases to
-// output instructions that refers global registers.
+// The results of this analysis are used in AsmPrinter to rename registers
+// globally and to output required instructions at the module level.
 //
 //===----------------------------------------------------------------------===//
 
@@ -26,260 +18,141 @@
 #include "SPIRVCapabilityUtils.h"
 #include "SPIRVEnumRequirements.h"
 #include "SPIRVGlobalRegistry.h"
+#include "SPIRVModuleAnalysis.h"
 #include "SPIRVSubtarget.h"
+#include "SPIRVTargetMachine.h"
 #include "SPIRVUtils.h"
 #include "TargetInfo/SPIRVTargetInfo.h"
 #include "llvm/CodeGen/MachineModuleInfo.h"
+#include "llvm/CodeGen/TargetPassConfig.h"
 
 using namespace llvm;
 
-#define DEBUG_TYPE "spirv-global-types-vreg"
+#define DEBUG_TYPE "spirv-module-analysis"
 
-namespace {
-struct SPIRVGlobalTypesAndRegNum : public ModulePass {
-  static char ID;
+char llvm::SPIRVModuleAnalysis::ID = 0;
 
-  SPIRVGlobalTypesAndRegNum() : ModulePass(ID) {
-    initializeSPIRVGlobalTypesAndRegNumPass(*PassRegistry::getPassRegistry());
-  }
+namespace llvm {
+void initializeSPIRVModuleAnalysisPass(PassRegistry &);
+} // namespace llvm
 
-public:
-  // Perform passes such as hoisting global instructions and numbering vregs.
-  // See end of file for details
-  bool runOnModule(Module &M) override;
+INITIALIZE_PASS(SPIRVModuleAnalysis, DEBUG_TYPE, "SPIRV module analysis", true,
+                true)
 
-  // State that we need MachineModuleInfo to operate on MachineFunctions
-  void getAnalysisUsage(AnalysisUsage &AU) const override {
-    AU.addRequired<MachineModuleInfoWrapperPass>();
-  }
-};
-} // namespace
-
-// Basic block indices in the global meta-function representing sections of the
-// SPIR-V module header that need filled in a specific order.
-enum MetaBlockType {
-  MB_Capabilities,   // All OpCapability instructions
-  MB_Extensions,     // Optional OpExtension instructions
-  MB_ExtInstImports, // Any language extension imports via OpExtInstImport
-  MB_MemoryModel,    // A single required OpMemoryModel instruction
-  MB_EntryPoints,    // All OpEntryPoint instructions (if any)
-  MB_ExecutionModes, // All OpExecutionMode or OpExecutionModeId instrs
-  MB_DebugSourceAndStrings, // OpString, OpSource, OpSourceExtension etc.
-  MB_DebugNames,            // All OpName and OpMemberMemberName intrs.
-  MB_DebugModuleProcessed,  // All OpModuleProcessed instructions.
-  MB_Annotations,           // OpDecorate, OpMemberDecorate etc.
-  MB_TypeConstVars,         // OpTypeXXX, OpConstantXXX, and global OpVariables
-  MB_ExtFuncDecls,          // OpFunction etc. to declare for external funcs
-  NUM_META_BLOCKS           // Total number of sections requiring basic blocks
-};
-
-static MachineBasicBlock *CurrentMetaMBB = nullptr;
-static MachineFunction *MetaMF = nullptr;
-
-static MachineFunction *getMetaMF() { return MetaMF; }
-
-static MachineBasicBlock *getMetaMBB(MetaBlockType block) {
-  return MetaMF->getBlockNumbered(block);
-}
-
-// Set the builder's MBB to one of the sections from the MetaBlockType enum.
-static void setMetaBlock(MetaBlockType block) {
-  CurrentMetaMBB = getMetaMBB(block);
-}
-
-static MachineBasicBlock *getMetaBlock() { return CurrentMetaMBB; }
-
-static MachineInstrBuilder buildInstrInCurrentMetaMBB(unsigned int Opcode) {
-  const auto &ST = static_cast<const SPIRVSubtarget &>(MetaMF->getSubtarget());
-  const SPIRVInstrInfo *TII = ST.getInstrInfo();
-  return BuildMI(getMetaBlock(), DebugLoc(), TII->get(Opcode));
-}
-
-// Macros to make it simpler to iterate over MachineFunctions within a module
-// Defines MachineFunction *MF and unsigned MFIndex between BEGIN and END lines.
-
-#define BEGIN_FOR_MF_IN_MODULE(M, MMI)                                         \
-  {                                                                            \
-    unsigned MFIndex = 0;                                                      \
-    for (Function & F : M) {                                                   \
-      MachineFunction *MF = MMI.getMachineFunction(F);                         \
-      if (MF) {
-
-#define BEGIN_FOR_MF_IN_MODULE_EXCEPT_FIRST(M, MMI)                            \
-  {                                                                            \
-    unsigned MFIndex = 1;                                                      \
-    for (auto F = (++M.begin()), E = M.end(); F != E; ++F) {                   \
-      MachineFunction *MF = MMI.getMachineFunction(*F);                        \
-      if (MF) {
-
-#define END_FOR_MF_IN_MODULE()                                                 \
-  ++MFIndex;                                                                   \
-  } /* close if statement */                                                   \
-  } /* close for loop */                                                       \
-  } /* close outer block */
-
-// Retrieve an unsigned int from an MDNode with a list of them as operands
+// Retrieve an unsigned int from an MDNode with a list of them as operands.
 static unsigned int getMetadataUInt(MDNode *MdNode, unsigned int OpIndex,
                                     unsigned int DefaultVal = 0) {
   if (MdNode && OpIndex < MdNode->getNumOperands()) {
     const auto &Op = MdNode->getOperand(OpIndex);
     return mdconst::extract<ConstantInt>(Op)->getZExtValue();
-  } else {
-    return DefaultVal;
   }
+  return DefaultVal;
 }
 
-// Add some initial header instructions such as OpSource and OpMemoryModel
-// TODO Maybe move the environment-specific logic used here elsewhere.
-static void addHeaderOps(Module &M, SPIRVRequirementHandler &Reqs,
-                         const SPIRVSubtarget &ST) {
-  setMetaBlock(MB_MemoryModel);
-  unsigned PtrSize = ST.getPointerSize();
+void SPIRVModuleAnalysis::setBaseInfo(const Module &M) {
+  MAI.MaxID = 0;
+  for (int i = 0; i < NUM_MODULE_SECTIONS; i++)
+    MAI.MS[i].clear();
+  MAI.RegisterAliasTable.clear();
+  MAI.InstrsToDelete.clear();
+  MAI.FuncNameMap.clear();
+  MAI.GlobalVarList.clear();
+  MAI.ExtInstSetMap.clear();
+  MAI.Reqs.clear();
 
-  // Add OpMemoryModel
-  auto Addr = PtrSize == 32 ? AddressingModel::Physical32
-                            : PtrSize == 64 ? AddressingModel::Physical64
-                                            : AddressingModel::Logical;
-  auto Mem = MemoryModel::OpenCL;
-  buildInstrInCurrentMetaMBB(SPIRV::OpMemoryModel).addImm(Addr).addImm(Mem);
-
-  // Update required capabilities for this memory model
-  Reqs.addRequirements(getMemoryModelRequirements(Mem, ST));
-  Reqs.addRequirements(getAddressingModelRequirements(Addr, ST));
-
-  // Get the OpenCL version number from metadata
-  unsigned OpenCLVersion = 0;
+  // TODO: determine memory model and source language from the configuratoin.
+  MAI.Mem = MemoryModel::OpenCL;
+  MAI.SrcLang = SourceLanguage::OpenCL_C;
+  unsigned PtrSize = ST->getPointerSize();
+  MAI.Addr = PtrSize == 32 ? AddressingModel::Physical32
+                           : PtrSize == 64 ? AddressingModel::Physical64
+                                           : AddressingModel::Logical;
+  // Get the OpenCL version number from metadata.
+  // TODO: support other source languages.
+  MAI.SrcLangVersion = 0;
   if (auto VerNode = M.getNamedMetadata("opencl.ocl.version")) {
     // Construct version literal according to OpenCL 2.2 environment spec.
     auto VersionMD = VerNode->getOperand(0);
     unsigned MajorNum = getMetadataUInt(VersionMD, 0, 2);
     unsigned MinorNum = getMetadataUInt(VersionMD, 1);
     unsigned RevNum = getMetadataUInt(VersionMD, 2);
-    OpenCLVersion = 0 | (MajorNum << 16) | (MinorNum << 8) | RevNum;
+    MAI.SrcLangVersion = 0 | (MajorNum << 16) | (MinorNum << 8) | RevNum;
   }
-  setMetaBlock(MB_DebugSourceAndStrings);
+  // Update required capabilities for this memory model, addressing model and
+  // source language.
+  MAI.Reqs.addRequirements(getMemoryModelRequirements(MAI.Mem, *ST));
+  MAI.Reqs.addRequirements(getSourceLanguageRequirements(MAI.SrcLang, *ST));
+  MAI.Reqs.addRequirements(getAddressingModelRequirements(MAI.Addr, *ST));
 
-  // Build the OpSource
-  auto SrcLang = SourceLanguage::OpenCL_C;
-  buildInstrInCurrentMetaMBB(SPIRV::OpSource)
-      .addImm(SrcLang)
-      .addImm(OpenCLVersion);
-  Reqs.addRequirements(getSourceLanguageRequirements(SrcLang, ST));
-}
-
-// Create a new Function and MachineFunction to add meta-instructions to.
-// It should have a series of empty basic blocks, one for each required
-// SPIR-V module section, so that subsequent users of the MachineFunction
-// can hoist instructions into the right places easily.
-static void initMetaFunction(Module &M, MachineModuleInfo &MMI) {
-  // Add an empty placeholder function - MachineInstrs need to exist somewhere.
-  auto VoidType = Type::getVoidTy(M.getContext());
-  auto FType = FunctionType::get(VoidType, false);
-  auto Linkage = Function::LinkageTypes::InternalLinkage;
-  Function *F = Function::Create(FType, Linkage, "GlobalStuff");
-
-  // Add the function and a corresponding MachineFunction to the module
-  LLVMContext &Ctx = M.getContext();
-  BasicBlock *BB = BasicBlock::Create(Ctx);
-  ReturnInst::Create(Ctx, BB);
-  F->getBasicBlockList().push_back(BB);
-  M.getFunctionList().push_front(F);
-
-  // Add the necessary basic blocks according to the MetaBlockTypes enum.
-  MetaMF = &MMI.getOrCreateMachineFunction(*F);
-  for (unsigned int i = 0; i < NUM_META_BLOCKS; ++i) {
-    MachineBasicBlock *MetaMBB = MetaMF->CreateMachineBasicBlock();
-    MetaMF->push_back(MetaMBB);
-  }
-
-  // Tell the builder about the meta function and an initial basic block.
-  setMetaBlock(MB_TypeConstVars);
+  // TODO: check if it's required by default.
+  MAI.ExtInstSetMap[static_cast<unsigned>(ExtInstSet::OpenCL_std)] =
+      Register::index2VirtReg(MAI.getNextID());
 }
 
 template <typename T>
-static void fillLocalAliasTables(SPIRVGlobalRegistry *GR,
-                                 MetaBlockType MBType) {
-  setMetaBlock(MBType);
-  MachineRegisterInfo &MRI = getMetaMF()->getRegInfo();
-
-  // Make meta registers for entries of DT.
+static void makeRegisterAliases(SPIRVGlobalRegistry *GR,
+                                ModuleAnalysisInfo &MAI) {
+  // Make global registers for entries of DT.
   for (auto &CU : GR->getAllUses<T>()) {
-    Register MetaReg = MRI.createVirtualRegister(&SPIRV::IDRegClass);
+    Register GlobalReg = Register::index2VirtReg(MAI.getNextID());
     for (auto &U : CU.second) {
       auto *MF = U.first;
       auto Reg = U.second;
-      GR->setRegisterAlias(MF, Reg, MetaReg);
+      MAI.setRegisterAlias(MF, Reg, GlobalReg);
     }
   }
-  // Make meta registers for special types and constants collected in the map.
+  // Make global registers for special types and constants collected in the map.
   if (std::is_same<T, Type>::value) {
     for (auto &CU : GR->getSpecialTypesAndConstsMap()) {
-      for (auto &typeGroup : CU.second) {
-        Register MetaReg = MRI.createVirtualRegister(&SPIRV::IDRegClass);
-        for (auto &t : typeGroup) {
+      for (auto &TypeGroup : CU.second) {
+        Register GlobalReg = Register::index2VirtReg(MAI.getNextID());
+        for (auto &t : TypeGroup) {
           MachineFunction *MF = t.first;
           assert(t.second->getOperand(0).isReg());
           Register Reg = t.second->getOperand(0).getReg();
-          GR->setRegisterAlias(MF, Reg, MetaReg);
+          MAI.setRegisterAlias(MF, Reg, GlobalReg);
         }
       }
     }
   }
 }
 
-static void makeGlobalOp(Register Reg, Register MetaReg, MachineInstr *ToHoist,
-                         MachineFunction *MF, SPIRVGlobalRegistry *GR) {
-  assert(ToHoist && "There should be an instruction that defines the register");
-  GR->setSkipEmission(ToHoist);
-  const MachineRegisterInfo &MRI = getMetaMF()->getRegInfo();
-
-  if (!MRI.getVRegDef(MetaReg)) {
-    auto MIB = buildInstrInCurrentMetaMBB(ToHoist->getOpcode());
-    MIB.addDef(MetaReg);
-
-    for (unsigned int i = ToHoist->getNumExplicitDefs();
-         i < ToHoist->getNumOperands(); ++i) {
-      MachineOperand Op = ToHoist->getOperand(i);
-      if (Op.isImm()) {
-        MIB.addImm(Op.getImm());
-      } else if (Op.isFPImm()) {
-        MIB.addFPImm(Op.getFPImm());
-      } else if (Op.isReg()) {
-        Register MetaReg2 = GR->getRegisterAlias(MF, Op.getReg());
-        assert(MetaReg2.isValid() && "No reg alias found");
-        if (Op.isDef())
-          MIB.addDef(MetaReg2);
-        else
-          MIB.addUse(MetaReg2);
-      } else {
-        errs() << *ToHoist;
-        llvm_unreachable(
-            "Unexpected operand type when copying spirv meta instr");
-      }
-    }
+// The set stores IDs of types, consts, global vars and func decls
+// already inserted into MS list.
+static DenseSet<Register> InsertedTypeConstVarDefs;
+// Insert instruction to a module section if it was not inserted before.
+// Set skip emission on function output.
+static void insertInstrToMS(Register GlobalReg, MachineInstr *MI,
+                            ModuleAnalysisInfo *MAI, ModuleSectionType MSType) {
+  assert(MI && "There should be an instruction that defines the register");
+  MAI->setSkipEmission(MI);
+  if (!InsertedTypeConstVarDefs.contains(GlobalReg)) {
+    MAI->MS[MSType].push_back(MI);
+    InsertedTypeConstVarDefs.insert(GlobalReg);
   }
 }
-
-static void hoistGlobalOp(Register Reg, MachineFunction *MF,
-                          SPIRVGlobalRegistry *GR) {
-  assert(GR->hasRegisterAlias(MF, Reg) && "Cannot find register alias");
-  Register MetaReg = GR->getRegisterAlias(MF, Reg);
-  MachineInstr *ToHoist = MF->getRegInfo().getVRegDef(Reg);
-  makeGlobalOp(Reg, MetaReg, ToHoist, MF, GR);
+// Collect MI which defines the register in the given machine function.
+static void collectDefInstr(Register Reg, MachineFunction *MF,
+                            ModuleAnalysisInfo *MAI, ModuleSectionType MSType) {
+  assert(MAI->hasRegisterAlias(MF, Reg) && "Cannot find register alias");
+  Register GlobalReg = MAI->getRegisterAlias(MF, Reg);
+  MachineInstr *MI = MF->getRegInfo().getVRegDef(Reg);
+  insertInstrToMS(GlobalReg, MI, MAI, MSType);
 }
 
-template <typename T>
-static void hoistGlobalOps(SPIRVGlobalRegistry *GR, MetaBlockType MBType) {
-  setMetaBlock(MBType);
-  // Hoist instructions from DT.
+template <typename T> void SPIRVModuleAnalysis::collectTypesConstsVars() {
+  // Collect instructions from DT.
   for (auto &CU : GR->getAllUses<T>()) {
     for (auto &U : CU.second) {
       auto *MF = U.first;
       auto Reg = U.second;
-      // Some instructions may be deleted during global isel, so hoist only
+      // Some instructions may be deleted during global isel, so collect only
       // those that exist in current IR.
-      if (MF->getRegInfo().getVRegDef(Reg))
-        hoistGlobalOp(Reg, MF, GR);
+      if (MF->getRegInfo().getVRegDef(Reg)) {
+        collectDefInstr(Reg, MF, &MAI, MB_TypeConstVars);
+        if (std::is_same<T, GlobalValue>::value)
+          MAI.GlobalVarList.push_back(MF->getRegInfo().getVRegDef(Reg));
+      }
     }
   }
   // Hoist special types and constants collected in the map.
@@ -290,112 +163,101 @@ static void hoistGlobalOps(SPIRVGlobalRegistry *GR, MetaBlockType MBType) {
           MachineFunction *MF = t.first;
           assert(t.second->getOperand(0).isReg());
           Register Reg = t.second->getOperand(0).getReg();
-          hoistGlobalOp(Reg, MF, GR);
+          collectDefInstr(Reg, MF, &MAI, MB_TypeConstVars);
         }
   }
 }
 
-// We need this specialization as for function decls we want to not only hoist
-// OpFunctions but OpFunctionParameters too.
+// We need to process this separately as for function decls we want to not only
+// collect OpFunctions but OpFunctionParameters too.
 //
-// TODO: consider replacing this with explicit OpFunctionParameter generation
-// here instead handling it in CallLowering.
-static void hoistGlobalOpsFunction(SPIRVGlobalRegistry *GR) {
-  setMetaBlock(MB_ExtFuncDecls);
-  MachineRegisterInfo &MRI = getMetaMF()->getRegInfo();
-
+// TODO: maybe consider replacing this with explicit OpFunctionParameter
+// generation here instead handling it in CallLowering.
+static void collectFuncDecls(SPIRVGlobalRegistry *GR, ModuleAnalysisInfo *MAI) {
   for (auto &CU : GR->getAllUses<Function>()) {
     for (auto &U : CU.second) {
       auto *MF = U.first;
       auto Reg = U.second;
-      auto *ToHoist = MF->getRegInfo().getVRegDef(Reg);
-      while (ToHoist && (ToHoist->getOpcode() == SPIRV::OpFunction ||
-                         ToHoist->getOpcode() == SPIRV::OpFunctionParameter)) {
-        Reg = ToHoist->getOperand(0).getReg();
-        if (ToHoist->getOpcode() == SPIRV::OpFunctionParameter) {
-          Register MetaReg = MRI.createVirtualRegister(&SPIRV::IDRegClass);
-          GR->setRegisterAlias(MF, Reg, MetaReg);
-          makeGlobalOp(Reg, MetaReg, ToHoist, MF, GR);
+      MachineInstr *MI = MF->getRegInfo().getVRegDef(Reg);
+      while (MI && (MI->getOpcode() == SPIRV::OpFunction ||
+                    MI->getOpcode() == SPIRV::OpFunctionParameter)) {
+        Reg = MI->getOperand(0).getReg();
+        if (MI->getOpcode() == SPIRV::OpFunctionParameter) {
+          Register GlobalReg = Register::index2VirtReg(MAI->getNextID());
+          ;
+          MAI->setRegisterAlias(MF, Reg, GlobalReg);
+          insertInstrToMS(GlobalReg, MI, MAI, MB_ExtFuncDecls);
         } else {
-          hoistGlobalOp(Reg, MF, GR);
+          collectDefInstr(Reg, MF, MAI, MB_ExtFuncDecls);
         }
-        ToHoist = ToHoist->getNextNode();
-        Reg = ToHoist->getOperand(0).getReg();
+        MI = MI->getNextNode();
+        Reg = MI->getOperand(0).getReg();
       }
     }
-    // TODO: perhaps we need to move this to emitting stage.
-    buildInstrInCurrentMetaMBB(SPIRV::OpFunctionEnd);
   }
 }
 
-// Move all OpType, OpConstant etc. instructions into the meta block,
-// avoiding creating duplicates, and mapping the global registers to the
-// equivalent function-local ones via functionLocalAliasTables.
-//
-// This function runs early on in the pass to initialize the alias tables, and
-// can only hoist instructions which never refer to function-local registers.
-// OpTypeXXX, OpConstantXXX, and external OpFunction declarations only refer to
-// other hoistable instructions vregs, so can be hoisted here.
-//
-// OpCapability instructions are removed and added to the minCaps and
-// allCaps lists instead of hoisting right now. This allows capabilities added
-// later, such as the Linkage capability for files with no OpEntryPoints, and
-// still get deduplicated before the global OpCapability instructions are added.
-static void hoistInstrsToMetablock(Module &M, MachineModuleInfo &MMI,
-                                   SPIRVGlobalRegistry *GR,
-                                   SPIRVRequirementHandler &Reqs) {
+// The function initializes global register alias table for types, consts,
+// global vars and func decls and collects these instruction for output
+// at module level. Also it collects explicit OpExtension/OpCapability
+// instructions.
+void SPIRVModuleAnalysis::processDefInstrs(const Module &M) {
   // OpTypes and OpConstants can have cross references so at first we create
-  // new meta regs and map them to old regs, then walk the list of instructions,
-  // and create new (hoisted) instructions with new meta regs instead of old
-  // ones. Also there are references to global values in constants.
-  fillLocalAliasTables<Type>(GR, MB_TypeConstVars);
-  fillLocalAliasTables<Constant>(GR, MB_TypeConstVars);
-  fillLocalAliasTables<GlobalValue>(GR, MB_TypeConstVars);
+  // new global registers and map them to old regs, then walk the list of
+  // instructions, and select ones that should be emitted at module level.
+  // Also there are references to global values in constants.
+  makeRegisterAliases<Type>(GR, MAI);
+  makeRegisterAliases<Constant>(GR, MAI);
+  makeRegisterAliases<GlobalValue>(GR, MAI);
 
-  hoistGlobalOps<Type>(GR, MB_TypeConstVars);
-  hoistGlobalOps<Constant>(GR, MB_TypeConstVars);
+  collectTypesConstsVars<Type>();
+  collectTypesConstsVars<Constant>();
 
-  BEGIN_FOR_MF_IN_MODULE_EXCEPT_FIRST(M, MMI)
-  // Iterate through and hoist any instructions we can at this stage.
-  // bool hasSeenFirstOpFunction = false;
-  for (MachineBasicBlock &MBB : *MF) {
-    for (MachineInstr &MI : MBB) {
-      if (MI.getOpcode() == SPIRV::OpExtension) {
-        // Here, OpExtension just has a single enum operand, not a string
-        auto Ext = Extension::Extension(MI.getOperand(0).getImm());
-        Reqs.addExtension(Ext);
-        GR->setSkipEmission(&MI);
-      } else if (MI.getOpcode() == SPIRV::OpCapability) {
-        auto Cap = Capability::Capability(MI.getOperand(0).getImm());
-        Reqs.addCapability(Cap);
-        GR->setSkipEmission(&MI);
+  for (auto F = M.begin(), E = M.end(); F != E; ++F) {
+    MachineFunction *MF = MMI->getMachineFunction(*F);
+    if (MF) {
+      // Iterate through and hoist any instructions we can at this stage.
+      // bool hasSeenFirstOpFunction = false;
+      for (MachineBasicBlock &MBB : *MF) {
+        for (MachineInstr &MI : MBB) {
+          if (MI.getOpcode() == SPIRV::OpExtension) {
+            // Here, OpExtension just has a single enum operand, not a string
+            auto Ext = Extension::Extension(MI.getOperand(0).getImm());
+            MAI.Reqs.addExtension(Ext);
+            MAI.setSkipEmission(&MI);
+          } else if (MI.getOpcode() == SPIRV::OpCapability) {
+            auto Cap = Capability::Capability(MI.getOperand(0).getImm());
+            MAI.Reqs.addCapability(Cap);
+            MAI.setSkipEmission(&MI);
+          }
+        }
       }
     }
   }
-  END_FOR_MF_IN_MODULE()
 
-  hoistGlobalOps<GlobalValue>(GR, MB_TypeConstVars);
-  fillLocalAliasTables<Function>(GR, MB_ExtFuncDecls);
-  hoistGlobalOpsFunction(GR);
+  collectTypesConstsVars<GlobalValue>();
+  makeRegisterAliases<Function>(GR, MAI);
+  collectFuncDecls(GR, &MAI);
 }
 
-// True if there is an instruction in BB with all the same operands as
+// True if there is an instruction in the MS list with all the same operands as
 // the given instruction has (after the given starting index).
 // TODO: maybe it needs to check Opcodes too.
-static bool findSameInstrInMBB(const MachineInstr &A, MachineBasicBlock *MBB,
-                               SPIRVGlobalRegistry *GR,
-                               unsigned int StartOpIndex = 0) {
-  for (const auto &B : *MBB) {
+static bool findSameInstrInMS(const MachineInstr &A, ModuleSectionType MSType,
+                              ModuleAnalysisInfo &MAI,
+                              unsigned int StartOpIndex = 0) {
+  for (const auto *B : MAI.MS[MSType]) {
     const unsigned int NumAOps = A.getNumOperands();
-    if (NumAOps == B.getNumOperands() && A.getNumDefs() == B.getNumDefs()) {
+    if (NumAOps == B->getNumOperands() && A.getNumDefs() == B->getNumDefs()) {
       bool AllOpsMatch = true;
       for (unsigned i = StartOpIndex; i < NumAOps && AllOpsMatch; ++i) {
-        if (A.getOperand(i).isReg() && B.getOperand(i).isReg()) {
+        if (A.getOperand(i).isReg() && B->getOperand(i).isReg()) {
           Register RegA = A.getOperand(i).getReg();
-          Register RegB = B.getOperand(i).getReg();
-          AllOpsMatch = GR->getRegisterAlias(A.getMF(), RegA) == RegB;
+          Register RegB = B->getOperand(i).getReg();
+          AllOpsMatch = MAI.getRegisterAlias(A.getMF(), RegA) ==
+                        MAI.getRegisterAlias(B->getMF(), RegB);
         } else {
-          AllOpsMatch = A.getOperand(i).isIdenticalTo(B.getOperand(i));
+          AllOpsMatch = A.getOperand(i).isIdenticalTo(B->getOperand(i));
         }
       }
       if (AllOpsMatch)
@@ -405,391 +267,138 @@ static bool findSameInstrInMBB(const MachineInstr &A, MachineBasicBlock *MBB,
   return false;
 }
 
-static void addOpExtInstImports(Module &M, MachineModuleInfo &MMI,
-                                const SPIRVInstrInfo *TII,
-                                SPIRVGlobalRegistry *GR) {
-  std::set<ExtInstSet> UsedExtInstSets = {ExtInstSet::OpenCL_std};
-  SmallVector<MachineInstr *, 8> ExtInstInstrs;
-
-  // Record all OpExtInst instuctions and the instruction sets they use
-  BEGIN_FOR_MF_IN_MODULE_EXCEPT_FIRST(M, MMI)
-  for (MachineBasicBlock &MBB : *MF) {
-    for (MachineInstr &MI : MBB) {
-      if (MI.getOpcode() == SPIRV::OpExtInst) {
-        auto Set = static_cast<ExtInstSet>(MI.getOperand(2).getImm());
-        UsedExtInstSets.insert(Set);
-        ExtInstInstrs.push_back(&MI);
+// Look for IDs declared with Import linkage, and map the imported name string
+// to the register defining that variable (which will usually be the result of
+// an OpFunction). This lets us call externally imported functions using
+// the correct ID registers.
+void SPIRVModuleAnalysis::collectFuncNames(MachineInstr &MI,
+                                           const Function &F) {
+  if (MI.getOpcode() == SPIRV::OpDecorate) {
+    // If it's got Import linkage
+    auto Dec = MI.getOperand(1).getImm();
+    if (Dec == Decoration::LinkageAttributes) {
+      auto Lnk = MI.getOperand(MI.getNumOperands() - 1).getImm();
+      if (Lnk == LinkageType::Import) {
+        // Map imported function name to function ID register.
+        std::string Name = getStringImm(MI, 2);
+        Register Target = MI.getOperand(0).getReg();
+        // TODO: check defs from different MFs.
+        MAI.FuncNameMap[Name] = MAI.getRegisterAlias(MI.getMF(), Target);
       }
     }
-  }
-  END_FOR_MF_IN_MODULE()
-
-  std::map<ExtInstSet, Register> SetEnumToGlobalIDReg;
-
-  setMetaBlock(MB_ExtInstImports);
-  MachineRegisterInfo &MetaMRI = getMetaMF()->getRegInfo();
-  for (const auto Set : UsedExtInstSets) {
-    Register SetReg = MetaMRI.createVirtualRegister(&SPIRV::IDRegClass);
-    auto MIB =
-        buildInstrInCurrentMetaMBB(SPIRV::OpExtInstImport).addDef(SetReg);
-    addStringImm(getExtInstSetName(Set), MIB);
-    SetEnumToGlobalIDReg.insert({Set, SetReg});
-  }
-
-  // Replace all OpFunctionCalls with new ones referring to funcID vregs
-  for (const auto MI : ExtInstInstrs) {
-    auto ExtInstSetVar = static_cast<ExtInstSet>(MI->getOperand(2).getImm());
-    MachineRegisterInfo &MRI = MI->getMF()->getRegInfo();
-
-    // Ensure the mapping between local and global vregs is maintained for the
-    // later reg numbering phase
-    Register LocalReg = MRI.createVirtualRegister(&SPIRV::IDRegClass);
-    Register GlobalReg = SetEnumToGlobalIDReg[ExtInstSetVar];
-    GR->setRegisterAlias(MI->getMF(), LocalReg, GlobalReg);
-
-    // Create a new copy of the OpExtInst but with the IDVReg for the imported
-    // instruction set rather than an enum, then delete the old instruction.
-    DebugLoc DL = MI->getDebugLoc();
-    auto MIB = BuildMI(*MI->getParent(), MI, DL, TII->get(SPIRV::OpExtInst))
-                   .addDef(MI->getOperand(0).getReg())
-                   .addUse(MI->getOperand(1).getReg())
-                   .addUse(LocalReg);
-    const unsigned int NumOps = MI->getNumOperands();
-    for (unsigned int i = 3; i < NumOps; ++i) {
-      MIB.add(MI->getOperand(i));
-    }
-    GR->setSkipEmission(MI);
+  } else if (MI.getOpcode() == SPIRV::OpFunction) {
+    // Record all internal OpFunction declarations.
+    Register Reg = MI.defs().begin()->getReg();
+    Register GlobalReg = MAI.getRegisterAlias(MI.getMF(), Reg);
+    assert(GlobalReg.isValid());
+    // TODO: check that it does not conflict with existing entries.
+    MAI.FuncNameMap[F.getGlobalIdentifier()] = GlobalReg;
   }
 }
 
-// We need to add dummy registers whenever we need to reference a VReg that
-// might be beyond the number of virtual registers declared in the function so
-// far. This stops addUse and setReg from crashing when we use the new index.
-static void addDummyVRegsUpToIndex(unsigned Index, MachineRegisterInfo &MRI) {
-  while (Index >= MRI.getNumVirtRegs()) {
-    MRI.createVirtualRegister(&SPIRV::IDRegClass);
-  }
-}
-
-// Create a copy of the given instruction in the specified basic block of the
-// global metadata function. We assume global register numbering has already
-// occurred by this point, so we can directly copy VReg arguments (with padding
-// to avoid crashed). We can also directly compare VReg arguments directly when
-// detecting duplicates, rather than having to use local-to-global alias tables.
-static void hoistMetaInstrWithGlobalRegs(MachineInstr &MI,
-                                         SPIRVGlobalRegistry *GR,
-                                         MetaBlockType MbType) {
-  GR->setSkipEmission(&MI);
-  if (findSameInstrInMBB(MI, getMetaMBB(MbType), GR))
+// Collect the given instruction in the specified MS. We assume global register
+// numbering has already occurred by this point. We can directly compare reg
+// arguments when detecting duplicates.
+static void collectOtherInstr(MachineInstr &MI, ModuleAnalysisInfo &MAI,
+                              ModuleSectionType MSType) {
+  MAI.setSkipEmission(&MI);
+  if (findSameInstrInMS(MI, MSType, MAI))
     return; // Found a duplicate, so don't add it
+  // No duplicates, so add it.
+  MAI.MS[MSType].push_back(&MI);
+}
 
-  // TODO: unify with makeGlobalOp()
-  // No duplicates, so add it
-  setMetaBlock(MbType);
-  MachineRegisterInfo &MetaMRI = getMetaMF()->getRegInfo();
-  const unsigned NumOperands = MI.getNumOperands();
-  auto MIB = buildInstrInCurrentMetaMBB(MI.getOpcode());
-  for (unsigned i = 0; i < NumOperands; ++i) {
-    MachineOperand Op = MI.getOperand(i);
-    if (Op.isImm()) {
-      MIB.addImm(Op.getImm());
-    } else if (Op.isReg()) {
-      // Add dummy regs to stop addUse crashing if Reg > max regs in func so far
-      Register NewReg = GR->getRegisterAlias(MI.getMF(), Op.getReg());
-      addDummyVRegsUpToIndex(NewReg.virtRegIndex(), MetaMRI);
-      if (Op.isDef())
-        MIB.addDef(NewReg);
-      else
-        MIB.addUse(NewReg);
-    } else {
-      errs() << MI;
-      llvm_unreachable("Unexpected operand type when copying spirv meta instr");
+// Some global instructions make reference to function-local ID regs, so cannot
+// be correctly collected until these registers are globally numbered.
+void SPIRVModuleAnalysis::processOtherInstrs(const Module &M) {
+  for (auto F = M.begin(), E = M.end(); F != E; ++F) {
+    MachineFunction *MF = MMI->getMachineFunction(*F);
+    if (MF) {
+      for (MachineBasicBlock &MBB : *MF)
+        for (MachineInstr &MI : MBB) {
+          if (MAI.getSkipEmission(&MI))
+            continue;
+          const unsigned OpCode = MI.getOpcode();
+          if (OpCode == SPIRV::OpName || OpCode == SPIRV::OpMemberName) {
+            collectOtherInstr(MI, MAI, MB_DebugNames);
+          } else if (OpCode == SPIRV::OpEntryPoint) {
+            collectOtherInstr(MI, MAI, MB_EntryPoints);
+          } else if (TII->isDecorationInstr(MI)) {
+            collectOtherInstr(MI, MAI, MB_Annotations);
+            collectFuncNames(MI, *F);
+          } else if (TII->isConstantInstr(MI)) {
+            // Now OpSpecConstant*s are not in DT,
+            // but they need to be collected anyway.
+            collectOtherInstr(MI, MAI, MB_TypeConstVars);
+          } else if (OpCode == SPIRV::OpFunction) {
+            collectFuncNames(MI, *F);
+          }
+        }
     }
   }
 }
 
-static void
-extractInstructionsWithGlobalRegsToMetablockForMBB(MachineBasicBlock &MBB,
-                                                   const SPIRVInstrInfo *TII,
-                                                   SPIRVGlobalRegistry *GR) {
-  for (MachineInstr &MI : MBB) {
-    if (GR->getSkipEmission(&MI))
-      continue;
-    const unsigned OpCode = MI.getOpcode();
-    if (OpCode == SPIRV::OpName || OpCode == SPIRV::OpMemberName)
-      hoistMetaInstrWithGlobalRegs(MI, GR, MB_DebugNames);
-    else if (OpCode == SPIRV::OpEntryPoint)
-      hoistMetaInstrWithGlobalRegs(MI, GR, MB_EntryPoints);
-    else if (TII->isDecorationInstr(MI))
-      hoistMetaInstrWithGlobalRegs(MI, GR, MB_Annotations);
-    else if (TII->isConstantInstr(MI))
-      // Now OpSpecConstant*s are not in DT, but they need to be hoisted anyway.
-      hoistMetaInstrWithGlobalRegs(MI, GR, MB_TypeConstVars);
-  }
-}
-
-// Some global instructions make reference to function-local ID vregs, so cannot
-// be hoisted until these registers are globally numbered and can be correctly
-// referenced from the instructions' new global context.
-static void
-extractInstructionsWithGlobalRegsToMetablock(Module &M, MachineModuleInfo &MMI,
-                                             const SPIRVInstrInfo *TII,
-                                             SPIRVGlobalRegistry *GR) {
-  BEGIN_FOR_MF_IN_MODULE_EXCEPT_FIRST(M, MMI)
-  for (MachineBasicBlock &MBB : *MF)
-    extractInstructionsWithGlobalRegsToMetablockForMBB(MBB, TII, GR);
-  END_FOR_MF_IN_MODULE()
-}
-
-// After all OpEntryPoint and OpVariable instructions have been globally
-// extracted, we need to add the entry point's interfaces. Interface is a list
-// of IDs of global OpVariable instructions. These declare the set of
-// global variables from a module that form the interface of this entry point.
-static void addEntryPointLinkageInterfaces(Module &M, MachineModuleInfo &MMI,
-                                           const SPIRVSubtarget &ST) {
-  // Find all OpVariable IDs with required StorageClass.
-  MachineBasicBlock *DecMBB = getMetaMBB(MB_TypeConstVars);
-  SmallVector<Register, 4> InputLinkedIDs;
-  for (MachineInstr &MI : *DecMBB) {
-    const unsigned OpCode = MI.getOpcode();
-    if (OpCode == SPIRV::OpVariable) {
-      auto SC =
-          static_cast<StorageClass::StorageClass>(MI.getOperand(2).getImm());
-      // Before version 1.4, the interface's storage classes are limited to
-      // the Input and Output storage classes. Starting with version 1.4,
-      // the interface's storage classes are all storage classes used in
-      // declaring all global variables referenced by the entry point call tree.
-      if (ST.getTargetSPIRVVersion() >= 14 || SC == StorageClass::Input ||
-          SC == StorageClass::Output) {
-        InputLinkedIDs.push_back(MI.getOperand(0).getReg());
-      }
-    }
-  }
-
-  // Add IDs as an interface args to all OpEntryPoints.
-  if (!InputLinkedIDs.empty()) {
-    MachineBasicBlock *EntryMBB = getMetaMBB(MB_EntryPoints);
-    for (MachineInstr &MI : *EntryMBB)
-      for (unsigned Id : InputLinkedIDs)
-        MI.addOperand(MachineOperand::CreateReg(Id, false));
-  }
-}
-
-static void numberRegistersInMBB(MachineBasicBlock &MBB,
-                                 unsigned int &RegBaseIndex,
-                                 MachineRegisterInfo &MRI,
-                                 SPIRVGlobalRegistry *GR) {
-  auto *MF = MBB.getParent();
-  for (MachineInstr &MI : MBB) {
-    for (MachineOperand &Op : MI.operands()) {
-      if (Op.isReg()) {
-        Register Reg = Op.getReg();
-        addDummyVRegsUpToIndex(RegBaseIndex, MRI);
-        if (!GR->hasRegisterAlias(MF, Reg)) {
-          Register NewReg = Register::index2VirtReg(RegBaseIndex);
-          ++RegBaseIndex;
-          GR->setRegisterAlias(MF, Reg, NewReg);
+// Number registers in all functions globally from 0 onwards and store
+// the result in global register alias table. Some registers are already
+// numbered in makeRegisterAliases.
+void SPIRVModuleAnalysis::numberRegistersGlobally(const Module &M) {
+  for (auto F = M.begin(), E = M.end(); F != E; ++F) {
+    MachineFunction *MF = MMI->getMachineFunction(*F);
+    if (MF) {
+      for (MachineBasicBlock &MBB : *MF) {
+        for (MachineInstr &MI : MBB) {
+          for (MachineOperand &Op : MI.operands()) {
+            if (Op.isReg()) {
+              Register Reg = Op.getReg();
+              if (!MAI.hasRegisterAlias(MF, Reg)) {
+                Register NewReg = Register::index2VirtReg(MAI.getNextID());
+                MAI.setRegisterAlias(MF, Reg, NewReg);
+              }
+            }
+          }
+          if (MI.getOpcode() == SPIRV::OpExtInst) {
+            auto Set = MI.getOperand(2).getImm();
+            if (MAI.ExtInstSetMap.find(Set) == MAI.ExtInstSetMap.end())
+              MAI.ExtInstSetMap[Set] = Register::index2VirtReg(MAI.getNextID());
+          }
         }
       }
     }
   }
 }
 
-// Number all registers in all functions globally from 0 onwards and store
-// the result in GR's register alias table.
-static void numberRegistersGlobally(Module &M, MachineModuleInfo &MMI,
-                                    SPIRVGlobalRegistry *GR) {
-  unsigned int RegBaseIndex = getMetaMF()->getRegInfo().getNumVirtRegs();
-  BEGIN_FOR_MF_IN_MODULE_EXCEPT_FIRST(M, MMI)
-  for (MachineBasicBlock &MBB : *MF)
-    numberRegistersInMBB(MBB, RegBaseIndex, MF->getRegInfo(), GR);
-  END_FOR_MF_IN_MODULE()
-  GR->setMaxID(RegBaseIndex);
+struct ModuleAnalysisInfo SPIRVModuleAnalysis::MAI;
+
+void SPIRVModuleAnalysis::getAnalysisUsage(AnalysisUsage &AU) const {
+  AU.addRequired<TargetPassConfig>();
+  AU.addRequired<MachineModuleInfoWrapperPass>();
 }
 
-using FuncNameToIDMap = std::map<std::string, Register>;
+bool SPIRVModuleAnalysis::runOnModule(Module &M) {
+  SPIRVTargetMachine &TM =
+      getAnalysis<TargetPassConfig>().getTM<SPIRVTargetMachine>();
+  ST = TM.getSubtargetImpl();
+  GR = ST->getSPIRVGlobalRegistry();
+  TII = ST->getInstrInfo();
 
-// Iterate over all extracted OpDecorate instructions to look for IDs declared
-// with Import linkage, and map the imported name string to the VReg defining
-// that variable (which will usually be the result of an OpFunction).
-// This lets us call externally imported functions using the correct VReg ID.
-static void addExternalDeclarationsToIDMap(FuncNameToIDMap &FuncNameToOpID) {
-  // Only look for OpDecorates in the global meta function
-  const MachineBasicBlock *DecMBB = getMetaMBB(MB_Annotations);
-  for (const auto &MI : *DecMBB) {
-    if (MI.getOpcode() == SPIRV::OpDecorate) {
-      // If it's got Import linkage
-      auto Dec = MI.getOperand(1).getImm();
-      if (Dec == Decoration::LinkageAttributes) {
-        auto Lnk = MI.getOperand(MI.getNumOperands() - 1).getImm();
-        if (Lnk == LinkageType::Import) {
-          // Map imported function name to function ID VReg.
-          std::string Name = getStringImm(MI, 2);
-          Register Target = MI.getOperand(0).getReg();
-          FuncNameToOpID[Name] = Target;
-        }
-      }
-    }
-  }
-}
+  MMI = &getAnalysis<MachineModuleInfoWrapperPass>().getMMI();
+  InsertedTypeConstVarDefs.clear();
 
-// Replace global value for the  Callee argument of OpFunctionCall with a
-// register number for the function ID now that all results of OpFunction are
-// globally numbered registers.
-static void assignFunctionCallIDs(Module &M, MachineModuleInfo &MMI,
-                                  const SPIRVInstrInfo *TII,
-                                  SPIRVGlobalRegistry *GR) {
-  std::map<std::string, Register> FuncNameToID;
-  SmallVector<MachineInstr *, 8> FuncCalls;
+  setBaseInfo(M);
 
-  addExternalDeclarationsToIDMap(FuncNameToID);
+  // Process type/const/global var/func decl instructions, number their
+  // destination registers from 0 to N, collect Extensions and Capabilities.
+  processDefInstrs(M);
 
-  // Record all OpFunctionCalls, and all internal OpFunction declarations.
-  BEGIN_FOR_MF_IN_MODULE_EXCEPT_FIRST(M, MMI)
-  for (MachineBasicBlock &MBB : *MF) {
-    for (MachineInstr &MI : MBB) {
-      if (MI.getOpcode() == SPIRV::OpFunction && !GR->getSkipEmission(&MI)) {
-        Register Reg = GR->getRegisterAlias(MF, MI.defs().begin()->getReg());
-        assert(Reg.isValid());
-        FuncNameToID[F->getGlobalIdentifier()] = Reg;
-      } else if (MI.getOpcode() == SPIRV::OpFunctionCall) {
-        FuncCalls.push_back(&MI);
-      }
-    }
-  }
-  END_FOR_MF_IN_MODULE()
+  // Number rest of registers from N+1 onwards.
+  numberRegistersGlobally(M);
 
-  // Replace all OpFunctionCalls with new ones referring to FuncID vregs
-  for (const auto FuncCall : FuncCalls) {
-    auto FuncName = FuncCall->getOperand(2).getGlobal()->getGlobalIdentifier();
-    auto FuncID = FuncNameToID.find(FuncName);
-    if (FuncID == FuncNameToID.end()) {
-      errs() << "Unknown function: " << FuncName << "\n";
-      llvm_unreachable("Error: Could not find function id");
-    }
-    const auto MF = FuncCall->getMF();
+  // Collect OpName, OpEntryPoint, OpDecorate etc, process other instructions.
+  processOtherInstrs(M);
 
-    // Stops addUse crashing if FuncID > max regs in func so far
-    addDummyVRegsUpToIndex(FuncID->second.virtRegIndex(), MF->getRegInfo());
+  // If there are no entry points, we need the Linkage capability.
+  if (MAI.MS[MB_EntryPoints].empty())
+    MAI.Reqs.addCapability(Capability::Linkage);
 
-    // Create a new copy of the OpFunctionCall but with the IDVReg for the
-    // callee rather than a GlobalValue, then delete the old instruction.
-    // Also insert dummy OpFunction which generates local register.
-    // TODO: maybe move OpFunction creation to SPIRVCallLowering.
-    Register GlobaFuncReg = FuncID->second;
-    Register FuncTypeReg = FuncCall->getOperand(1).getReg();
-    Register LocalFuncReg =
-        MF->getRegInfo().createVirtualRegister(&SPIRV::IDRegClass);
-    DebugLoc DL = FuncCall->getDebugLoc();
-    auto MIB = BuildMI(*FuncCall->getParent(), FuncCall, DL,
-                       TII->get(SPIRV::OpFunction))
-                   .addDef(LocalFuncReg)
-                   .addUse(FuncCall->getOperand(1).getReg())
-                   .addImm(FunctionControl::None)
-                   .addUse(FuncTypeReg);
-    GR->setSkipEmission(MIB);
-
-    auto MIB2 = BuildMI(*FuncCall->getParent(), FuncCall, DL,
-                        TII->get(SPIRV::OpFunctionCall))
-                    .addDef(FuncCall->getOperand(0).getReg())
-                    .addUse(FuncCall->getOperand(1).getReg())
-                    .addUse(LocalFuncReg);
-    const unsigned int NumOps = FuncCall->getNumOperands();
-    for (unsigned int i = 3; i < NumOps; ++i) {
-      MIB2.addUse(FuncCall->getOperand(i).getReg());
-    }
-    GR->setRegisterAlias(MF, LocalFuncReg, GlobaFuncReg);
-    FuncCall->removeFromParent();
-  }
-}
-
-// Create global OpCapability instructions for the required capabilities
-static void addGlobalRequirements(const SPIRVRequirementHandler &Reqs,
-                                  const SPIRVSubtarget &ST) {
-  // Abort here if not all requirements can be satisfied
-  Reqs.checkSatisfiable(ST);
-  setMetaBlock(MB_Capabilities);
-
-  for (const auto &Cap : Reqs.getMinimalCapabilities())
-    buildInstrInCurrentMetaMBB(SPIRV::OpCapability).addImm(Cap);
-
-  // Generate the final OpExtensions with strings instead of enums
-  for (const auto &Ext : Reqs.getExtensions()) {
-    auto MIB = buildInstrInCurrentMetaMBB(SPIRV::OpExtension);
-    addStringImm(getExtensionName(Ext), MIB);
-  }
-
-  // TODO add a pseudo instr for version number
-}
-
-// If a register has no definition in the meta function, insert a dummy def in
-// the first MBB.
-static void insertDummyDefsInMetafunc(SPIRVGlobalRegistry *GR) {
-  setMetaBlock(MB_Capabilities);
-  MachineRegisterInfo &MetaMRI = getMetaMF()->getRegInfo();
-  unsigned NumRegs = MetaMRI.getNumVirtRegs();
-  for (unsigned int i = 0; i < NumRegs; i++) {
-    Register MetaReg = Register::index2VirtReg(i);
-    if (MetaMRI.getVRegDef(MetaReg) == nullptr) {
-      auto MIB = buildInstrInCurrentMetaMBB(SPIRV::OpUndef)
-                     .addDef(MetaReg)
-                     .addUse(Register::index2VirtReg(0));
-      GR->setSkipEmission(MIB);
-    }
-  }
-}
-
-// Add a meta function containing all OpType, OpConstant etc.
-// Extract all OpType, OpConst etc. into this meta block
-// Number registers globally, including references to global OpType etc.
-bool SPIRVGlobalTypesAndRegNum::runOnModule(Module &M) {
-  MachineModuleInfoWrapperPass &MMIWrapper =
-      getAnalysis<MachineModuleInfoWrapperPass>();
-
-  initMetaFunction(M, MMIWrapper.getMMI());
-  const auto &ST = static_cast<const SPIRVSubtarget &>(MetaMF->getSubtarget());
-  const SPIRVInstrInfo *TII = ST.getInstrInfo();
-  SPIRVGlobalRegistry *GR = ST.getSPIRVGlobalRegistry();
-  GR->setMetaMF(getMetaMF());
-
-  SPIRVRequirementHandler Reqs;
-
-  addHeaderOps(M, Reqs, ST);
-
-  addOpExtInstImports(M, MMIWrapper.getMMI(), TII, GR);
-
-  // Extract type instructions to the top MetaMBB and keep track of which local
-  // VRegs the correspond to with functionLocalAliasTables
-  hoistInstrsToMetablock(M, MMIWrapper.getMMI(), GR, Reqs);
-
-  // Number registers from 0 onwards, and fix references to global OpType etc
-  numberRegistersGlobally(M, MMIWrapper.getMMI(), GR);
-
-  // Extract instructions like OpName, OpEntryPoint, OpDecorate etc.
-  // which all rely on globally numbered registers, which they forward-reference
-  extractInstructionsWithGlobalRegsToMetablock(M, MMIWrapper.getMMI(), TII, GR);
-
-  addEntryPointLinkageInterfaces(M, MMIWrapper.getMMI(), ST);
-
-  assignFunctionCallIDs(M, MMIWrapper.getMMI(), TII, GR);
-
-  // If there are no entry points, we need the Linkage capability
-  if (getMetaMBB(MB_EntryPoints)->empty())
-    Reqs.addCapability(Capability::Linkage);
-
-  addGlobalRequirements(Reqs, ST);
-
-  // Insert dummy defs to the meta function for registers with no definition.
-  insertDummyDefsInMetafunc(GR);
-
-  return true;
-}
-
-INITIALIZE_PASS(SPIRVGlobalTypesAndRegNum, DEBUG_TYPE,
-                "SPIRV hoist OpType etc. & number VRegs globally", false, false)
-
-char SPIRVGlobalTypesAndRegNum::ID = 0;
-
-ModulePass *llvm::createSPIRVGlobalTypesAndRegNumPass() {
-  return new SPIRVGlobalTypesAndRegNum();
+  return false;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVMCInstLower.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVMCInstLower.cpp
@@ -13,7 +13,8 @@
 
 #include "SPIRVMCInstLower.h"
 #include "SPIRV.h"
-#include "SPIRVSubtarget.h"
+#include "SPIRVModuleAnalysis.h"
+#include "SPIRVUtils.h"
 #include "llvm/CodeGen/MachineInstr.h"
 #include "llvm/IR/Constants.h"
 
@@ -21,13 +22,13 @@ using namespace llvm;
 
 // Defined in SPIRVAsmPrinter.cpp
 extern Register getOrCreateMBBRegister(const MachineBasicBlock &MBB,
-                                       SPIRVGlobalRegistry *GR);
+                                       ModuleAnalysisInfo *MAI);
 
 void SPIRVMCInstLower::Lower(const MachineInstr *MI, MCInst &OutMI,
-                             SPIRVGlobalRegistry *GR) const {
+                             const MachineFunction *CurMF,
+                             ModuleAnalysisInfo *MAI) const {
   OutMI.setOpcode(MI->getOpcode());
   const MachineFunction *MF = MI->getMF();
-  bool IsMetaFunc = GR->getMetaMF() == MF;
   for (unsigned i = 0, e = MI->getNumOperands(); i != e; ++i) {
     const MachineOperand &MO = MI->getOperand(i);
     // At this stage, SPIR-V should only have Register and Immediate operands
@@ -36,17 +37,28 @@ void SPIRVMCInstLower::Lower(const MachineInstr *MI, MCInst &OutMI,
     default:
       MI->print(errs());
       llvm_unreachable("unknown operand type");
+    case MachineOperand::MO_GlobalAddress: {
+      Register FuncReg = MAI->getFuncReg(MO.getGlobal()->getGlobalIdentifier());
+      assert(FuncReg.isValid() && "Cannot find function Id");
+      MCOp = MCOperand::createReg(FuncReg);
+      break;
+    }
     case MachineOperand::MO_MachineBasicBlock:
-      MCOp = MCOperand::createReg(getOrCreateMBBRegister(*MO.getMBB(), GR));
+      MCOp = MCOperand::createReg(getOrCreateMBBRegister(*MO.getMBB(), MAI));
       break;
     case MachineOperand::MO_Register: {
-      Register NewReg = GR->getRegisterAlias(MF, MO.getReg());
-      bool IsOldReg = IsMetaFunc || !NewReg.isValid();
+      Register NewReg = MAI->getRegisterAlias(MF, MO.getReg());
+      bool IsOldReg = !CurMF || !NewReg.isValid();
       MCOp = MCOperand::createReg(IsOldReg ? MO.getReg() : NewReg);
       break;
     }
     case MachineOperand::MO_Immediate:
-      MCOp = MCOperand::createImm(MO.getImm());
+      if (MI->getOpcode() == SPIRV::OpExtInst && i == 2) {
+        Register Reg = MAI->getExtInstSetReg(MO.getImm());
+        MCOp = MCOperand::createReg(Reg);
+      } else {
+        MCOp = MCOperand::createImm(MO.getImm());
+      }
       break;
     case MachineOperand::MO_FPImmediate:
       MCOp = MCOperand::createDFPImm(

--- a/llvm/lib/Target/SPIRV/SPIRVMCInstLower.h
+++ b/llvm/lib/Target/SPIRV/SPIRVMCInstLower.h
@@ -14,13 +14,14 @@
 namespace llvm {
 class MCInst;
 class MachineInstr;
-class SPIRVGlobalRegistry;
+class MachineFunction;
+class ModuleAnalysisInfo;
 
 // This class is used to lower a MachineInstr into an MCInst.
 class LLVM_LIBRARY_VISIBILITY SPIRVMCInstLower {
 public:
   void Lower(const MachineInstr *MI, MCInst &OutMI,
-             SPIRVGlobalRegistry *GR) const;
+             const MachineFunction *CurMF, ModuleAnalysisInfo *MAI) const;
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
@@ -1,0 +1,131 @@
+//===- SPIRVModuleAnalysis.h - analysis of global instrs & regs -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// The analysis collects instructions that should be output at the module level
+// and performs the global register numbering.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_SPIRV_SPIRVMODULEANALYSIS_H
+#define LLVM_LIB_TARGET_SPIRV_SPIRVMODULEANALYSIS_H
+
+#include "SPIRVCapabilityUtils.h"
+#include "SPIRVEnumRequirements.h"
+#include "SPIRVSubtarget.h"
+#include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/ADT/StringMap.h"
+
+namespace llvm {
+
+// The enum contains logical module sections for instruction callection.
+enum ModuleSectionType {
+  //  MB_Capabilities,   // All OpCapability instructions
+  //  MB_Extensions,     // Optional OpExtension instructions
+  //  MB_ExtInstImports, // Any language extension imports via OpExtInstImport
+  //  MB_MemoryModel,    // A single required OpMemoryModel instruction
+  MB_EntryPoints, // All OpEntryPoint instructions (if any)
+  //  MB_ExecutionModes, // All OpExecutionMode or OpExecutionModeId instrs
+  //  MB_DebugSourceAndStrings, // OpString, OpSource, OpSourceExtension etc.
+  MB_DebugNames,           // All OpName and OpMemberName intrs.
+  MB_DebugModuleProcessed, // All OpModuleProcessed instructions.
+  MB_Annotations,          // OpDecorate, OpMemberDecorate etc.
+  MB_TypeConstVars,        // OpTypeXXX, OpConstantXXX, and global OpVariables
+  MB_ExtFuncDecls,         // OpFunction etc. to declare for external funcs
+  NUM_MODULE_SECTIONS      // Total number of sections requiring basic blocks
+};
+
+class MachineFunction;
+class MachineModuleInfo;
+
+using InstrList = SmallVector<MachineInstr *>;
+// Maps a local register to the corresponding global alias.
+using LocalToGlobalRegTable = std::map<Register, Register>;
+using RegisterAliasMapTy =
+    std::map<const MachineFunction *, LocalToGlobalRegTable>;
+
+// The struct contains results of the module analysis and methods
+// to access them.
+struct ModuleAnalysisInfo {
+  SPIRVRequirementHandler Reqs;
+  MemoryModel::MemoryModel Mem;
+  AddressingModel::AddressingModel Addr;
+  SourceLanguage::SourceLanguage SrcLang;
+  unsigned int SrcLangVersion;
+  // Maps ExtInstSet to corresponding ID register.
+  DenseMap<unsigned, Register> ExtInstSetMap;
+  // Contains the list of all global OpVariables in the module.
+  SmallVector<MachineInstr *, 4> GlobalVarList;
+  // Maps function names to coresponding function ID registers.
+  StringMap<Register> FuncNameMap;
+  // The set contains machine instructions which are necessary
+  // for correct MIR but will not be emitted in function bodies.
+  DenseSet<MachineInstr *> InstrsToDelete;
+  // The table contains global aliases of local registers for each machine
+  // function. The aliases are used to substitute local registers during
+  // code emission.
+  RegisterAliasMapTy RegisterAliasTable;
+  // The counter holds the maximum ID we have in the module.
+  unsigned MaxID;
+  // The array contains lists of MIs for each module section.
+  InstrList MS[NUM_MODULE_SECTIONS];
+
+  Register getFuncReg(std::string FuncName) {
+    auto FuncReg = FuncNameMap.find(FuncName);
+    assert(FuncReg != FuncNameMap.end() && "Cannot find function Id");
+    return FuncReg->second;
+  }
+  Register getExtInstSetReg(unsigned SetNum) { return ExtInstSetMap[SetNum]; }
+  InstrList &getMSInstrs(unsigned MSType) { return MS[MSType]; }
+  void setSkipEmission(MachineInstr *MI) { InstrsToDelete.insert(MI); }
+  bool getSkipEmission(const MachineInstr *MI) {
+    return InstrsToDelete.contains(MI);
+  }
+  void setRegisterAlias(const MachineFunction *MF, Register Reg,
+                        Register AliasReg) {
+    RegisterAliasTable[MF][Reg] = AliasReg;
+  }
+  Register getRegisterAlias(const MachineFunction *MF, Register Reg) {
+    auto RI = RegisterAliasTable[MF].find(Reg);
+    if (RI == RegisterAliasTable[MF].end()) {
+      return Register(0);
+    }
+    return RegisterAliasTable[MF][Reg];
+  }
+  bool hasRegisterAlias(const MachineFunction *MF, Register Reg) {
+    return RegisterAliasTable.find(MF) != RegisterAliasTable.end() &&
+           RegisterAliasTable[MF].find(Reg) != RegisterAliasTable[MF].end();
+  }
+  unsigned getNextID() { return MaxID++; }
+};
+
+struct SPIRVModuleAnalysis : public ModulePass {
+  static char ID;
+
+public:
+  SPIRVModuleAnalysis() : ModulePass(ID) {}
+
+  bool runOnModule(Module &M) override;
+  void getAnalysisUsage(AnalysisUsage &AU) const override;
+  static struct ModuleAnalysisInfo MAI;
+
+private:
+  void setBaseInfo(const Module &M);
+  template <typename T> void collectTypesConstsVars();
+  void processDefInstrs(const Module &M);
+  void collectFuncNames(MachineInstr &MI, const Function &F);
+  void processOtherInstrs(const Module &M);
+  void numberRegistersGlobally(const Module &M);
+
+  const SPIRVSubtarget *ST;
+  SPIRVGlobalRegistry *GR;
+  const SPIRVInstrInfo *TII;
+  MachineModuleInfo *MMI;
+};
+} // namespace llvm
+#endif // LLVM_LIB_TARGET_SPIRV_SPIRVMODULEANALYSIS_H

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -47,8 +47,8 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeSPIRVTarget() {
   // Register all custom passes so we can use "-stop-after" etc.
   PassRegistry &PR = *PassRegistry::getPassRegistry();
   initializeGlobalISel(PR);
-  initializeSPIRVGlobalTypesAndRegNumPass(PR);
   initializeSPIRVAddRequirementsPass(PR);
+  initializeSPIRVModuleAnalysisPass(PR);
   initializeSPIRVPreLegalizerPass(PR);
 }
 
@@ -176,10 +176,6 @@ void SPIRVPassConfig::addISelPrepare() {
 void SPIRVPassConfig::addPreEmitPass2() {
   // Add all required OpCapability instructions locally (to be hoisted later)
   addPass(createSPIRVAddRequirementsPass());
-
-  // Hoist all global instructions, and number VRegs globally.
-  // We disable verification after this, as global VRegs are invalid in MIR
-  addPass(createSPIRVGlobalTypesAndRegNumPass(), false);
 }
 
 bool SPIRVPassConfig::addIRTranslator() {

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -39,6 +39,14 @@ static size_t getPaddedLen(const StringRef &Str) {
   return (Len % 4 == 0) ? Len : Len + (4 - (Len % 4));
 }
 
+void addStringImm(const StringRef &Str, MCInst &Inst) {
+  const size_t PaddedLen = getPaddedLen(Str);
+  for (unsigned i = 0; i < PaddedLen; i += 4) {
+    // Add an operand for the 32-bits of chars or padding
+    Inst.addOperand(MCOperand::createImm(convertCharsToWord(Str, i)));
+  }
+}
+
 void addStringImm(const StringRef &Str, MachineInstrBuilder &MIB) {
   const size_t PaddedLen = getPaddedLen(Str);
   for (unsigned i = 0; i < PaddedLen; i += 4) {

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -24,6 +24,7 @@
 // Add the given string as a series of integer operand, inserting null
 // terminators and padding to make sure the operands all have 32-bit
 // little-endian words.
+void addStringImm(const llvm::StringRef &Str, llvm::MCInst &Inst);
 void addStringImm(const llvm::StringRef &Str, llvm::MachineInstrBuilder &MIB);
 void addStringImm(const llvm::StringRef &Str, llvm::IRBuilder<> &B,
                   std::vector<llvm::Value *> &Args);

--- a/llvm/test/CodeGen/SPIRV/opencl/basic/get_global_offset.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl/basic/get_global_offset.ll
@@ -13,7 +13,7 @@ target triple = "spirv64-unknown-unknown"
 ; CHECK: %[[func_ty:[0-9]+]] = OpTypeFunction %[[void_ty]] %[[iptr_ty]]
 ; CHECK: %[[int64_ty:[0-9]+]] = OpTypeInt 64 0
 ; CHECK: %[[vec_ty:[0-9]+]] = OpTypeVector %[[int64_ty]] 3
-; CHECK: %[[func2_ty:[0-9]+]] = OpTypeFunction %7
+; CHECK: %[[func2_ty:[0-9]+]] = OpTypeFunction %[[vec_ty]]
 ; TODO: add 64-bit constant defs
 ; CHECK: %[[f2_decl]] = OpFunction %[[vec_ty]] Pure %[[func2_ty]]
 ; CHECK: OpFunctionEnd

--- a/llvm/test/CodeGen/SPIRV/opencl/basic/progvar_prog_scope_uninit.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl/basic/progvar_prog_scope_uninit.ll
@@ -2,10 +2,13 @@
 
 target triple = "spirv64-unknown-unknown"
 
-; CHECK: OpEntryPoint Kernel %[[f1:[0-9]+]] "global_check" %[[var:[0-9]+]]
-; CHECK: OpEntryPoint Kernel %[[f2:[0-9]+]] "writer" %[[var]]
-; CHECK: OpEntryPoint Kernel %[[f3:[0-9]+]] "reader" %[[var]]
-; CHECK: OpName %[[var]] "var"
+; CHECK: OpEntryPoint Kernel %[[f1:[0-9]+]] "global_check" %[[var0:[0-9]+]] %[[var1:[0-9]+]] %[[var2:[0-9]+]] %[[var3:[0-9]+]]
+; CHECK: OpEntryPoint Kernel %[[f2:[0-9]+]] "writer" %[[var0:[0-9]+]] %[[var1:[0-9]+]] %[[var2:[0-9]+]] %[[var3:[0-9]+]]
+; CHECK: OpEntryPoint Kernel %[[f3:[0-9]+]] "reader" %[[var0:[0-9]+]] %[[var1:[0-9]+]] %[[var2:[0-9]+]] %[[var3:[0-9]+]]
+; CHECK-DAG: OpName %[[var0]]
+; CHECK-DAG: OpName %[[var1]]
+; CHECK-DAG: OpName %[[var2]]
+; CHECK-DAG: OpName %[[var3]]
 @var = addrspace(1) global <2 x i8> zeroinitializer, align 2
 @g_var = addrspace(1) global <2 x i8> zeroinitializer, align 2
 @a_var = addrspace(1) global [2 x <2 x i8>] zeroinitializer, align 2


### PR DESCRIPTION
The latest version of GlobalTypesAndRegNum pass removing. The critical issue with OpenCL CTS testing was fixed. SPIRVGlobalTypesAndRegNumPass.cpp will be renamed to SPIRVModuleAnalysis.cpp later.