### PR TITLE
[SPIR-V] support OpSpecConstantOp creation

### DIFF
--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.h
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.h
@@ -180,6 +180,11 @@ namespace KernelProfilingInfo {
 #include "SPIRVGenTables.inc"
 } // namespace KernelProfilingInfo
 
+namespace Opcode {
+#define GET_Opcode_DECL
+#include "SPIRVGenTables.inc"
+} // namespace Opcode
+
 std::string
 getSymbolicOperandMnemonic(::OperandCategory::OperandCategory Category,
                            int32_t Value);

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -352,7 +352,9 @@ void SPIRVEmitIntrinsics::insertAssignTypeIntrs(Instruction *I) {
     buildIntrWithMD(Intrinsic::spv_assign_type, {Ty}, Const, I);
   }
   for (const auto &Op : I->operands()) {
-    if (isa<ConstantPointerNull>(Op) || isa<UndefValue>(Op)) {
+    if (isa<ConstantPointerNull>(Op) || isa<UndefValue>(Op) ||
+        // Check GetElementPtrConstantExpr case.
+        (isa<ConstantExpr>(Op) && isa<GEPOperator>(Op))) {
       IRB->SetInsertPoint(I);
       buildIntrWithMD(Intrinsic::spv_assign_type, {Op->getType()}, Op, Op);
     }

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -658,37 +658,36 @@ bool SPIRVGlobalRegistry::isScalarOrVectorOfType(
 
 unsigned
 SPIRVGlobalRegistry::getScalarOrVectorBitWidth(const SPIRVType *Type) const {
-  if (Type && Type->getOpcode() == SPIRV::OpTypeVector) {
+  assert(Type && "Invalid Type pointer");
+  if (Type->getOpcode() == SPIRV::OpTypeVector) {
     auto EleTypeReg = Type->getOperand(1).getReg();
     Type = getSPIRVTypeForVReg(EleTypeReg);
   }
-  if (Type && (Type->getOpcode() == SPIRV::OpTypeInt ||
-               Type->getOpcode() == SPIRV::OpTypeFloat))
+  if (Type->getOpcode() == SPIRV::OpTypeInt ||
+      Type->getOpcode() == SPIRV::OpTypeFloat)
     return Type->getOperand(1).getImm();
-  if (Type && Type->getOpcode() == SPIRV::OpTypeBool)
+  if (Type->getOpcode() == SPIRV::OpTypeBool)
     return 1;
   llvm_unreachable("Attempting to get bit width of non-integer/float type.");
 }
 
 bool SPIRVGlobalRegistry::isScalarOrVectorSigned(const SPIRVType *Type) const {
-  if (Type && Type->getOpcode() == SPIRV::OpTypeVector) {
+  assert(Type && "Invalid Type pointer");
+  if (Type->getOpcode() == SPIRV::OpTypeVector) {
     auto EleTypeReg = Type->getOperand(1).getReg();
     Type = getSPIRVTypeForVReg(EleTypeReg);
   }
-  if (Type && Type->getOpcode() == SPIRV::OpTypeInt) {
+  if (Type->getOpcode() == SPIRV::OpTypeInt)
     return Type->getOperand(2).getImm() != 0;
-  }
   llvm_unreachable("Attempting to get sign of non-integer type.");
 }
 
 StorageClass::StorageClass
 SPIRVGlobalRegistry::getPointerStorageClass(Register VReg) const {
   SPIRVType *Type = getSPIRVTypeForVReg(VReg);
-  if (Type && Type->getOpcode() == SPIRV::OpTypePointer) {
-    auto scOp = Type->getOperand(1).getImm();
-    return static_cast<StorageClass::StorageClass>(scOp);
-  }
-  llvm_unreachable("Attempting to get storage class of non-pointer type.");
+  assert(Type && Type->getOpcode() == SPIRV::OpTypePointer &&
+         Type->getOperand(1).isImm() && "Pointer type is expected");
+  return static_cast<StorageClass::StorageClass>(Type->getOperand(1).getImm());
 }
 
 SPIRVType *SPIRVGlobalRegistry::getOpTypeImage(

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -448,6 +448,10 @@ bool SPIRVInstructionSelector::spvSelect(Register ResVReg,
   case TargetOpcode::G_ADDRSPACE_CAST:
     return selectAddrSpaceCast(ResVReg, ResType, I);
   case TargetOpcode::G_PTR_ADD: {
+    // Currently, we get G_PTR_ADD only as a result of translating
+    // global variables, initialized with constant expressions (see test
+    // opencl/basic/progvar_prog_scope_init.ll).
+    // TODO: extend the handler once we have other cases.
     const SPIRVType *SpvI32Ty = GR.getOrCreateSPIRVIntegerType(32, I, TII);
     Register Idx = buildZerosVal(SpvI32Ty, I);
     MachineBasicBlock &BB = *I.getParent();

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -216,6 +216,8 @@ void SPIRVInstructionSelector::setupMF(MachineFunction &MF, GISelKnownBits *KB,
   InstructionSelector::setupMF(MF, KB, CoverageInfo, PSI, BFI);
 }
 
+static bool isImm(const MachineOperand &MO, MachineRegisterInfo *MRI);
+
 // Defined in SPIRVLegalizerInfo.cpp
 extern bool isTypeFoldingSupported(unsigned Opcode);
 
@@ -449,17 +451,22 @@ bool SPIRVInstructionSelector::spvSelect(Register ResVReg,
     return selectAddrSpaceCast(ResVReg, ResType, I);
   case TargetOpcode::G_PTR_ADD: {
     // Currently, we get G_PTR_ADD only as a result of translating
-    // global variables, initialized with constant expressions (see test
-    // opencl/basic/progvar_prog_scope_init.ll).
+    // global variables, initialized with constant expressions like GV + Const
+    // (see test opencl/basic/progvar_prog_scope_init.ll).
     // TODO: extend the handler once we have other cases.
-    const SPIRVType *SpvI32Ty = GR.getOrCreateSPIRVIntegerType(32, I, TII);
-    Register Idx = buildZerosVal(SpvI32Ty, I);
+    assert(I.getOperand(1).isReg() && I.getOperand(2).isReg());
+    Register GV = I.getOperand(1).getReg();
+    MachineRegisterInfo::def_instr_iterator II = MRI->def_instr_begin(GV);
+    assert(((*II).getOpcode() == TargetOpcode::G_GLOBAL_VALUE ||
+            (*II).getOpcode() == SPIRV::OpVariable) &&
+           isImm(I.getOperand(2), MRI));
+    Register Idx = buildZerosVal(GR.getOrCreateSPIRVIntegerType(32, I, TII), I);
     MachineBasicBlock &BB = *I.getParent();
     auto MIB = BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpSpecConstantOp))
                    .addDef(ResVReg)
                    .addUse(GR.getSPIRVTypeID(ResType))
                    .addImm(Opcode::InBoundsPtrAccessChain)
-                   .addUse(I.getOperand(1).getReg())
+                   .addUse(GV)
                    .addUse(Idx)
                    .addUse(I.getOperand(2).getReg());
     return MIB.constrainAllUses(TII, TRI, RBI);
@@ -1253,9 +1260,11 @@ bool SPIRVInstructionSelector::selectOpUndef(Register ResVReg,
 }
 
 static bool isImm(const MachineOperand &MO, MachineRegisterInfo *MRI) {
+  assert(MO.isReg());
   const SPIRVType *TypeInst = MRI->getVRegDef(MO.getReg());
   if (TypeInst->getOpcode() != SPIRV::ASSIGN_TYPE)
     return false;
+  assert(TypeInst->getOperand(1).isReg());
   MachineInstr *ImmInst = MRI->getVRegDef(TypeInst->getOperand(1).getReg());
   return ImmInst->getOpcode() == TargetOpcode::G_CONSTANT;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
+++ b/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
@@ -163,6 +163,7 @@ def ScopeOperand : OperandCategory;
 def GroupOperationOperand : OperandCategory;
 def KernelEnqueueFlagsOperand : OperandCategory;
 def KernelProfilingInfoOperand : OperandCategory;
+def OpcodeOperand : OperandCategory;
 
 //===----------------------------------------------------------------------===//
 // Multiclass used to define Extesions enum values and at the same time
@@ -1507,3 +1508,27 @@ multiclass KernelProfilingInfoOperand<bits<32> value, bits<32> minVersion, bits<
 
 defm None : KernelProfilingInfoOperand<0x0, 0, 0, [], []>;
 defm CmdExecTime : KernelProfilingInfoOperand<0x1, 0, 0, [], [Kernel]>;
+
+//===----------------------------------------------------------------------===//
+// Multiclass used to define Opcode enum values and at the same time
+// SymbolicOperand entries with string mnemonics and capabilities.
+//===----------------------------------------------------------------------===//
+
+def Opcode : GenericEnum, Operand<i32> {
+  let FilterClass = "Opcode";
+  let NameField = "Name";
+  let ValueField = "Value";
+  let PrintMethod = !strconcat("printSymbolicOperand<OperandCategory::", FilterClass, "Operand>");
+}
+
+class Opcode<string name, bits<32> value> {
+  string Name = name;
+  bits<32> Value = value;
+}
+
+multiclass OpcodeOperand<bits<32> value> {
+  def : Opcode<NAME, value>;
+  defm : SymbolicOperandWithRequirements<OpcodeOperand, value, NAME, 0, 0, [], []>;
+}
+// TODO: implement other mnemonics.
+defm InBoundsPtrAccessChain : OpcodeOperand<70>;

--- a/llvm/test/CodeGen/SPIRV/opencl/basic/progvar_prog_scope_init.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl/basic/progvar_prog_scope_init.ll
@@ -2,9 +2,18 @@
 
 target triple = "spirv64-unknown-unknown"
 
-; CHECK: OpEntryPoint Kernel %[[f1:[0-9]+]] "writer" %[[var:[0-9]+]]
-; CHECK: OpEntryPoint Kernel %[[f2:[0-9]+]] "reader" %[[var]]
-; CHECK: OpName %[[var]] "var"
+; CHECK: OpEntryPoint Kernel %[[f1:[0-9]+]] "writer"
+; CHECK: OpEntryPoint Kernel %[[f2:[0-9]+]] "reader"
+; CHECK-DAG: OpName %[[a_var:[0-9]+]] "a_var"
+; CHECK-DAG: OpName %[[p_var:[0-9]+]] "p_var"
+; CHECK-DAG: %[[uchar:[0-9]+]] = OpTypeInt 8 0
+; CHECK-DAG: %[[pt1:[0-9]+]] = OpTypePointer CrossWorkgroup %[[uchar]]
+; CHECK-DAG: %[[arr2:[0-9]+]] = OpTypeArray %[[uchar]]
+; CHECK-DAG: %[[pt2:[0-9]+]] = OpTypePointer CrossWorkgroup %[[arr2]]
+; CHECK-DAG: %[[pt3:[0-9]+]] = OpTypePointer CrossWorkgroup %[[pt1]]
+; CHECK-DAG: %[[a_var]] = OpVariable %[[pt2]] CrossWorkgroup
+; CHECK-DAG: %[[const:[0-9]+]] = OpSpecConstantOp %[[pt1]] 70 %[[a_var]]
+; CHECK-DAG: %[[p_var]] = OpVariable %[[pt3]] CrossWorkgroup %[[const]]
 @var = addrspace(1) global i8 0, align 1
 @g_var = addrspace(1) global i8 1, align 1
 @a_var = addrspace(1) global [2 x i8] c"\01\01", align 1


### PR DESCRIPTION
The change supports a OpSpecConstantOp creation from global var init. Also it removes extra MachineIRBuilder construction in SPIRVPreLegalizer pass and corrects opencl/basic/progvar_prog_scope_init.ll test. This LIT test should pass.