### PR TITLE
[SPIR-V] remove SPIRVInstructionSelect::runOnMachineFunction

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGenerateDecorations.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGenerateDecorations.cpp
@@ -71,27 +71,45 @@ static uint32_t getFastMathFlags(const MachineInstr &I) {
   return flags;
 }
 
+// Defined in SPIRVLegalizerInfo.cpp
+extern bool isTypeFoldingSupported(unsigned Opcode);
+
 bool SPIRVGenerateDecorations::runOnMachineFunction(MachineFunction &MF) {
   MachineIRBuilder MIRBuilder(MF);
+  auto &MRI = MF.getRegInfo();
   for (auto &MBB : MF) {
     MIRBuilder.setMBB(MBB);
     for (auto &MI : MBB) {
       if (!canUseFastMathFlags(MI.getOpcode()))
         continue;
       MIRBuilder.setInstr(MI);
-      auto fmFlags = getFastMathFlags(MI);
-      if (fmFlags != FPFastMathMode::None) {
+      auto FMFlags = getFastMathFlags(MI);
+      if (FMFlags != FPFastMathMode::None) {
+        Register DstReg = MI.getOperand(0).getReg();
         // can be only a source of an ASSIGN_TYPE instr
-        assert(MI.getMF()->getRegInfo().hasOneUse(MI.getOperand(0).getReg()));
-        auto DstReg = MI.getMF()
-                          ->getRegInfo()
-                          .use_instr_begin(MI.getOperand(0).getReg())
-                          ->getOperand(0)
-                          .getReg();
+        assert(MRI.hasOneUse(DstReg) && "One use is expected");
+        Register NewReg = MRI.use_instr_begin(DstReg)->getOperand(0).getReg();
         MIRBuilder.buildInstr(SPIRV::OpDecorate)
-            .addUse(DstReg)
+            .addUse(NewReg)
             .addImm(Decoration::FPFastMathMode)
-            .addImm(fmFlags);
+            .addImm(FMFlags);
+      }
+    }
+  }
+
+  for (auto &MBB : MF) {
+    for (auto &MI : MBB) {
+      // We need to rewrite dst types for ASSIGN_TYPE instrs to be able
+      // to perform tblgen'erated selection and we can't do that on Legalizer
+      // as it operates on gMIR only.
+      if (MI.getOpcode() == SPIRV::ASSIGN_TYPE) {
+        Register SrcReg = MI.getOperand(1).getReg();
+        if (isTypeFoldingSupported(MRI.getVRegDef(SrcReg)->getOpcode())) {
+          Register DstReg = MI.getOperand(0).getReg();
+          if (MRI.getType(DstReg).isVector())
+            MRI.setRegClass(DstReg, &SPIRV::IDRegClass);
+          MRI.setType(DstReg, LLT::scalar(32));
+        }
       }
     }
   }

--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.cpp
@@ -238,3 +238,15 @@ void SPIRVInstrInfo::copyPhysReg(MachineBasicBlock &MBB,
   auto &MRI = I->getMF()->getRegInfo();
   MRI.replaceRegWith(DstOp.getReg(), SrcOp.getReg());
 }
+
+bool SPIRVInstrInfo::expandPostRAPseudo(MachineInstr &MI) const {
+  if (MI.getOpcode() == SPIRV::GET_ID || MI.getOpcode() == SPIRV::GET_fID ||
+      MI.getOpcode() == SPIRV::GET_pID || MI.getOpcode() == SPIRV::GET_vfID ||
+      MI.getOpcode() == SPIRV::GET_vID) {
+    auto &MRI = MI.getMF()->getRegInfo();
+    MRI.replaceRegWith(MI.getOperand(0).getReg(), MI.getOperand(1).getReg());
+    MI.eraseFromParent();
+    return true;
+  }
+  return false;
+}

--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.h
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.h
@@ -48,6 +48,7 @@ public:
   void copyPhysReg(MachineBasicBlock &MBB, MachineBasicBlock::iterator I,
                    const DebugLoc &DL, MCRegister DestReg, MCRegister SrcReg,
                    bool KillSrc) const override;
+  bool expandPostRAPseudo(MachineInstr &MI) const override;
 };
 } // namespace llvm
 

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -210,49 +210,6 @@ class SPIRVInstructionSelect : public InstructionSelect {
     return InstructionSelect::getRequiredProperties().reset(
         MachineFunctionProperties::Property::RegBankSelected);
   }
-
-  // Init a SPIRVGlobalRegistry before and reset it after the default
-  // parent code.
-  bool runOnMachineFunction(MachineFunction &MF) override {
-    auto &MRI = MF.getRegInfo();
-
-    // we need to rewrite dst types for ASSIGN_TYPE instrs
-    // to be able to perform tblgen'erated selection
-    // and we can't do that on Legalizer as it operates on gMIR only
-    // TODO: consider redesigning this approach
-    for (auto &MBB : MF) {
-      for (auto &MI : MBB) {
-        if (MI.getOpcode() == SPIRV::ASSIGN_TYPE) {
-          auto &SrcOp = MI.getOperand(1);
-          if (isTypeFoldingSupported(
-                  MRI.getVRegDef(SrcOp.getReg())->getOpcode())) {
-            if (MRI.getType(MI.getOperand(0).getReg()).isVector())
-              MRI.setRegClass(MI.getOperand(0).getReg(), &SPIRV::IDRegClass);
-            MRI.setType(MI.getOperand(0).getReg(), LLT::scalar(32));
-          }
-        }
-      }
-    }
-
-    bool Success = InstructionSelect::runOnMachineFunction(MF);
-    std::vector<MachineInstr *> ToRemove;
-    for (auto &MBB : MF) {
-      for (auto &MI : MBB) {
-        if (MI.getOpcode() == SPIRV::GET_ID ||
-            MI.getOpcode() == SPIRV::GET_fID ||
-            MI.getOpcode() == SPIRV::GET_pID ||
-            MI.getOpcode() == SPIRV::GET_vfID ||
-            MI.getOpcode() == SPIRV::GET_vID) {
-          MRI.replaceRegWith(MI.getOperand(0).getReg(),
-                             MI.getOperand(1).getReg());
-          ToRemove.push_back(&MI);
-        }
-      }
-    }
-    for (auto *MI : ToRemove)
-      MI->eraseFromParent();
-    return Success;
-  }
 };
 } // namespace
 


### PR DESCRIPTION
The change removes custom SPIRVInstructionSelect::runOnMachineFunction function moving specific MI processing around InstructionSelect::runOnMachineFunction() call to the previous and the subsequent passes.