### PR TITLE
[SPIR-V] support OpSwitch instruction

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -27,4 +27,5 @@ let TargetPrefix = "spv" in {
   def int_spv_insertelt : Intrinsic<[llvm_any_ty], [llvm_any_ty, llvm_any_ty, llvm_anyint_ty]>;
   def int_spv_const_composite : Intrinsic<[llvm_i32_ty], [llvm_vararg_ty]>;
   def int_spv_bitcast : Intrinsic<[llvm_any_ty], [llvm_any_ty]>;
+  def int_spv_switch : Intrinsic<[], [llvm_any_ty, llvm_vararg_ty]>;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -124,7 +124,7 @@ void SPIRVAsmPrinter::emitFunctionHeader() {
   MF->setSection(Section);
 }
 
-// The table maps MMB number to SPIR-V unique ID register.
+// The table maps MBB number to SPIR-V unique ID register.
 static DenseMap<int, Register> BBNumToRegMap;
 
 void SPIRVAsmPrinter::outputOpFunctionEnd() {
@@ -155,6 +155,8 @@ Register getOrCreateMBBRegister(const MachineBasicBlock &MBB,
 }
 
 void SPIRVAsmPrinter::emitOpLabel(const MachineBasicBlock &MBB) {
+  if (MAI->MBBsToSkip.contains(&MBB))
+    return;
   MCInst LabelInst;
   LabelInst.setOpcode(SPIRV::OpLabel);
   LabelInst.addOperand(MCOperand::createReg(getOrCreateMBBRegister(MBB, MAI)));
@@ -245,7 +247,7 @@ void SPIRVAsmPrinter::emitInstruction(const MachineInstr *MI) {
   if (!MAI->getSkipEmission(MI))
     outputInstruction(MI);
 
-  // Output OpLabel after OpFunction and OpFunctionParameter in the first MMB.
+  // Output OpLabel after OpFunction and OpFunctionParameter in the first MBB.
   const MachineInstr *NextMI = MI->getNextNode();
   if (!hasMBBRegister(*MI->getParent()) && isFuncOrHeaderInstr(MI, TII) &&
       (!NextMI || !isFuncOrHeaderInstr(NextMI, TII))) {

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -1434,6 +1434,20 @@ bool SPIRVInstructionSelector::selectIntrinsic(
     }
     return MIB.constrainAllUses(TII, TRI, RBI);
   } break;
+  case Intrinsic::spv_switch: {
+    auto MIB = MIRBuilder.buildInstr(SPIRV::OpSwitch);
+    for (unsigned i = 1; i < I.getNumExplicitOperands(); ++i) {
+      if (I.getOperand(i).isReg())
+        MIB.addReg(I.getOperand(i).getReg());
+      else if (I.getOperand(i).isCImm())
+        addNumImm(I.getOperand(i).getCImm()->getValue(), MIB);
+      else if (I.getOperand(i).isMBB())
+        MIB.addMBB(I.getOperand(i).getMBB());
+      else
+        llvm_unreachable("Unexpected OpSwitch operand");
+    }
+    return MIB.constrainAllUses(TII, TRI, RBI);
+  } break;
   default:
     llvm_unreachable("Intrinsic selection not implemented");
   }

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
@@ -66,6 +66,9 @@ struct ModuleAnalysisInfo {
   // The set contains machine instructions which are necessary
   // for correct MIR but will not be emitted in function bodies.
   DenseSet<MachineInstr *> InstrsToDelete;
+  // The set contains machine basic blocks which are necessary
+  // for correct MIR but will not be emitted.
+  DenseSet<MachineBasicBlock *> MBBsToSkip;
   // The table contains global aliases of local registers for each machine
   // function. The aliases are used to substitute local registers during
   // code emission.

--- a/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
@@ -294,24 +294,6 @@ static Register buildOpSampledImage(Register res, Register image,
   return sampledImage;
 }
 
-static MachineInstr *getDefInstrMaybeConstant(Register &constVReg,
-                                      const MachineRegisterInfo *MRI) {
-  MachineInstr *constInstr = MRI->getVRegDef(constVReg);
-  if (constInstr->getOpcode() == TargetOpcode::G_INTRINSIC_W_SIDE_EFFECTS &&
-      constInstr->getIntrinsicID() == Intrinsic::spv_track_constant) {
-    constVReg = constInstr->getOperand(2).getReg();
-    constInstr = MRI->getVRegDef(constVReg);
-  }
-  return constInstr;
-}
-
-static uint64_t getIConstVal(Register constReg,
-                             const MachineRegisterInfo *MRI) {
-  const auto c = getDefInstrMaybeConstant(constReg, MRI);
-  assert(c && c->getOpcode() == TargetOpcode::G_CONSTANT);
-  return c->getOperand(1).getCImm()->getValue().getZExtValue();
-}
-
 static Register buildBuiltInLoad(MachineIRBuilder &MIRBuilder,
                               SPIRVType *varType,
                               SPIRVGlobalRegistry *GR, BuiltIn::BuiltIn builtIn,

--- a/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
@@ -379,6 +379,89 @@ static void processInstrsWithTypeFolding(MachineFunction &MF,
         processInstr(MI, MIB, MRI, GR);
 }
 
+static void processSwitches(MachineFunction &MF, SPIRVGlobalRegistry *GR) {
+  DenseMap<Register, SmallDenseMap<uint64_t, MachineBasicBlock *>>
+      SwitchRegToMBB;
+  DenseMap<Register, MachineBasicBlock *> DefaultMBBs;
+  DenseSet<Register> SwitchRegs;
+  auto &MRI = MF.getRegInfo();
+  MachineIRBuilder MIB(MF);
+
+  // Walk MIs and collect information about destination MBBs to update
+  // spv_switch call. We assume that all spv_switch precede corresponding ICMPs.
+  for (auto &MBB : MF) {
+    for (auto &MI : MBB) {
+      if (isSpvIntrinsic(MI, Intrinsic::spv_switch)) {
+        assert(MI.getOperand(1).isReg());
+        Register Reg = MI.getOperand(1).getReg();
+        SwitchRegs.insert(Reg);
+        // Set the first successor as default MBB to support empty switches.
+        DefaultMBBs[Reg] = *MBB.succ_begin();
+      }
+      // Process only ICMPs that relate to spv_switches.
+      if (MI.getOpcode() == TargetOpcode::G_ICMP && MI.getOperand(2).isReg() &&
+          SwitchRegs.contains(MI.getOperand(2).getReg())) {
+        assert(MI.getOperand(0).isReg() && MI.getOperand(1).isPredicate() &&
+               MI.getOperand(3).isReg());
+        Register Dst = MI.getOperand(0).getReg();
+        // Set type info for destination register of switch's ICMP instruction.
+        if (GR->getSPIRVTypeForVReg(Dst) == nullptr) {
+          MIB.setInsertPt(*MI.getParent(), MI);
+          Type *LLVMTy = IntegerType::get(MF.getFunction().getContext(), 1);
+          SPIRVType *SpirvTy = GR->getOrCreateSPIRVType(LLVMTy, MIB);
+          MRI.setRegClass(Dst, &SPIRV::IDRegClass);
+          GR->assignSPIRVTypeToVReg(SpirvTy, Dst, MIB);
+        }
+        Register CmpReg = MI.getOperand(2).getReg();
+        auto PredOp = MI.getOperand(1);
+        const auto CC = static_cast<CmpInst::Predicate>(PredOp.getPredicate());
+        assert(CC == CmpInst::ICMP_EQ && MRI.hasOneUse(Dst) &&
+               MRI.hasOneDef(CmpReg));
+        uint64_t Val = getIConstVal(MI.getOperand(3).getReg(), &MRI);
+        MachineInstr *CBr = MRI.use_begin(Dst)->getParent();
+        assert(CBr->getOpcode() == SPIRV::G_BRCOND &&
+               CBr->getOperand(1).isMBB());
+        SwitchRegToMBB[CmpReg][Val] = CBr->getOperand(1).getMBB();
+        // The next MI is always BR to either the next case or the default.
+        MachineInstr *NextMI = CBr->getNextNode();
+        assert(NextMI->getOpcode() == SPIRV::G_BR &&
+               NextMI->getOperand(0).isMBB());
+        MachineBasicBlock *NextMBB = NextMI->getOperand(0).getMBB();
+        assert(NextMBB != nullptr);
+        // The default MBB is not started by ICMP with switch's cmp register.
+        if (NextMBB->instr_front().getOpcode() != SPIRV::G_ICMP ||
+            (NextMBB->instr_front().getOperand(2).isReg() &&
+             NextMBB->instr_front().getOperand(2).getReg() != CmpReg))
+          DefaultMBBs[CmpReg] = NextMBB;
+      }
+    }
+  }
+  // Modify spv_switch's operands by collected values.
+  for (auto &MBB : MF)
+    for (auto &MI : MBB)
+      if (isSpvIntrinsic(MI, Intrinsic::spv_switch)) {
+        assert(MI.getOperand(1).isReg());
+        Register Reg = MI.getOperand(1).getReg();
+        unsigned NumOp = MI.getNumExplicitOperands();
+        SmallVector<const ConstantInt *, 3> Vals;
+        SmallVector<MachineBasicBlock *, 3> MBBs;
+        for (unsigned i = 2; i < NumOp; i++) {
+          Register CReg = MI.getOperand(i).getReg();
+          uint64_t Val = getIConstVal(CReg, &MRI);
+          MachineInstr *ConstInstr = getDefInstrMaybeConstant(CReg, &MRI);
+          Vals.push_back(ConstInstr->getOperand(1).getCImm());
+          MBBs.push_back(SwitchRegToMBB[Reg][Val]);
+        }
+        for (unsigned i = MI.getNumExplicitOperands() - 1; i > 1; i--)
+          MI.RemoveOperand(i);
+        MI.addOperand(MachineOperand::CreateMBB(DefaultMBBs[Reg]));
+        for (unsigned i = 0; i < Vals.size(); i++) {
+          MI.addOperand(MachineOperand::CreateCImm(Vals[i]));
+          MI.addOperand(MachineOperand::CreateMBB(MBBs[i]));
+        }
+      }
+}
+
 bool SPIRVPreLegalizer::runOnMachineFunction(MachineFunction &MF) {
   // Initialize the type registry
   const auto *ST = static_cast<const SPIRVSubtarget *>(&MF.getSubtarget());
@@ -389,6 +472,7 @@ bool SPIRVPreLegalizer::runOnMachineFunction(MachineFunction &MF) {
   insertBitcasts(MF, GR);
   generateAssignInstrs(MF, GR);
   processInstrsWithTypeFolding(MF, GR);
+  processSwitches(MF, GR);
 
   return true;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -13,6 +13,7 @@
 #include "SPIRVUtils.h"
 #include "SPIRV.h"
 #include "SPIRVStringReader.h"
+#include "llvm/IR/IntrinsicsSPIRV.h"
 
 using namespace llvm;
 
@@ -176,4 +177,24 @@ bool constrainRegOperands(MachineInstrBuilder &MIB, MachineFunction *MF) {
   const RegisterBankInfo *RBI = Subtarget.getRegBankInfo();
 
   return constrainSelectedInstRegOperands(*MIB, *TII, *TRI, *RBI);
+}
+
+MachineInstr *getDefInstrMaybeConstant(Register &ConstReg,
+                                       const MachineRegisterInfo *MRI) {
+  MachineInstr *ConstInstr = MRI->getVRegDef(ConstReg);
+  if (ConstInstr->getOpcode() == TargetOpcode::G_INTRINSIC_W_SIDE_EFFECTS &&
+      ConstInstr->getIntrinsicID() == Intrinsic::spv_track_constant) {
+    ConstReg = ConstInstr->getOperand(2).getReg();
+    ConstInstr = MRI->getVRegDef(ConstReg);
+  } else if (ConstInstr->getOpcode() == SPIRV::ASSIGN_TYPE) {
+    ConstReg = ConstInstr->getOperand(1).getReg();
+    ConstInstr = MRI->getVRegDef(ConstReg);
+  }
+  return ConstInstr;
+}
+
+uint64_t getIConstVal(Register ConstReg, const MachineRegisterInfo *MRI) {
+  const MachineInstr *MI = getDefInstrMaybeConstant(ConstReg, MRI);
+  assert(MI && MI->getOpcode() == TargetOpcode::G_CONSTANT);
+  return MI->getOperand(1).getCImm()->getValue().getZExtValue();
 }

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -61,4 +61,15 @@ bool constrainRegOperands(llvm::MachineInstrBuilder &MIB,
 
 MemorySemantics::MemorySemantics
 getMemSemanticsForStorageClass(StorageClass::StorageClass sc);
+
+// Find def instruction for the given ConstReg, walking through
+// spv_track_constant and ASSIGN_TYPE instructions. Updates ConstReg by def
+// of OpConstant instruction.
+llvm::MachineInstr *
+getDefInstrMaybeConstant(llvm::Register &ConstReg,
+                         const llvm::MachineRegisterInfo *MRI);
+
+// Get constant integer value of the given ConstReg.
+uint64_t getIConstVal(llvm::Register ConstReg,
+                      const llvm::MachineRegisterInfo *MRI);
 #endif // LLVM_LIB_TARGET_SPIRV_SPIRVUTILS_H

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpSwitchEmpty.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpSwitchEmpty.ll
@@ -11,7 +11,7 @@
 ; RUN: llc -O0 %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; CHECK-SPIRV: %[[X:[0-9]+]] = OpFunctionParameter %{{[0-9]+}}
-; CHECK-SPIRV: OpSwitch %[[X]] %[[DEFAULT:[0-9]+]] {{$}}
+; CHECK-SPIRV: OpSwitch %[[X]] %[[DEFAULT:[0-9]+]]{{$}}
 ; CHECK-SPIRV: %[[DEFAULT]] = OpLabel
 
 ; ModuleID = 'test/SPIRV/OpSwitchEmpty.ll'


### PR DESCRIPTION
The change implements OpSwitch support using spv_switch intrinsic. 4 LIT tests with switches are passed.