### PR TITLE
[SPIR-V] support UserSemantic decoration

### DIFF
--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.cpp
@@ -248,6 +248,7 @@ void SPIRVInstPrinter::printOpDecorate(const MCInst *MI, raw_ostream &O) {
           MI, NumFixedOps, O);
       break;
     case Decoration::LinkageAttributes:
+    case Decoration::UserSemantic:
       printStringImm(MI, NumFixedOps, O);
       break;
     default:

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -319,6 +319,9 @@ Instruction *SPIRVEmitIntrinsics::visitAllocaInst(AllocaInst &I) {
 }
 
 void SPIRVEmitIntrinsics::processGlobalValue(GlobalVariable &GV) {
+  // Skip special artifical variable llvm.global.annotations.
+  if (GV.getName() == "llvm.global.annotations")
+    return;
   if (GV.hasInitializer() && !isa<UndefValue>(GV.getInitializer())) {
     Constant *Init = GV.getInitializer();
     Type *Ty = isAggrToReplace(Init) ? IRB->getInt32Ty() : Init->getType();

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -1533,8 +1533,8 @@ bool SPIRVInstructionSelector::selectGlobalValue(
       GR.getOrCreateSPIRVType(GV->getType(), MIRBuilder, AQ::ReadWrite, false);
 
   std::string GlobalIdent = GV->getGlobalIdentifier();
-  // TODO: suport @llvm.global.annotations
   auto GlobalVar = cast<GlobalVariable>(GV);
+  assert(GlobalVar->getName() != "llvm.global.annotations");
 
   bool HasInit = GlobalVar->hasInitializer() &&
                  !isa<UndefValue>(GlobalVar->getInitializer());


### PR DESCRIPTION
The change adds support of UserSemantic decoration processing llvm.global.annotations like in the translator. One LIT test should pass (transcoding/GlobalFunAnnotate.ll).