### PR TITLE
[SPIR-V] move SPIRVSymbolicOperands to MCTargetDesc/SPIRVBaseInfo

### DIFF
--- a/llvm/lib/Target/SPIRV/CMakeLists.txt
+++ b/llvm/lib/Target/SPIRV/CMakeLists.txt
@@ -20,7 +20,6 @@ add_llvm_target(SPIRVCodeGen
   SPIRVCallLowering.cpp
   SPIRVCapabilityUtils.cpp
   SPIRVDuplicatesTracker.cpp
-  SPIRVSymbolicOperands.cpp
   SPIRVEnumRequirements.cpp
   SPIRVExtInsts.cpp
   SPIRVGenerateDecorations.cpp

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/CMakeLists.txt
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_llvm_component_library(LLVMSPIRVDesc
+  SPIRVBaseInfo.cpp
   SPIRVMCAsmInfo.cpp
   SPIRVMCTargetDesc.cpp
   SPIRVTargetStreamer.cpp
@@ -6,7 +7,6 @@ add_llvm_component_library(LLVMSPIRVDesc
   SPIRVMCCodeEmitter.cpp
   SPIRVObjectTargetWriter.cpp
   SPIRVInstPrinter.cpp
-  ../SPIRVSymbolicOperands.cpp
   ../SPIRVExtInsts.cpp
 
   LINK_COMPONENTS

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.cpp
@@ -1,4 +1,4 @@
-//===-- SPIRVSymbolicOperands.cpp - Top level SPIRV definitions -*- C++ -*-===//
+//===-- SPIRVBaseInfo.cpp - Top level SPIRV definitions ---------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -12,8 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "SPIRVSymbolicOperands.h"
-
+#include "SPIRVBaseInfo.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/StringRef.h"
 

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.h
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.h
@@ -1,4 +1,4 @@
-//===-- SPIRVSymbolicOperands.h - Top level SPIRV definitions ---*- C++ -*-===//
+//===-- SPIRVBaseInfo.h - Top level SPIRV definitions -----------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,12 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// This file contains TableGen generated enum definitions, mnemonic lookup 
+// This file contains TableGen generated enum definitions, mnemonic lookup
 // functions, versioning/capabilities/extensions getters for symbolic/named
 // operands for various SPIR-V instructions.
 //
 //===----------------------------------------------------------------------===//
-
 
 #ifndef LLVM_LIB_TARGET_SPIRV_SPIRVSYMBOLICOPERANDS_H
 #define LLVM_LIB_TARGET_SPIRV_SPIRVSYMBOLICOPERANDS_H
@@ -24,162 +23,162 @@
 namespace OperandCategory {
 #define GET_OperandCategory_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace OperandCategory
 
 namespace Extension {
 #define GET_Extension_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace Extension
 
 namespace Capability {
 #define GET_Capability_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace Capability
 
 namespace SourceLanguage {
 #define GET_SourceLanguage_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace SourceLanguage
 
 namespace AddressingModel {
 #define GET_AddressingModel_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace AddressingModel
 
 namespace ExecutionModel {
 #define GET_ExecutionModel_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace ExecutionModel
 
 namespace MemoryModel {
 #define GET_MemoryModel_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace MemoryModel
 
 namespace ExecutionMode {
 #define GET_ExecutionMode_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace ExecutionMode
 
 namespace StorageClass {
 #define GET_StorageClass_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace StorageClass
 
 namespace Dim {
 #define GET_Dim_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace Dim
 
 namespace SamplerAddressingMode {
 #define GET_SamplerAddressingMode_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace SamplerAddressingMode
 
 namespace SamplerFilterMode {
 #define GET_SamplerFilterMode_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace SamplerFilterMode
 
 namespace ImageFormat {
 #define GET_ImageFormat_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace ImageFormat
 
 namespace ImageChannelOrder {
 #define GET_ImageChannelOrder_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace ImageChannelOrder
 
 namespace ImageChannelDataType {
 #define GET_ImageChannelDataType_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace ImageChannelDataType
 
 namespace ImageOperand {
 #define GET_ImageOperand_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace ImageOperand
 
 namespace FPFastMathMode {
 #define GET_FPFastMathMode_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace FPFastMathMode
 
 namespace FPRoundingMode {
 #define GET_FPRoundingMode_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace FPRoundingMode
 
 namespace LinkageType {
 #define GET_LinkageType_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace LinkageType
 
 namespace AccessQualifier {
 #define GET_AccessQualifier_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace AccessQualifier
 
 namespace FunctionParameterAttribute {
 #define GET_FunctionParameterAttribute_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace FunctionParameterAttribute
 
 namespace Decoration {
 #define GET_Decoration_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace Decoration
 
 namespace BuiltIn {
 #define GET_BuiltIn_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace BuiltIn
 
 namespace SelectionControl {
 #define GET_SelectionControl_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace SelectionControl
 
 namespace LoopControl {
 #define GET_LoopControl_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace LoopControl
 
 namespace FunctionControl {
 #define GET_FunctionControl_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace FunctionControl
 
 namespace MemorySemantics {
 #define GET_MemorySemantics_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace MemorySemantics
 
 namespace MemoryOperand {
 #define GET_MemoryOperand_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace MemoryOperand
 
 namespace Scope {
 #define GET_Scope_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace Scope
 
 namespace GroupOperation {
 #define GET_GroupOperation_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace GroupOperation
 
 namespace KernelEnqueueFlags {
 #define GET_KernelEnqueueFlags_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace KernelEnqueueFlags
 
 namespace KernelProfilingInfo {
 #define GET_KernelProfilingInfo_DECL
 #include "SPIRVGenTables.inc"
-}
+} // namespace KernelProfilingInfo
 
 std::string
 getSymbolicOperandMnemonic(::OperandCategory::OperandCategory Category,

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
@@ -11,6 +11,10 @@
 //===----------------------------------------------------------------------===//
 
 #include "SPIRVInstPrinter.h"
+#include "SPIRV.h"
+#include "SPIRVBaseInfo.h"
+#include "SPIRVExtInsts.h"
+#include "SPIRVStringReader.h"
 #include "llvm/CodeGen/Register.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCExpr.h"
@@ -19,11 +23,6 @@
 #include "llvm/MC/MCSymbol.h"
 #include "llvm/Support/ErrorHandling.h"
 #include "llvm/Support/FormattedStream.h"
-
-#include "SPIRV.h"
-#include "SPIRVExtInsts.h"
-#include "SPIRVStringReader.h"
-#include "SPIRVSymbolicOperands.h"
 
 using namespace llvm;
 

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.h
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.h
@@ -13,8 +13,8 @@
 #ifndef LLVM_LIB_TARGET_SPIRV_INSTPRINTER_SPIRVINSTPRINTER_H
 #define LLVM_LIB_TARGET_SPIRV_INSTPRINTER_SPIRVINSTPRINTER_H
 
+#include "MCTargetDesc/SPIRVBaseInfo.h"
 #include "SPIRVExtInsts.h"
-#include "SPIRVSymbolicOperands.h"
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/MC/MCInstPrinter.h"
 

--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -12,13 +12,13 @@
 //===----------------------------------------------------------------------===//
 
 #include "SPIRVCallLowering.h"
+#include "MCTargetDesc/SPIRVBaseInfo.h"
 #include "SPIRV.h"
 #include "SPIRVGlobalRegistry.h"
 #include "SPIRVISelLowering.h"
 #include "SPIRVOpenCLBIFs.h"
 #include "SPIRVRegisterInfo.h"
 #include "SPIRVSubtarget.h"
-#include "SPIRVSymbolicOperands.h"
 #include "SPIRVUtils.h"
 #include "llvm/CodeGen/FunctionLoweringInfo.h"
 #include "llvm/Demangle/Demangle.h"

--- a/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.h
+++ b/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.h
@@ -14,7 +14,7 @@
 #ifndef LLVM_LIB_TARGET_SPIRV_SPIRVDUPLICATESTRACKER_H
 #define LLVM_LIB_TARGET_SPIRV_SPIRVDUPLICATESTRACKER_H
 
-#include "SPIRVSymbolicOperands.h"
+#include "MCTargetDesc/SPIRVBaseInfo.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"

--- a/llvm/lib/Target/SPIRV/SPIRVEnumRequirements.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEnumRequirements.cpp
@@ -11,7 +11,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "SPIRVSymbolicOperands.h"
+#include "MCTargetDesc/SPIRVBaseInfo.h"
 #include "SPIRVEnumRequirements.h"
 #include "SPIRVSubtarget.h"
 

--- a/llvm/lib/Target/SPIRV/SPIRVEnumRequirements.h
+++ b/llvm/lib/Target/SPIRV/SPIRVEnumRequirements.h
@@ -14,7 +14,7 @@
 #ifndef LLVM_LIB_TARGET_SPIRV_ENUMREQUIREMENTS_H
 #define LLVM_LIB_TARGET_SPIRV_ENUMREQUIREMENTS_H
 
-#include "SPIRVSymbolicOperands.h"
+#include "MCTargetDesc/SPIRVBaseInfo.h"
 #include "llvm/ADT/Optional.h"
 
 namespace llvm {

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -17,7 +17,6 @@
 #include "SPIRVGlobalRegistry.h"
 #include "SPIRV.h"
 #include "SPIRVOpenCLBIFs.h"
-#include "SPIRVSymbolicOperands.h"
 #include "SPIRVSubtarget.h"
 #include "SPIRVTargetMachine.h"
 #include "SPIRVUtils.h"

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -16,8 +16,8 @@
 #ifndef LLVM_LIB_TARGET_SPIRV_SPIRVTYPEMANAGER_H
 #define LLVM_LIB_TARGET_SPIRV_SPIRVTYPEMANAGER_H
 
+#include "MCTargetDesc/SPIRVBaseInfo.h"
 #include "SPIRVDuplicatesTracker.h"
-#include "SPIRVSymbolicOperands.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 
 namespace AQ = AccessQualifier;

--- a/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
@@ -14,9 +14,9 @@
 #include "SPIRVOpenCLBIFs.h"
 #include "SPIRV.h"
 #include "SPIRVExtInsts.h"
-#include "SPIRVSymbolicOperands.h"
 #include "SPIRVRegisterInfo.h"
 #include "SPIRVUtils.h"
+#include "MCTargetDesc/SPIRVBaseInfo.h"
 
 #include "llvm/IR/IntrinsicsSPIRV.h"
 

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.h
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.h
@@ -13,13 +13,13 @@
 #ifndef LLVM_LIB_TARGET_SPIRV_SPIRVSUBTARGET_H
 #define LLVM_LIB_TARGET_SPIRV_SPIRVSUBTARGET_H
 
+#include "MCTargetDesc/SPIRVBaseInfo.h"
 #include "SPIRVCallLowering.h"
 #include "SPIRVExtInsts.h"
 #include "SPIRVFrameLowering.h"
 #include "SPIRVGlobalRegistry.h"
 #include "SPIRVISelLowering.h"
 #include "SPIRVInstrInfo.h"
-#include "SPIRVSymbolicOperands.h"
 #include "llvm/CodeGen/GlobalISel/CallLowering.h"
 #include "llvm/CodeGen/GlobalISel/InstructionSelector.h"
 #include "llvm/CodeGen/GlobalISel/LegalizerInfo.h"

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -13,7 +13,7 @@
 #ifndef LLVM_LIB_TARGET_SPIRV_SPIRVUTILS_H
 #define LLVM_LIB_TARGET_SPIRV_SPIRVUTILS_H
 
-#include "SPIRVSymbolicOperands.h"
+#include "MCTargetDesc/SPIRVBaseInfo.h"
 #include "llvm/ADT/StringRef.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 #include "llvm/CodeGen/MachineInstr.h"


### PR DESCRIPTION
I propose to move SPIRVSymbolicOperands.* to MCTargetDesc/SPIRVBaseInfo.* and avoid duplication of the source file in CMakeLists.txt and MCTargetDesc/CMakeLists.txt as it's implemented in the 5th patch of LLVM review.