### PR TITLE
Enable topological sort of the module's global entities, i.e. types/c…

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -225,7 +225,7 @@ void SPIRVAsmPrinter::outputMCInst(MCInst &Inst) {
 void SPIRVAsmPrinter::outputInstruction(const MachineInstr *MI) {
   SPIRVMCInstLower MCInstLowering;
   MCInst TmpInst;
-  MCInstLowering.Lower(MI, TmpInst, MF, MAI);
+  MCInstLowering.lower(MI, TmpInst, MF, MAI);
   outputMCInst(TmpInst);
 }
 
@@ -304,7 +304,7 @@ void SPIRVAsmPrinter::outputEntryPoints() {
   for (MachineInstr *MI : MAI->getMSInstrs(MB_EntryPoints)) {
     SPIRVMCInstLower MCInstLowering;
     MCInst TmpInst;
-    MCInstLowering.Lower(MI, TmpInst, MF, MAI);
+    MCInstLowering.lower(MI, TmpInst, MF, MAI);
     for (Register Reg : InterfaceIDs) {
       assert(Reg.isValid());
       TmpInst.addOperand(MCOperand::createReg(Reg));

--- a/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.cpp
@@ -32,8 +32,8 @@ const SPIRVConstantTracker *SPIRVGeneralDuplicatesTracker::get(Constant *Arg) {
 }
 
 template <>
-const SPIRVGlobalValueTracker *
-SPIRVGeneralDuplicatesTracker::get(GlobalValue *Arg) {
+const SPIRVGlobalVariableTracker *
+SPIRVGeneralDuplicatesTracker::get(GlobalVariable *Arg) {
   return &GT;
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.cpp
@@ -41,4 +41,9 @@ template <>
 const SPIRVFuncDeclsTracker *SPIRVGeneralDuplicatesTracker::get(Function *Arg) {
   return &FT;
 }
+
+template <>
+const SPIRVSpecialDeclsTracker *SPIRVGeneralDuplicatesTracker::get(SpecialTypeDescriptor *Arg) {
+  return &ST;
+}
   

--- a/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.h
+++ b/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.h
@@ -17,24 +17,41 @@
 #include "MCTargetDesc/SPIRVBaseInfo.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 #include "llvm/ADT/DenseMap.h"
-#include "llvm/ADT/MapVector.h"
-
-#include <map>
 
 namespace llvm {
 
+class DTSortableEntry : public DenseMap<MachineFunction *, Register> {
+  std::vector<DTSortableEntry *> Deps;
+
+  struct FlagsTy {
+    unsigned IsFunc : 1;
+    unsigned IsGV : 1;
+    // NOTE: bit-field default init is a C++20 feature
+    FlagsTy() : IsFunc(0), IsGV(0) {}
+  };
+  FlagsTy Flags;
+
+public:
+  // common hoisting utility doesn't support
+  // function because their hoisting require hoisting of params as well
+  bool getIsFunc() const { return Flags.IsFunc; }
+  bool getIsGV() const { return Flags.IsGV; }
+  void setIsFunc(bool V) { Flags.IsFunc = V; }
+  void setIsGV(bool V) { Flags.IsGV = V; }
+
+  std::vector<DTSortableEntry *> &getDeps() { return Deps; }
+};
+
 template <typename T> class SPIRVDuplicatesTracker {
+
   using StorageKeyTy = const T *;
-  using StorageValueTy = Register;
   // TODO: consider replacing MapVector with DenseMap which
   // requires topological sorting of the storage contents
   // (e.g. to handle dependencies of const composites to its
   // elements)
   // Currently we rely on the order of insertion to be correct
-  using StorageTy =
-      MapVector<StorageKeyTy, MapVector<MachineFunction *, StorageValueTy>>;
+  using StorageTy = DenseMap<StorageKeyTy, DTSortableEntry>;
 
-protected:
   StorageTy Storage;
 
 public:
@@ -47,6 +64,10 @@ public:
       return;
     }
     Storage[V][MF] = R;
+    if (std::is_same<Function, T>())
+      Storage[V].setIsFunc(true);
+    if (std::is_same<GlobalVariable, T>())
+      Storage[V].setIsGV(true);
   }
 
   bool find(const T *V, MachineFunction *MF, Register& R) {
@@ -63,27 +84,89 @@ public:
   }
 
   const StorageTy &getAllUses() const { return Storage; }
+
+private:
+  StorageTy &getAllUses() { return Storage; }
+
+  // The frined class needs to have access to the internal storage
+  // to be able to build dependency graph, can't declare only one
+  // function a 'friend' due to the incomplete declaration at this point
+  // and mutual dependency problems.
+  friend class SPIRVGeneralDuplicatesTracker;
 };
 
 using SPIRVTypeTracker = SPIRVDuplicatesTracker<Type>;
 using SPIRVConstantTracker = SPIRVDuplicatesTracker<Constant>;
-using SPIRVGlobalValueTracker = SPIRVDuplicatesTracker<GlobalValue>;
+using SPIRVGlobalVariableTracker = SPIRVDuplicatesTracker<GlobalVariable>;
 using SPIRVFuncDeclsTracker = SPIRVDuplicatesTracker<Function>;
 
 class SPIRVGeneralDuplicatesTracker {
   SPIRVTypeTracker TT;
   SPIRVConstantTracker CT;
-  SPIRVGlobalValueTracker GT;
+  SPIRVGlobalVariableTracker GT;
   SPIRVFuncDeclsTracker FT;
 
+  // NOTE: using MOs instead of regs to get rid of MF dependency
+  // to be able to use flat data structure
+  // NOTE: replacing DenseMap with MapVector doesn't affect overall
+  // correctness but makes LITs more stable, should prefer DenseMap still
+  // due to significant perf difference
+  using Reg2EntryTy = DenseMap<MachineOperand *, DTSortableEntry *>;
+
+private:
+  template <typename T>
+  void prebuildReg2Entry(SPIRVDuplicatesTracker<T> &DT,
+                         Reg2EntryTy &Reg2Entry) {
+    for (auto &TPair : DT.getAllUses()) {
+      for (auto &RegPair : TPair.second) {
+        auto *MF = RegPair.first;
+        auto R = RegPair.second;
+        auto *MI = MF->getRegInfo().getVRegDef(R);
+        if (!MI)
+          continue;
+        Reg2Entry[&MI->getOperand(0)] = &TPair.second;
+      }
+    }
+  }
+
 public:
+  void buildDepsGraph(std::vector<DTSortableEntry *> &Graph) {
+    Reg2EntryTy Reg2Entry;
+    prebuildReg2Entry(TT, Reg2Entry);
+    prebuildReg2Entry(CT, Reg2Entry);
+    prebuildReg2Entry(GT, Reg2Entry);
+    prebuildReg2Entry(FT, Reg2Entry);
+
+    for (auto &Op2E : Reg2Entry) {
+      auto *E = Op2E.second;
+      Graph.push_back(E);
+      for (auto &U : *E) {
+        auto *MF = U.first;
+        auto R = U.second;
+
+        auto *MI = MF->getRegInfo().getVRegDef(R);
+        if (!MI)
+          continue;
+        assert(MI && MI->getParent() && "No MachineInstr created yet");
+        for (auto i = MI->getNumDefs(); i < MI->getNumOperands(); i++) {
+          auto Op = MI->getOperand(i);
+          if (!Op.isReg())
+            continue;
+          auto &RegOp = MF->getRegInfo().getVRegDef(Op.getReg())->getOperand(0);
+          assert(Reg2Entry.count(&RegOp));
+          E->getDeps().push_back(Reg2Entry[&RegOp]);
+        }
+      }
+    }
+  }
+
   void add(const Type *T, MachineFunction *MF, Register R) { TT.add(T, MF, R); }
 
   void add(const Constant *C, MachineFunction *MF, Register R) {
     CT.add(C, MF, R);
   }
 
-  void add(const GlobalValue *GV, MachineFunction *MF, Register R) {
+  void add(const GlobalVariable *GV, MachineFunction *MF, Register R) {
     GT.add(GV, MF, R);
   }
 
@@ -99,7 +182,7 @@ public:
     return CT.find(C, MF, R);
   }
 
-  bool find(const GlobalValue *GV, MachineFunction *MF, Register& R) {
+  bool find(const GlobalVariable *GV, MachineFunction *MF, Register &R) {
     return GT.find(GV, MF, R);
   }
 

--- a/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.h
+++ b/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.h
@@ -15,13 +15,20 @@
 #define LLVM_LIB_TARGET_SPIRV_SPIRVDUPLICATESTRACKER_H
 
 #include "MCTargetDesc/SPIRVBaseInfo.h"
+#include "MCTargetDesc/SPIRVMCTargetDesc.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 #include "llvm/ADT/DenseMap.h"
+#include "llvm/ADT/MapVector.h"
+
+#include <type_traits>
 
 namespace llvm {
 
-class DTSortableEntry : public DenseMap<MachineFunction *, Register> {
-  std::vector<DTSortableEntry *> Deps;
+// NOTE: using MapVector instead of DenseMap because it helps getting
+// everything ordered in a stable manner for a price of extra (NumKeys)*PtrSize
+// memory and expensive removals which do not happen anyway
+class DTSortableEntry : public MapVector<const MachineFunction *, Register> {
+  SmallVector<DTSortableEntry *, 2> Deps;
 
   struct FlagsTy {
     unsigned IsFunc : 1;
@@ -39,38 +46,151 @@ public:
   void setIsFunc(bool V) { Flags.IsFunc = V; }
   void setIsGV(bool V) { Flags.IsGV = V; }
 
-  std::vector<DTSortableEntry *> &getDeps() { return Deps; }
+  SmallVector<DTSortableEntry *, 2> &getDeps() { return Deps; }
 };
 
-template <typename T> class SPIRVDuplicatesTracker {
+struct SpecialTypeDescriptor {
+  enum SpecialTypeKind {
+    STK_Empty = 0,
+    STK_Image,
+    STK_SampledImage,
+    STK_Sampler,
+    STK_Pipe,
+    STK_Last = -1
+  };
+  SpecialTypeKind Kind;
 
-  using StorageKeyTy = const T *;
-  // TODO: consider replacing MapVector with DenseMap which
-  // requires topological sorting of the storage contents
-  // (e.g. to handle dependencies of const composites to its
-  // elements)
-  // Currently we rely on the order of insertion to be correct
-  using StorageTy = DenseMap<StorageKeyTy, DTSortableEntry>;
+  unsigned Hash;
+  
+  SpecialTypeDescriptor() = delete;
+  SpecialTypeDescriptor(SpecialTypeKind K): Kind(K) { Hash = Kind; }
 
+  unsigned getHash() const {
+    return Hash;
+  }
+
+  virtual ~SpecialTypeDescriptor() {}
+};
+
+struct ImageTypeDescriptor: public SpecialTypeDescriptor {
+  union ImageAttrs {
+    struct BitFlags {
+      unsigned Dim : 3;
+      unsigned Depth : 2;
+      unsigned Arrayed : 1;
+      unsigned MS : 1;
+      unsigned Sampled : 2;
+      unsigned ImageFormat : 6;
+      unsigned AQ : 2;
+    } Flags;
+    unsigned Val;
+  };
+
+  ImageTypeDescriptor(const Type *SampledTy, unsigned Dim, unsigned Depth,
+                      unsigned Arrayed, unsigned MS, unsigned Sampled,
+                      unsigned ImageFormat, unsigned AQ = 0)
+      : SpecialTypeDescriptor(SpecialTypeKind::STK_Image) {
+    ImageAttrs Attrs;
+    Attrs.Val = 0;
+    Attrs.Flags.Dim = Dim;
+    Attrs.Flags.Depth = Depth;
+    Attrs.Flags.Arrayed = Arrayed;
+    Attrs.Flags.MS = MS;
+    Attrs.Flags.Sampled = Sampled;
+    Attrs.Flags.ImageFormat = ImageFormat;
+    Attrs.Flags.AQ = AQ;
+    Hash = (DenseMapInfo<Type*>().getHashValue(SampledTy) & 0xffff) ^ ((Attrs.Val << 8) | Kind);
+  }
+
+  static bool classof(const SpecialTypeDescriptor *TD) {
+    return TD->Kind == SpecialTypeKind::STK_Image;
+  }
+};
+
+struct SampledImageTypeDescriptor: public SpecialTypeDescriptor {
+  SampledImageTypeDescriptor(const Type *SampledTy, const MachineInstr *ImageTy)
+      : SpecialTypeDescriptor(SpecialTypeKind::STK_SampledImage) {
+    assert(ImageTy->getOpcode() == SPIRV::OpTypeImage);
+    ImageTypeDescriptor TD(
+        SampledTy, ImageTy->getOperand(2).getImm(),
+        ImageTy->getOperand(3).getImm(), ImageTy->getOperand(4).getImm(),
+        ImageTy->getOperand(5).getImm(), ImageTy->getOperand(6).getImm(),
+        ImageTy->getOperand(7).getImm(), ImageTy->getOperand(8).getImm());
+    Hash = TD.getHash() ^ Kind;
+  }
+
+  static bool classof(const SpecialTypeDescriptor *TD) {
+    return TD->Kind == SpecialTypeKind::STK_SampledImage;
+  }
+};
+
+struct SamplerTypeDescriptor: public SpecialTypeDescriptor {
+  SamplerTypeDescriptor(): SpecialTypeDescriptor(SpecialTypeKind::STK_Sampler) {
+    Hash = Kind;
+  }
+
+  static bool classof(const SpecialTypeDescriptor *TD) {
+    return TD->Kind == SpecialTypeKind::STK_Sampler;
+  }
+};
+struct PipeTypeDescriptor: public SpecialTypeDescriptor {
+
+  PipeTypeDescriptor(uint8_t AQ): SpecialTypeDescriptor(SpecialTypeKind::STK_Pipe) {
+    Hash = (AQ << 8) | Kind;
+  }
+
+  static bool classof(const SpecialTypeDescriptor *TD) {
+    return TD->Kind == SpecialTypeKind::STK_Pipe;
+  }
+};
+
+template <> struct DenseMapInfo<SpecialTypeDescriptor> {
+  static inline SpecialTypeDescriptor getEmptyKey() {
+    return SpecialTypeDescriptor(SpecialTypeDescriptor::STK_Empty);
+  }
+  static inline SpecialTypeDescriptor getTombstoneKey() {
+    return SpecialTypeDescriptor(SpecialTypeDescriptor::STK_Last);
+  }
+  static unsigned getHashValue(SpecialTypeDescriptor Val) {
+    return Val.getHash();
+  }
+  static bool isEqual(SpecialTypeDescriptor LHS, SpecialTypeDescriptor RHS) {
+    return getHashValue(LHS) == getHashValue(RHS);
+  }
+};
+
+
+template <typename KeyTy> class SPIRVDuplicatesTrackerBase {
+public:
+  // NOTE: using MapVector instead of DenseMap helps getting
+  // everything ordered in a stable manner for a price of extra
+  // (NumKeys)*PtrSize memory and expensive removals which don't happen anyway
+  using StorageTy = MapVector<KeyTy, DTSortableEntry>;
+
+private:
   StorageTy Storage;
 
 public:
-  SPIRVDuplicatesTracker() {}
+  SPIRVDuplicatesTrackerBase() {}
 
-  void add(const T *V, MachineFunction *MF, Register R) {
+  void add(KeyTy V, const MachineFunction *MF, Register R) {
     Register OldReg;
     if (find(V, MF, OldReg)) {
       assert(OldReg == R);
       return;
     }
     Storage[V][MF] = R;
-    if (std::is_same<Function, T>())
+    if (std::is_same<Function,
+                     typename std::remove_const<
+                         typename std::remove_pointer<KeyTy>::type>::type>())
       Storage[V].setIsFunc(true);
-    if (std::is_same<GlobalVariable, T>())
+    if (std::is_same<GlobalVariable,
+                     typename std::remove_const<
+                         typename std::remove_pointer<KeyTy>::type>::type>())
       Storage[V].setIsGV(true);
   }
 
-  bool find(const T *V, MachineFunction *MF, Register& R) {
+  bool find(KeyTy V, const MachineFunction *MF, Register& R) const {
     auto iter = Storage.find(V);
     if (iter != Storage.end()) {
       auto Map = iter->second;
@@ -88,30 +208,38 @@ public:
 private:
   StorageTy &getAllUses() { return Storage; }
 
-  // The frined class needs to have access to the internal storage
+  // The friend class needs to have access to the internal storage
   // to be able to build dependency graph, can't declare only one
   // function a 'friend' due to the incomplete declaration at this point
   // and mutual dependency problems.
   friend class SPIRVGeneralDuplicatesTracker;
 };
 
+template<typename T>
+class SPIRVDuplicatesTracker: public SPIRVDuplicatesTrackerBase<const T*> {};
+
+template<>
+class SPIRVDuplicatesTracker<SpecialTypeDescriptor>: public SPIRVDuplicatesTrackerBase<SpecialTypeDescriptor> {};
+
 using SPIRVTypeTracker = SPIRVDuplicatesTracker<Type>;
 using SPIRVConstantTracker = SPIRVDuplicatesTracker<Constant>;
 using SPIRVGlobalVariableTracker = SPIRVDuplicatesTracker<GlobalVariable>;
 using SPIRVFuncDeclsTracker = SPIRVDuplicatesTracker<Function>;
+using SPIRVSpecialDeclsTracker = SPIRVDuplicatesTracker<SpecialTypeDescriptor>;
 
 class SPIRVGeneralDuplicatesTracker {
   SPIRVTypeTracker TT;
   SPIRVConstantTracker CT;
   SPIRVGlobalVariableTracker GT;
   SPIRVFuncDeclsTracker FT;
+  SPIRVSpecialDeclsTracker ST;
 
   // NOTE: using MOs instead of regs to get rid of MF dependency
   // to be able to use flat data structure
   // NOTE: replacing DenseMap with MapVector doesn't affect overall
   // correctness but makes LITs more stable, should prefer DenseMap still
   // due to significant perf difference
-  using Reg2EntryTy = DenseMap<MachineOperand *, DTSortableEntry *>;
+  using Reg2EntryTy = MapVector<MachineOperand *, DTSortableEntry *>;
 
 private:
   template <typename T>
@@ -136,6 +264,7 @@ public:
     prebuildReg2Entry(CT, Reg2Entry);
     prebuildReg2Entry(GT, Reg2Entry);
     prebuildReg2Entry(FT, Reg2Entry);
+    prebuildReg2Entry(ST, Reg2Entry);
 
     for (auto &Op2E : Reg2Entry) {
       auto *E = Op2E.second;
@@ -152,43 +281,53 @@ public:
           auto Op = MI->getOperand(i);
           if (!Op.isReg())
             continue;
-          auto &RegOp = MF->getRegInfo().getVRegDef(Op.getReg())->getOperand(0);
-          assert(Reg2Entry.count(&RegOp));
-          E->getDeps().push_back(Reg2Entry[&RegOp]);
+          MachineOperand *RegOp = &MF->getRegInfo().getVRegDef(Op.getReg())->getOperand(0);
+          assert((MI->getOpcode() == SPIRV::OpVariable && i == 3) || Reg2Entry.count(RegOp));
+          if (Reg2Entry.count(RegOp))
+            E->getDeps().push_back(Reg2Entry[RegOp]);
         }
       }
     }
   }
 
-  void add(const Type *T, MachineFunction *MF, Register R) { TT.add(T, MF, R); }
+  void add(const Type *T, const MachineFunction *MF, Register R) { TT.add(T, MF, R); }
 
-  void add(const Constant *C, MachineFunction *MF, Register R) {
+  void add(const Constant *C, const MachineFunction *MF, Register R) {
     CT.add(C, MF, R);
   }
 
-  void add(const GlobalVariable *GV, MachineFunction *MF, Register R) {
+  void add(const GlobalVariable *GV, const MachineFunction *MF, Register R) {
     GT.add(GV, MF, R);
   }
 
-  void add(const Function *F, MachineFunction *MF, Register R) {
+  void add(const Function *F, const MachineFunction *MF, Register R) {
     FT.add(F, MF, R);
   }
 
-  bool find(const Type *T, MachineFunction *MF, Register& R) {
-    return TT.find(T, MF, R);
+  void add(const SpecialTypeDescriptor &TD, const MachineFunction *MF, Register R) {
+    ST.add(TD, MF, R);
   }
 
-  bool find(const Constant *C, MachineFunction *MF, Register& R) {
-    return CT.find(C, MF, R);
+  bool find(const Type *T, const MachineFunction *MF, Register& R) {
+    return TT.find(const_cast<Type*>(T), MF, R);
   }
 
-  bool find(const GlobalVariable *GV, MachineFunction *MF, Register &R) {
-    return GT.find(GV, MF, R);
+  bool find(const Constant *C, const MachineFunction *MF, Register& R) {
+    return CT.find(const_cast<Constant*>(C), MF, R);
   }
 
-  bool find(const Function *F, MachineFunction *MF, Register& R) {
-    return FT.find(F, MF, R);
+  bool find(const GlobalVariable *GV, const MachineFunction *MF, Register &R) {
+    return GT.find(const_cast<GlobalVariable*>(GV), MF, R);
   }
+
+  bool find(const Function *F, const MachineFunction *MF, Register& R) {
+    return FT.find(const_cast<Function*>(F), MF, R);
+  }
+
+  bool find(const SpecialTypeDescriptor &TD, const MachineFunction *MF, Register& R) {
+    return ST.find(TD, MF, R);
+  }
+
 
   // NOTE:
   // T *Arg = nullptr is added as compiler fails to infer T for specializations

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -394,7 +394,7 @@ Register SPIRVGlobalRegistry::buildGlobalVariable(
     GV = GVar;
   }
   Register Reg;
-  if (DT.find(GV, &MIRBuilder.getMF(), Reg)) {
+  if (DT.find(GVar, &MIRBuilder.getMF(), Reg)) {
     if (Reg != ResVReg)
       MIRBuilder.buildCopy(ResVReg, Reg);
     return ResVReg;
@@ -418,7 +418,7 @@ Register SPIRVGlobalRegistry::buildGlobalVariable(
                                      *Subtarget.getRegBankInfo());
   }
   Reg = MIB->getOperand(0).getReg();
-  DT.add(GV, &MIRBuilder.getMF(), Reg);
+  DT.add(GVar, &MIRBuilder.getMF(), Reg);
 
   // Set to Reg the same type as ResVReg has.
   auto MRI = MIRBuilder.getMRI();

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -359,14 +359,13 @@ Register SPIRVGlobalRegistry::buildConstantSampler(
       ResReg.isValid()
           ? ResReg
           : MIRBuilder.getMRI()->createVirtualRegister(&SPIRV::IDRegClass);
-  auto MIB = MIRBuilder.buildInstr(SPIRV::OpConstantSampler)
+  auto Res = MIRBuilder.buildInstr(SPIRV::OpConstantSampler)
                  .addDef(Sampler)
                  .addUse(getSPIRVTypeID(SampTy))
                  .addImm(AddrMode)
                  .addImm(Param)
                  .addImm(FilerMode);
-  constrainRegOperands(MIB);
-  auto Res = checkSpecialInstrMap(MIB, SpecialTypesAndConstsMap);
+  constrainRegOperands(Res);
   assert(Res->getOperand(0).isReg());
   return Res->getOperand(0).getReg();
 }
@@ -516,12 +515,10 @@ SPIRVGlobalRegistry::handleOpenCLBuiltin(const StructType *Ty,
                                          AQ::AccessQualifier AccQual) {
   assert(Ty->hasName());
   unsigned NumStartingVRegs = MIRBuilder.getMRI()->getNumVirtRegs();
-  auto NewTy = generateOpenCLOpaqueType(Ty, MIRBuilder, AccQual);
-  auto ResTy = checkSpecialInstrMap(NewTy, BuiltinTypeMap);
-  if (NumStartingVRegs < MIRBuilder.getMRI()->getNumVirtRegs() &&
-      ResTy == NewTy)
-    buildOpName(getSPIRVTypeID(ResTy), Ty->getName(), MIRBuilder);
-  return ResTy;
+  auto NewTy = getOrCreateOpenCLOpaqueType(Ty, MIRBuilder, AccQual);
+  if (NumStartingVRegs < MIRBuilder.getMRI()->getNumVirtRegs())
+    buildOpName(getSPIRVTypeID(NewTy), Ty->getName(), MIRBuilder);
+  return NewTy;
 }
 
 SPIRVType *SPIRVGlobalRegistry::getOpTypePointer(StorageClass::StorageClass SC,
@@ -772,10 +769,14 @@ SPIRVGlobalRegistry::getPointerStorageClass(Register VReg) const {
   return static_cast<StorageClass::StorageClass>(Type->getOperand(1).getImm());
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOpTypeImage(
+SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypeImage(
     MachineIRBuilder &MIRBuilder, SPIRVType *SampledType, Dim::Dim Dim,
     uint32_t Depth, uint32_t Arrayed, uint32_t Multisampled, uint32_t Sampled,
     ImageFormat::ImageFormat ImageFormat, AQ::AccessQualifier AccessQual) {
+  ImageTypeDescriptor TD(SPIRVToLLVMType.lookup(SampledType), Dim, Depth, Arrayed,
+                         Multisampled, Sampled, ImageFormat, AccessQual);
+  if (auto *Res = checkSpecialInstr(TD, MIRBuilder))
+    return Res;
   Register ResVReg = createTypeVReg(MIRBuilder);
   auto MIB = MIRBuilder.buildInstr(SPIRV::OpTypeImage)
                  .addDef(ResVReg)
@@ -787,35 +788,52 @@ SPIRVType *SPIRVGlobalRegistry::getOpTypeImage(
                  .addImm(Sampled)      // Sampled (0 = usage known at runtime)
                  .addImm(ImageFormat)
                  .addImm(AccessQual);
+  DT.add(TD, &MIRBuilder.getMF(), ResVReg);
   return MIB;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getSamplerType(MachineIRBuilder &MIRBuilder) {
+SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypeSampler(MachineIRBuilder &MIRBuilder) {
+  SamplerTypeDescriptor TD;
+  if (auto *Res = checkSpecialInstr(TD, MIRBuilder))
+    return Res;
   Register ResVReg = createTypeVReg(MIRBuilder);
   auto MIB = MIRBuilder.buildInstr(SPIRV::OpTypeSampler).addDef(ResVReg);
   constrainRegOperands(MIB);
+  DT.add(TD, &MIRBuilder.getMF(), ResVReg);
   return MIB;
 }
 
-SPIRVType *SPIRVGlobalRegistry::getOpTypePipe(MachineIRBuilder &MIRBuilder,
+SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypePipe(MachineIRBuilder &MIRBuilder,
                                               AQ::AccessQualifier AccessQual) {
+  PipeTypeDescriptor TD(AccessQual);
+  if (auto *Res = checkSpecialInstr(TD, MIRBuilder))
+    return Res;
   Register ResVReg = createTypeVReg(MIRBuilder);
   auto MIB = MIRBuilder.buildInstr(SPIRV::OpTypePipe)
                  .addDef(ResVReg)
                  .addImm(AccessQual);
   constrainRegOperands(MIB);
+  DT.add(TD, &MIRBuilder.getMF(), ResVReg);
   return MIB;
 }
 
 SPIRVType *
-SPIRVGlobalRegistry::getSampledImageType(SPIRVType *ImageType,
+SPIRVGlobalRegistry::getOrCreateOpTypeSampledImage(SPIRVType *ImageType,
                                          MachineIRBuilder &MIRBuilder) {
+  SampledImageTypeDescriptor TD(
+      SPIRVToLLVMType.lookup(MIRBuilder.getMF().getRegInfo().getVRegDef(
+          ImageType->getOperand(1).getReg())),
+      ImageType);
+  if (auto *Res = checkSpecialInstr(TD, MIRBuilder))
+    return Res;
   Register ResVReg = createTypeVReg(MIRBuilder);
   auto MIB = MIRBuilder.buildInstr(SPIRV::OpTypeSampledImage)
                  .addDef(ResVReg)
                  .addUse(getSPIRVTypeID(ImageType));
   constrainRegOperands(MIB);
-  return checkSpecialInstrMap(MIB, SpecialTypesAndConstsMap);
+  DT.add(TD, &MIRBuilder.getMF(), ResVReg);
+
+  return MIB;
 }
 
 SPIRVType *SPIRVGlobalRegistry::getOpTypeByOpcode(MachineIRBuilder &MIRBuilder,
@@ -827,41 +845,16 @@ SPIRVType *SPIRVGlobalRegistry::getOpTypeByOpcode(MachineIRBuilder &MIRBuilder,
 }
 
 const MachineInstr *
-SPIRVGlobalRegistry::checkSpecialInstrMap(const MachineInstr *NewInstr,
-                                          SpecialInstrMapTy &InstrMap) {
-  auto t = InstrMap.find(NewInstr->getOpcode());
-  if (t != InstrMap.end()) {
-    for (auto InstrGroup : t->second) {
-      // Each group contins identical special instructions in different MFs,
-      // it's enough to check the first instruction in the group.
-      const MachineInstr *Instr = InstrGroup.begin()->second;
-      if (Instr->isIdenticalTo(*NewInstr,
-                               MachineInstr::MICheckType::IgnoreDefs)) {
-        auto tt =
-            InstrGroup.find(const_cast<MachineFunction *>(NewInstr->getMF()));
-        if (tt != InstrGroup.end()) {
-          // The equivalent instruction was found in this MF,
-          // remove new instruction and return the existing one.
-          const_cast<llvm::MachineInstr *>(NewInstr)->eraseFromParent();
-          return tt->second;
-        }
-        // No such instruction in the group, add new instruction.
-        InstrGroup[const_cast<MachineFunction *>(NewInstr->getMF())] = NewInstr;
-        return NewInstr;
-      }
-    }
-  }
-  // It's new instruction with no existent group, so create a group,
-  // insert the instruction to the group and insert the group to the map.
-  InstrMap[NewInstr->getOpcode()].push_back(SPIRVInstrGroup());
-  MachineFunction *MF = const_cast<MachineFunction *>(NewInstr->getMF());
-  std::pair<MachineFunction *, const MachineInstr *> Pair(MF, NewInstr);
-  InstrMap[NewInstr->getOpcode()].back().insert(Pair);
-  return NewInstr;
+SPIRVGlobalRegistry::checkSpecialInstr(const SpecialTypeDescriptor &TD,
+                                       MachineIRBuilder &MIRBuilder) {
+  Register Reg;
+  if (DT.find(TD, &MIRBuilder.getMF(), Reg))
+    return MIRBuilder.getMF().getRegInfo().getUniqueVRegDef(Reg);
+  return nullptr;
 }
 
 SPIRVType *
-SPIRVGlobalRegistry::generateOpenCLOpaqueType(const StructType *Ty,
+SPIRVGlobalRegistry::getOrCreateOpenCLOpaqueType(const StructType *Ty,
                                               MachineIRBuilder &MIRBuilder,
                                               AQ::AccessQualifier AccessQual) {
   const StringRef Name = Ty->getName();
@@ -890,11 +883,11 @@ SPIRVGlobalRegistry::generateOpenCLOpaqueType(const StructType *Ty,
       auto *VoidTy = getOrCreateSPIRVType(
           Type::getVoidTy(MIRBuilder.getMF().getFunction().getContext()),
           MIRBuilder);
-      return getOpTypeImage(MIRBuilder, VoidTy, Dim, 0, Arrayed, 0, 0,
+      return getOrCreateOpTypeImage(MIRBuilder, VoidTy, Dim, 0, Arrayed, 0, 0,
                             ImageFormat::Unknown, AccessQual);
     }
   } else if (TypeName.startswith("sampler_t")) {
-    return getSamplerType(MIRBuilder);
+    return getOrCreateOpTypeSampler(MIRBuilder);
   } else if (TypeName.startswith("pipe")) {
     if (TypeName.endswith("_ro_t"))
       AccessQual = AQ::ReadOnly;
@@ -902,7 +895,7 @@ SPIRVGlobalRegistry::generateOpenCLOpaqueType(const StructType *Ty,
       AccessQual = AQ::WriteOnly;
     else if (TypeName.endswith("_rw_t"))
       AccessQual = AQ::ReadWrite;
-    return getOpTypePipe(MIRBuilder, AccessQual);
+    return getOrCreateOpTypePipe(MIRBuilder, AccessQual);
   } else if (TypeName.startswith("queue"))
     return getOpTypeByOpcode(MIRBuilder, SPIRV::OpTypeQueue);
   else if (TypeName.startswith("event_t"))
@@ -956,16 +949,14 @@ SPIRVGlobalRegistry::handleSPIRVBuiltin(const StructType *Ty,
                                         AQ::AccessQualifier AccQual) {
   assert(Ty->hasName());
   unsigned NumStartingVRegs = MIRBuilder.getMRI()->getNumVirtRegs();
-  auto NewTy = generateSPIRVOpaqueType(Ty, MIRBuilder, AccQual);
-  auto ResTy = checkSpecialInstrMap(NewTy, BuiltinTypeMap);
-  if (NumStartingVRegs < MIRBuilder.getMRI()->getNumVirtRegs() &&
-      NewTy == ResTy)
-    buildOpName(getSPIRVTypeID(ResTy), Ty->getName(), MIRBuilder);
-  return ResTy;
+  auto NewTy = getOrCreateSPIRVOpaqueType(Ty, MIRBuilder, AccQual);
+  if (NumStartingVRegs < MIRBuilder.getMRI()->getNumVirtRegs())
+    buildOpName(getSPIRVTypeID(NewTy), Ty->getName(), MIRBuilder);
+  return NewTy;
 }
 
 SPIRVType *
-SPIRVGlobalRegistry::generateSPIRVOpaqueType(const StructType *Ty,
+SPIRVGlobalRegistry::getOrCreateSPIRVOpaqueType(const StructType *Ty,
                                              MachineIRBuilder &MIRBuilder,
                                              AQ::AccessQualifier AccessQual) {
   const StringRef Name = Ty->getName();
@@ -993,7 +984,7 @@ SPIRVGlobalRegistry::generateSPIRVOpaqueType(const StructType *Ty,
         TypeLiterals[6].getAsInteger(10, ImageFormat) ||
         TypeLiterals[7].getAsInteger(10, AccQual))
       llvm_unreachable("Unable to recognize Image type literals");
-    return getOpTypeImage(MIRBuilder, SpirvType, Dim::Dim(Ddim), Depth, Arrayed,
+    return getOrCreateOpTypeImage(MIRBuilder, SpirvType, Dim::Dim(Ddim), Depth, Arrayed,
                           MS, Sampled, ImageFormat::ImageFormat(ImageFormat),
                           AQ::AccessQualifier(AccQual));
   } else if (TypeName.startswith("SampledImage.")) {
@@ -1003,11 +994,11 @@ SPIRVGlobalRegistry::generateSPIRVOpaqueType(const StructType *Ty,
     Type *ImgTy =
         StructType::getTypeByName(Ctx, "spirv.Image." + Literals.str());
     SPIRVType *SpirvImageType = getOrCreateSPIRVType(ImgTy, MIRBuilder);
-    return getOrCreateSPIRVSampledImageType(SpirvImageType, MIRBuilder);
+    return getOrCreateOpTypeSampledImage(SpirvImageType, MIRBuilder);
   } else if (TypeName.startswith("DeviceEvent"))
     return getOpTypeByOpcode(MIRBuilder, SPIRV::OpTypeDeviceEvent);
   else if (TypeName.startswith("Sampler"))
-    return getSamplerType(MIRBuilder);
+    return getOrCreateOpTypeSampler(MIRBuilder);
   else if (TypeName.startswith("Event"))
     return getOpTypeByOpcode(MIRBuilder, SPIRV::OpTypeEvent);
   else if (TypeName.startswith("Queue"))
@@ -1019,7 +1010,7 @@ SPIRVGlobalRegistry::generateSPIRVOpaqueType(const StructType *Ty,
       AccessQual = AQ::WriteOnly;
     else if (TypeName.endswith("_2"))
       AccessQual = AQ::ReadWrite;
-    return getOpTypePipe(MIRBuilder, AccessQual);
+    return getOrCreateOpTypePipe(MIRBuilder, AccessQual);
   } else if (TypeName.startswith("PipeStorage"))
     return getOpTypeByOpcode(MIRBuilder, SPIRV::OpTypePipeStorage);
   else if (TypeName.startswith("ReserveId"))
@@ -1116,10 +1107,4 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVPointerType(
                  .addImm(static_cast<uint32_t>(SC))
                  .addUse(getSPIRVTypeID(BaseType));
   return restOfCreateSPIRVType(LLVMTy, MIB);
-}
-
-SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVSampledImageType(
-    SPIRVType *ImageType, MachineIRBuilder &MIRBuilder) {
-  SPIRVType *Type = getSampledImageType(ImageType, MIRBuilder);
-  return Type;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -40,28 +40,11 @@ class SPIRVGlobalRegistry {
 
   DenseMap<SPIRVType *, const Type *> SPIRVToLLVMType;
 
-  using SPIRVInstrGroup = DenseMap<MachineFunction *, const MachineInstr *>;
-  using VectorOfSPIRVInstrGroups = SmallVector<SPIRVInstrGroup>;
-  using SpecialInstrMapTy = MapVector<unsigned, VectorOfSPIRVInstrGroups>;
-
-  // Builtin types may be represented in two ways while translating to SPIR-V:
-  // in OpenCL form and in SPIR-V form. We have to keep only one type for such
-  // pairs so check any builtin type for existance in the map before emitting
-  // it to SPIR-V. The map contains a vector of SPIR-V builtin types already
-  // emitted for a given type opcode.
-  SpecialInstrMapTy BuiltinTypeMap;
-
-  // Some SPIR-V types and constants have no explicit analogues in LLVM types
-  // and constants. We create and store these special types and constants in
-  // this map to avoid type/const duplicatoin and to hoist the instructions
-  // properly to MB_TypeConstVars in GlobalTypesAndRegNumPass.
-  // Currently it holds OpTypeSampledImage and OpConstantSampler instances.
-  SpecialInstrMapTy SpecialTypesAndConstsMap;
-
   // Look for an equivalent of the newType in the map. Return the equivalent
   // if it's found, otherwise insert newType to the map and return the type.
-  const MachineInstr *checkSpecialInstrMap(const MachineInstr *NewInstr,
-                                           SpecialInstrMapTy &InstrMap);
+  const MachineInstr *checkSpecialInstr(const SpecialTypeDescriptor &TD,
+                                        MachineIRBuilder &MIRBuilder);
+
   SmallPtrSet<const Type *, 4> TypesInProcessing;
   DenseMap<const Type *, SPIRVType *> ForwardPointerTypes;
 
@@ -105,14 +88,14 @@ public:
   }
 
   template <typename T>
-  const DenseMap<const T *, DTSortableEntry> &getAllUses() {
+  const typename SPIRVDuplicatesTracker<T>::StorageTy &getAllUses() {
     return DT.get<T>()->getAllUses();
   }
 
   // This interface is for walking the map in GlobalTypesAndRegNumPass.
-  SpecialInstrMapTy &getSpecialTypesAndConstsMap() {
-    return SpecialTypesAndConstsMap;
-  }
+  // SpecialInstrMapTy &getSpecialTypesAndConstsMap() {
+  //   return SpecialTypesAndConstsMap;
+  // }
 
   SPIRVGlobalRegistry(unsigned PointerSize);
 
@@ -197,12 +180,7 @@ public:
 
 private:
   // Internal methods for creating types which are unsafe in duplications
-  // check sense hence can only be called within getOrCreateSPIRVType callstack.
-  SPIRVType *getSamplerType(MachineIRBuilder &MIRBuilder);
-
-  SPIRVType *getSampledImageType(SPIRVType *ImageType,
-                                 MachineIRBuilder &MIRBuilder);
-
+  // check sense hence can only be called within getOrCreateSPIRVType callstack
   SPIRVType *getOpTypeBool(MachineIRBuilder &MIRBuilder);
 
   SPIRVType *getOpTypeInt(uint32_t Width, MachineIRBuilder &MIRBuilder,
@@ -235,16 +213,6 @@ private:
                                const SmallVectorImpl<SPIRVType *> &ArgTypes,
                                MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *getOpTypeImage(MachineIRBuilder &MIRBuilder,
-                            SPIRVType *SampledType, Dim::Dim Dim,
-                            uint32_t Depth, uint32_t Arrayed,
-                            uint32_t Multisampled, uint32_t Sampled,
-                            ImageFormat::ImageFormat ImageFormat,
-                            AQ::AccessQualifier AccQual);
-
-  SPIRVType *getOpTypePipe(MachineIRBuilder &MIRBuilder,
-                           AQ::AccessQualifier AccQual);
-
   SPIRVType *getOpTypeByOpcode(MachineIRBuilder &MIRBuilder, unsigned Opcode);
 
   SPIRVType *handleOpenCLBuiltin(const StructType *Ty,
@@ -252,7 +220,7 @@ private:
                                  AQ::AccessQualifier AccQual);
 
   SPIRVType *
-  generateOpenCLOpaqueType(const StructType *Ty, MachineIRBuilder &MIRBuilder,
+  getOrCreateOpenCLOpaqueType(const StructType *Ty, MachineIRBuilder &MIRBuilder,
                            AQ::AccessQualifier AccQual = AQ::ReadWrite);
 
   SPIRVType *handleSPIRVBuiltin(const StructType *Ty,
@@ -260,7 +228,7 @@ private:
                                 AQ::AccessQualifier AccQual);
 
   SPIRVType *
-  generateSPIRVOpaqueType(const StructType *Ty, MachineIRBuilder &MIRBuilder,
+  getOrCreateSPIRVOpaqueType(const StructType *Ty, MachineIRBuilder &MIRBuilder,
                           AQ::AccessQualifier AccQual = AQ::ReadWrite);
 
   std::tuple<Register, ConstantInt *, bool> getOrCreateConstIntReg(
@@ -310,8 +278,20 @@ public:
       SPIRVType *BaseType, MachineInstr &I, const SPIRVInstrInfo &TII,
       StorageClass::StorageClass SC = StorageClass::Function);
 
-  SPIRVType *getOrCreateSPIRVSampledImageType(SPIRVType *ImageType,
+  SPIRVType *getOrCreateOpTypeImage(MachineIRBuilder &MIRBuilder,
+                            SPIRVType *SampledType, Dim::Dim Dim,
+                            uint32_t Depth, uint32_t Arrayed,
+                            uint32_t Multisampled, uint32_t Sampled,
+                            ImageFormat::ImageFormat ImageFormat,
+                            AQ::AccessQualifier AccQual);
+
+  SPIRVType *getOrCreateOpTypeSampler(MachineIRBuilder &MIRBuilder);
+
+  SPIRVType *getOrCreateOpTypeSampledImage(SPIRVType *ImageType,
                                               MachineIRBuilder &MIRBuilder);
+
+  SPIRVType *getOrCreateOpTypePipe(MachineIRBuilder &MIRBuilder,
+                           AQ::AccessQualifier AccQual);
 };
 } // end namespace llvm
 #endif // LLLVM_LIB_TARGET_SPIRV_SPIRVTYPEMANAGER_H

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -19,6 +19,7 @@
 #include "MCTargetDesc/SPIRVBaseInfo.h"
 #include "SPIRVDuplicatesTracker.h"
 #include "SPIRVInstrInfo.h"
+#include "llvm/ADT/MapVector.h"
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 
 namespace AQ = AccessQualifier;
@@ -83,7 +84,7 @@ public:
     DT.add(C, MF, R);
   }
 
-  void add(const GlobalValue *GV, MachineFunction *MF, Register R) {
+  void add(const GlobalVariable *GV, MachineFunction *MF, Register R) {
     DT.add(GV, MF, R);
   }
 
@@ -95,7 +96,7 @@ public:
     return DT.find(C, MF, R);
   }
 
-  bool find(const GlobalValue *GV, MachineFunction *MF, Register &R) {
+  bool find(const GlobalVariable *GV, MachineFunction *MF, Register &R) {
     return DT.find(GV, MF, R);
   }
 
@@ -104,8 +105,7 @@ public:
   }
 
   template <typename T>
-  const MapVector<const T *, MapVector<MachineFunction *, Register>> &
-  getAllUses() {
+  const DenseMap<const T *, DTSortableEntry> &getAllUses() {
     return DT.get<T>()->getAllUses();
   }
 
@@ -169,6 +169,10 @@ public:
   Register getSPIRVTypeID(const SPIRVType *SpirvType) const;
 
   void setCurrentFunc(MachineFunction &MF) { CurMF = &MF; }
+
+  void buildDepsGraph(std::vector<DTSortableEntry *> &Graph) {
+    DT.buildDepsGraph(Graph);
+  }
 
   // Whether the given VReg has an OpTypeXXX instruction mapped to it with the
   // given opcode (e.g. OpTypeFloat).

--- a/llvm/lib/Target/SPIRV/SPIRVMCInstLower.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVMCInstLower.cpp
@@ -20,7 +20,7 @@
 
 using namespace llvm;
 
-void SPIRVMCInstLower::Lower(const MachineInstr *MI, MCInst &OutMI,
+void SPIRVMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI,
                              const MachineFunction *CurMF,
                              ModuleAnalysisInfo *MAI) const {
   OutMI.setOpcode(MI->getOpcode());

--- a/llvm/lib/Target/SPIRV/SPIRVMCInstLower.h
+++ b/llvm/lib/Target/SPIRV/SPIRVMCInstLower.h
@@ -20,7 +20,7 @@ struct ModuleAnalysisInfo;
 // This class is used to lower a MachineInstr into an MCInst.
 class LLVM_LIBRARY_VISIBILITY SPIRVMCInstLower {
 public:
-  void Lower(const MachineInstr *MI, MCInst &OutMI,
+  void lower(const MachineInstr *MI, MCInst &OutMI,
              const MachineFunction *CurMF, ModuleAnalysisInfo *MAI) const;
 };
 } // namespace llvm

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -92,11 +92,10 @@ void SPIRVModuleAnalysis::setBaseInfo(const Module &M) {
       Register::index2VirtReg(MAI.getNextID());
 }
 
-template <typename T>
-static void makeRegisterAliases(SPIRVGlobalRegistry *GR,
-                                ModuleAnalysisInfo &MAI) {
+static void makeRegisterAliasesFunc(SPIRVGlobalRegistry *GR,
+                                    ModuleAnalysisInfo &MAI) {
   // Make global registers for entries of DT.
-  for (auto &CU : GR->getAllUses<T>()) {
+  for (auto &CU : GR->getAllUses<Function>()) {
     Register GlobalReg = Register::index2VirtReg(MAI.getNextID());
     for (auto &U : CU.second) {
       auto *MF = U.first;
@@ -104,17 +103,40 @@ static void makeRegisterAliases(SPIRVGlobalRegistry *GR,
       MAI.setRegisterAlias(MF, Reg, GlobalReg);
     }
   }
-  // Make global registers for special types and constants collected in the map.
-  if (std::is_same<T, Type>::value) {
-    for (auto &CU : GR->getSpecialTypesAndConstsMap()) {
-      for (auto &TypeGroup : CU.second) {
-        Register GlobalReg = Register::index2VirtReg(MAI.getNextID());
-        for (auto &t : TypeGroup) {
-          MachineFunction *MF = t.first;
-          assert(t.second->getOperand(0).isReg());
-          Register Reg = t.second->getOperand(0).getReg();
-          MAI.setRegisterAlias(MF, Reg, GlobalReg);
-        }
+}
+
+static void makeRegisterAliases(SPIRVGlobalRegistry *GR,
+                                std::vector<DTSortableEntry *> &DepsGraph,
+                                ModuleAnalysisInfo &MAI) {
+  std::set<DTSortableEntry *> Visited;
+  for (auto *E : DepsGraph) {
+    std::function<void(DTSortableEntry *)> RecHoistUtil;
+    // NOTE: here we prefer recursive approach over iterative because
+    // we don't expect depchains long enough to cause SO
+    RecHoistUtil = [&Visited, &RecHoistUtil, &MAI](DTSortableEntry *E) {
+      if (Visited.count(E) || E->getIsFunc())
+        return;
+      Visited.insert(E);
+      for (auto *S : E->getDeps())
+        RecHoistUtil(S);
+
+      Register GlobalReg = Register::index2VirtReg(MAI.getNextID());
+      for (auto &U : *E) {
+        auto *MF = U.first;
+        auto Reg = U.second;
+        MAI.setRegisterAlias(MF, Reg, GlobalReg);
+      }
+    };
+    RecHoistUtil(E);
+  }
+  for (auto &CU : GR->getSpecialTypesAndConstsMap()) {
+    for (auto &TypeGroup : CU.second) {
+      Register GlobalReg = Register::index2VirtReg(MAI.getNextID());
+      for (auto &t : TypeGroup) {
+        MachineFunction *MF = t.first;
+        assert(t.second->getOperand(0).isReg());
+        Register Reg = t.second->getOperand(0).getReg();
+        MAI.setRegisterAlias(MF, Reg, GlobalReg);
       }
     }
   }
@@ -143,31 +165,41 @@ static void collectDefInstr(Register Reg, MachineFunction *MF,
   insertInstrToMS(GlobalReg, MI, MAI, MSType);
 }
 
-template <typename T> void SPIRVModuleAnalysis::collectTypesConstsVars() {
-  // Collect instructions from DT.
-  for (auto &CU : GR->getAllUses<T>()) {
-    for (auto &U : CU.second) {
-      auto *MF = U.first;
-      auto Reg = U.second;
-      // Some instructions may be deleted during global isel, so collect only
-      // those that exist in current IR.
-      if (MF->getRegInfo().getVRegDef(Reg)) {
-        collectDefInstr(Reg, MF, &MAI, MB_TypeConstVars);
-        if (std::is_same<T, GlobalValue>::value)
-          MAI.GlobalVarList.push_back(MF->getRegInfo().getVRegDef(Reg));
+void SPIRVModuleAnalysis::collectTypesConstsVars() {
+  std::set<DTSortableEntry *> Visited;
+  for (auto *E : DepsGraph) {
+    std::function<void(DTSortableEntry *)> RecHoistUtil;
+    // NOTE: here we prefer recursive approach over iterative because
+    // we don't expect depchains long enough to cause SO
+    RecHoistUtil = [&Visited, &RecHoistUtil](DTSortableEntry *E) {
+      if (Visited.count(E) || E->getIsFunc())
+        return;
+      Visited.insert(E);
+      for (auto *S : E->getDeps())
+        RecHoistUtil(S);
+
+      for (auto &U : *E) {
+        auto *MF = U.first;
+        auto Reg = U.second;
+        if (MF->getRegInfo().getVRegDef(Reg)) {
+          collectDefInstr(Reg, MF, &MAI, MB_TypeConstVars);
+          if (E->getIsGV())
+            MAI.GlobalVarList.push_back(MF->getRegInfo().getVRegDef(Reg));
+        }
       }
-    }
+    };
+    RecHoistUtil(E);
   }
   // Hoist special types and constants collected in the map.
-  if (std::is_same<T, Type>::value) {
-    for (auto &CU : GR->getSpecialTypesAndConstsMap())
-      for (auto &TypeGroup : CU.second)
-        for (auto &t : TypeGroup) {
-          MachineFunction *MF = t.first;
-          assert(t.second->getOperand(0).isReg());
-          Register Reg = t.second->getOperand(0).getReg();
-          collectDefInstr(Reg, MF, &MAI, MB_TypeConstVars);
-        }
+  for (auto &CU : GR->getSpecialTypesAndConstsMap()) {
+    for (auto &TypeGroup : CU.second) {
+      for (auto &t : TypeGroup) {
+        MachineFunction *MF = t.first;
+        assert(t.second->getOperand(0).isReg());
+        Register Reg = t.second->getOperand(0).getReg();
+        collectDefInstr(Reg, MF, &MAI, MB_TypeConstVars);
+      }
+    }
   }
 }
 
@@ -186,7 +218,6 @@ static void collectFuncDecls(SPIRVGlobalRegistry *GR, ModuleAnalysisInfo *MAI) {
         Reg = MI->getOperand(0).getReg();
         if (MI->getOpcode() == SPIRV::OpFunctionParameter) {
           Register GlobalReg = Register::index2VirtReg(MAI->getNextID());
-          ;
           MAI->setRegisterAlias(MF, Reg, GlobalReg);
           insertInstrToMS(GlobalReg, MI, MAI, MB_ExtFuncDecls);
         } else {
@@ -204,16 +235,14 @@ static void collectFuncDecls(SPIRVGlobalRegistry *GR, ModuleAnalysisInfo *MAI) {
 // at module level. Also it collects explicit OpExtension/OpCapability
 // instructions.
 void SPIRVModuleAnalysis::processDefInstrs(const Module &M) {
+  GR->buildDepsGraph(DepsGraph);
   // OpTypes and OpConstants can have cross references so at first we create
   // new global registers and map them to old regs, then walk the list of
   // instructions, and select ones that should be emitted at module level.
   // Also there are references to global values in constants.
-  makeRegisterAliases<Type>(GR, MAI);
-  makeRegisterAliases<Constant>(GR, MAI);
-  makeRegisterAliases<GlobalValue>(GR, MAI);
+  makeRegisterAliases(GR, DepsGraph, MAI);
 
-  collectTypesConstsVars<Type>();
-  collectTypesConstsVars<Constant>();
+  collectTypesConstsVars();
 
   for (auto F = M.begin(), E = M.end(); F != E; ++F) {
     MachineFunction *MF = MMI->getMachineFunction(*F);
@@ -237,8 +266,8 @@ void SPIRVModuleAnalysis::processDefInstrs(const Module &M) {
     }
   }
 
-  collectTypesConstsVars<GlobalValue>();
-  makeRegisterAliases<Function>(GR, MAI);
+  // collectTypesConstsVars<GlobalValue>();
+  makeRegisterAliasesFunc(GR, MAI);
   collectFuncDecls(GR, &MAI);
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
@@ -133,7 +133,7 @@ public:
 
 private:
   void setBaseInfo(const Module &M);
-  template <typename T> void collectTypesConstsVars();
+  void collectTypesConstsVars();
   void processDefInstrs(const Module &M);
   void collectFuncNames(MachineInstr &MI, const Function &F);
   void processOtherInstrs(const Module &M);
@@ -143,6 +143,8 @@ private:
   SPIRVGlobalRegistry *GR;
   const SPIRVInstrInfo *TII;
   MachineModuleInfo *MMI;
+
+  std::vector<DTSortableEntry *> DepsGraph;
 };
 } // namespace llvm
 #endif // LLVM_LIB_TARGET_SPIRV_SPIRVMODULEANALYSIS_H

--- a/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
@@ -281,7 +281,7 @@ static Register buildOpSampledImage(Register res, Register image,
   const auto MRI = MIRBuilder.getMRI();
   SPIRVType *imageType = GR->getSPIRVTypeForVReg(image);
   SPIRVType *sampImTy =
-      GR->getOrCreateSPIRVSampledImageType(imageType, MIRBuilder);
+      GR->getOrCreateOpTypeSampledImage(imageType, MIRBuilder);
 
   Register sampledImage = res.isValid() ? res
       : MRI->createVirtualRegister(&SPIRV::IDRegClass);

--- a/llvm/test/CodeGen/SPIRV/transcoding/extract_insert_value.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/extract_insert_value.ll
@@ -11,15 +11,16 @@ target triple = "spirv32-unknown-unknown"
 %struct.inner = type { float }
 
 ; CHECK-SPIRV: %[[float_ty:[0-9]+]] = OpTypeFloat 32
-; CHECK-SPIRV: %[[struct1_in_ty:[0-9]+]] = OpTypeStruct %[[float_ty]]
-; CHECK-SPIRV: %[[struct1_in_ptr_ty:[0-9]+]] = OpTypePointer CrossWorkgroup %[[struct1_in_ty]]
-; CHECK-SPIRV: %[[struct1_ty:[0-9]+]] = OpTypeStruct %[[struct1_in_ty]]
-; CHECK-SPIRV: %[[struct1_ptr_ty:[0-9]+]] = OpTypePointer CrossWorkgroup %[[struct1_ty]]
-; CHECK-SPIRV: %[[arr_size:[0-9]+]] = OpConstant %{{[0-9]+}} 7
+; CHECK-SPIRV: %[[int_ty:[0-9]+]] = OpTypeInt 32
+; CHECK-SPIRV: %[[arr_size:[0-9]+]] = OpConstant %[[int_ty]] 7
 ; CHECK-SPIRV: %[[array_ty:[0-9]+]] = OpTypeArray %[[float_ty]] %[[arr_size]]
-; CHECK-SPIRV: %[[array_ptr_ty:[0-9]+]] = OpTypePointer CrossWorkgroup %[[array_ty]]
 ; CHECK-SPIRV: %[[struct_ty:[0-9]+]] = OpTypeStruct %[[array_ty]]
 ; CHECK-SPIRV: %[[struct_ptr_ty:[0-9]+]] = OpTypePointer CrossWorkgroup %[[struct_ty]]
+; CHECK-SPIRV: %[[array_ptr_ty:[0-9]+]] = OpTypePointer CrossWorkgroup %[[array_ty]]
+; CHECK-SPIRV: %[[struct1_in_ty:[0-9]+]] = OpTypeStruct %[[float_ty]]
+; CHECK-SPIRV: %[[struct1_ty:[0-9]+]] = OpTypeStruct %[[struct1_in_ty]]
+; CHECK-SPIRV: %[[struct1_ptr_ty:[0-9]+]] = OpTypePointer CrossWorkgroup %[[struct1_ty]]
+; CHECK-SPIRV: %[[struct1_in_ptr_ty:[0-9]+]] = OpTypePointer CrossWorkgroup %[[struct1_in_ty]]
 
 ; CHECK-SPIRV-LABEL:  OpFunction
 ; CHECK-SPIRV-NEXT:   %[[object:[0-9]+]] = OpFunctionParameter %[[struct_ptr_ty]]

--- a/llvm/test/CodeGen/SPIRV/transcoding/extract_insert_value.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/extract_insert_value.ll
@@ -11,16 +11,15 @@ target triple = "spirv32-unknown-unknown"
 %struct.inner = type { float }
 
 ; CHECK-SPIRV: %[[float_ty:[0-9]+]] = OpTypeFloat 32
-; FIXME: properly order array type decl & num elems constant
-; CHECK-SPIRV: %[[array_ty:[0-9]+]] = OpTypeArray %[[float_ty]]
-; CHECK-SPIRV: %[[struct_ty:[0-9]+]] = OpTypeStruct %[[array_ty]]
-; CHECK-SPIRV-DAG: %[[array_ptr_ty:[0-9]+]] = OpTypePointer CrossWorkgroup %[[array_ty]]
-; CHECK-SPIRV-DAG: %[[struct_ptr_ty:[0-9]+]] = OpTypePointer CrossWorkgroup %[[struct_ty]]
-
 ; CHECK-SPIRV: %[[struct1_in_ty:[0-9]+]] = OpTypeStruct %[[float_ty]]
+; CHECK-SPIRV: %[[struct1_in_ptr_ty:[0-9]+]] = OpTypePointer CrossWorkgroup %[[struct1_in_ty]]
 ; CHECK-SPIRV: %[[struct1_ty:[0-9]+]] = OpTypeStruct %[[struct1_in_ty]]
-; CHECK-SPIRV-DAG: %[[struct1_in_ptr_ty:[0-9]+]] = OpTypePointer CrossWorkgroup %[[struct1_in_ty]]
-; CHECK-SPIRV-DAG: %[[struct1_ptr_ty:[0-9]+]] = OpTypePointer CrossWorkgroup %[[struct1_ty]]
+; CHECK-SPIRV: %[[struct1_ptr_ty:[0-9]+]] = OpTypePointer CrossWorkgroup %[[struct1_ty]]
+; CHECK-SPIRV: %[[arr_size:[0-9]+]] = OpConstant %{{[0-9]+}} 7
+; CHECK-SPIRV: %[[array_ty:[0-9]+]] = OpTypeArray %[[float_ty]] %[[arr_size]]
+; CHECK-SPIRV: %[[array_ptr_ty:[0-9]+]] = OpTypePointer CrossWorkgroup %[[array_ty]]
+; CHECK-SPIRV: %[[struct_ty:[0-9]+]] = OpTypeStruct %[[array_ty]]
+; CHECK-SPIRV: %[[struct_ptr_ty:[0-9]+]] = OpTypePointer CrossWorkgroup %[[struct_ty]]
 
 ; CHECK-SPIRV-LABEL:  OpFunction
 ; CHECK-SPIRV-NEXT:   %[[object:[0-9]+]] = OpFunctionParameter %[[struct_ptr_ty]]


### PR DESCRIPTION
…onsts/etc.

In general this is needed to ensure proper ordering which was previously ensured by using MapVector
and hoping everything's added to it in the correct order (not always true).

Currently it breaks up to 20 LITs due to the unstable (correct from the spec PoV though) types/consts declaration order.
Also conecptually fixes transcoding/extract_insert_value.ll which had
a wrong ordering before which wasn't covered with LIT checks