### PR TITLE
[SPIR-V] support formal args' metadata and fix small issues

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -19,7 +19,6 @@
 #include "SPIRVInstrInfo.h"
 #include "SPIRVRegisterBankInfo.h"
 #include "SPIRVRegisterInfo.h"
-#include "SPIRVSubtarget.h"
 #include "SPIRVTargetMachine.h"
 #include "SPIRVUtils.h"
 #include "llvm/ADT/APFloat.h"
@@ -1363,10 +1362,10 @@ bool SPIRVInstructionSelector::selectGEP(Register ResVReg,
   unsigned Opcode = I.getOperand(2).getImm() ? SPIRV::OpInBoundsPtrAccessChain
                                              : SPIRV::OpPtrAccessChain;
   auto Res = MIRBuilder.buildInstr(Opcode)
-                  .addDef(ResVReg)
-                  .addUse(GR.getSPIRVTypeID(ResType))
-                  // object to get a pointer to
-                  .addUse(I.getOperand(3).getReg());
+                 .addDef(ResVReg)
+                 .addUse(GR.getSPIRVTypeID(ResType))
+                 // object to get a pointer to
+                 .addUse(I.getOperand(3).getReg());
   // adding indices
   for (unsigned i = 4; i < I.getNumExplicitOperands(); ++i)
     Res.addUse(I.getOperand(i).getReg());

--- a/llvm/lib/Target/SPIRV/SPIRVOCLRegularizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVOCLRegularizer.cpp
@@ -48,8 +48,8 @@ private:
 
 char SPIRVOCLRegularizer::ID = 0;
 
-INITIALIZE_PASS(SPIRVOCLRegularizer, "spirv-decor-generation",
-                "SPIRV Decorations Generation", false, false)
+INITIALIZE_PASS(SPIRVOCLRegularizer, "spirv-ocl-regularizer",
+                "SPIRV OpenCL Regularizer", false, false)
 
 void SPIRVOCLRegularizer::visitCallInst(CallInst &CI) {
   auto F = CI.getCalledFunction();

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
@@ -15,6 +15,7 @@
 #include "SPIRVEnumRequirements.h"
 #include "SPIRVGlobalRegistry.h"
 #include "SPIRVLegalizerInfo.h"
+#include "SPIRVRegisterBankInfo.h"
 #include "SPIRVTargetMachine.h"
 #include "llvm/Support/Host.h"
 #include "llvm/Support/TargetRegistry.h"

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.h
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.h
@@ -14,17 +14,15 @@
 #define LLVM_LIB_TARGET_SPIRV_SPIRVSUBTARGET_H
 
 #include "SPIRVCallLowering.h"
-#include "SPIRVSymbolicOperands.h"
 #include "SPIRVExtInsts.h"
 #include "SPIRVFrameLowering.h"
 #include "SPIRVGlobalRegistry.h"
 #include "SPIRVISelLowering.h"
 #include "SPIRVInstrInfo.h"
-#include "SPIRVRegisterBankInfo.h"
+#include "SPIRVSymbolicOperands.h"
 #include "llvm/CodeGen/GlobalISel/CallLowering.h"
 #include "llvm/CodeGen/GlobalISel/InstructionSelector.h"
 #include "llvm/CodeGen/GlobalISel/LegalizerInfo.h"
-#include "llvm/CodeGen/GlobalISel/RegisterBankInfo.h"
 #include "llvm/CodeGen/SelectionDAGTargetInfo.h"
 #include "llvm/CodeGen/TargetSubtargetInfo.h"
 #include "llvm/IR/DataLayout.h"

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -15,7 +15,6 @@
 #include "SPIRVCallLowering.h"
 #include "SPIRVGlobalRegistry.h"
 #include "SPIRVLegalizerInfo.h"
-#include "SPIRVSubtarget.h"
 #include "SPIRVTargetObjectFile.h"
 #include "SPIRVTargetTransformInfo.h"
 #include "TargetInfo/SPIRVTargetInfo.h"


### PR DESCRIPTION
The changes adds Function metadata processing on lowerFormalArguments to support some decorations. Two tests are expected to pass (spirv_param_decorations.ll, spirv_param_decorations_quals.ll). Several includes were fixed as it was done in the latest patch rebase on Phabricator. Also clang-format corrected some issues.