### PR TITLE
[SPIR-V] insert OpExecutionMode instructions

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
@@ -453,6 +453,7 @@ def OpCopyLogical: UnOp<"OpCopyLogical", 400>;
 
 def OpSNegate: UnOp<"OpSNegate", 126>;
 def OpFNegate: UnOpTyped<"OpFNegate", 127, fID, fneg>;
+def OpFNegateV: UnOpTyped<"OpFNegate", 127, vfID, fneg>;
 defm OpIAdd: BinOpTypedGen<"OpIAdd", 128, add, 0, 1>;
 defm OpFAdd: BinOpTypedGen<"OpFAdd", 129, fadd, 1, 1>;
 

--- a/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
@@ -244,9 +244,7 @@ static void generateAssignInstrs(MachineFunction &MF, SPIRVGlobalRegistry *GR) {
 
       if (isSpvIntrinsic(MI, Intrinsic::spv_assign_type)) {
         auto Reg = MI.getOperand(1).getReg();
-        auto *Ty =
-            cast<ValueAsMetadata>(MI.getOperand(2).getMetadata()->getOperand(0))
-                ->getType();
+        auto *Ty = getMDOperandAsType(MI.getOperand(2).getMetadata(), 0);
         auto *Def = MRI.getVRegDef(Reg);
         assert(Def && "Expecting an instruction that defines the register");
         // G_GLOBAL_VALUE already has type info.

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.cpp
@@ -185,6 +185,10 @@ void SPIRVSubtarget::initAvailableCapabilities(const Triple &TT) {
                GroupNonUniformBallot, GroupNonUniformClustered,
                GroupNonUniformShuffle, GroupNonUniformShuffleRelative});
     }
+    if (isAtLeastVer(TargetSPIRVVersion, 14))
+      addCaps(AvailableCaps,
+              {DenormPreserve, DenormFlushToZero, SignedZeroInfNanPreserve,
+               RoundingModeRTE, RoundingModeRTZ});
 
     // TODO Remove this - it's only here because the tests assume it's supported
     addCaps(AvailableCaps, {Float16, Float64});

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -198,3 +198,7 @@ uint64_t getIConstVal(Register ConstReg, const MachineRegisterInfo *MRI) {
   assert(MI && MI->getOpcode() == TargetOpcode::G_CONSTANT);
   return MI->getOperand(1).getCImm()->getValue().getZExtValue();
 }
+
+Type *getMDOperandAsType(const MDNode *N, unsigned I) {
+  return cast<ValueAsMetadata>(N->getOperand(I))->getType();
+}

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -71,4 +71,7 @@ getDefInstrMaybeConstant(llvm::Register &ConstReg,
 // Get constant integer value of the given ConstReg.
 uint64_t getIConstVal(llvm::Register ConstReg,
                       const llvm::MachineRegisterInfo *MRI);
+
+// Get type of i-th operand of the metadata node.
+llvm::Type *getMDOperandAsType(const llvm::MDNode *N, unsigned I);
 #endif // LLVM_LIB_TARGET_SPIRV_SPIRVUTILS_H


### PR DESCRIPTION
The change adds insertion of OpExecutionMode instructions from metadata. Also it adds corresponding OpCapability insertions. 6 LIT tests should pass (ExecutionMode.ll, exec_mode_float_control_khr.ll, preprocess-metadata.ll, transcoding/ExecutionMode_SPIR_to_SPIRV.ll, transcoding/ReqdSubgroupSize.ll, transcoding/vec_type_hint.ll).