### PR TITLE
[SPIR-V] reduce usage of stl containers in EmitIntrinsics

### DIFF
--- a/llvm/lib/MC/MCSPIRVStreamer.cpp
+++ b/llvm/lib/MC/MCSPIRVStreamer.cpp
@@ -19,7 +19,7 @@ void MCSPIRVStreamer::emitInstToData(const MCInst &Inst,
                                      const MCSubtargetInfo &STI) {
   MCAssembler &Assembler = getAssembler();
   SmallVector<MCFixup, 0> Fixups;
-  SmallString<512> Code;
+  SmallString<256> Code;
   raw_svector_ostream VecOS(Code);
   Assembler.getEmitter().encodeInstruction(Inst, VecOS, Fixups, STI);
 

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCCodeEmitter.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVMCCodeEmitter.cpp
@@ -90,7 +90,7 @@ static void emitOperand(const MCOperand &Op, EndianWriter &OSE) {
   } else if (Op.isImm()) {
     OSE.write<uint32_t>(Op.getImm());
   } else {
-    llvm_unreachable("Error: Unexpected operand type in VReg");
+    llvm_unreachable("Unexpected operand type in VReg");
   }
 }
 


### PR DESCRIPTION
The change removes std::unordered_map usage and reduces use of std::vector in SPIRVEmitIntrinsics.cpp. Also it ports small fixes from new reviewing of the 3rd patch.