### PR TITLE
[SPIR-V] support recursive types

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.cpp
@@ -47,12 +47,13 @@ bool SPIRVInstrInfo::isConstantInstr(const MachineInstr &MI) const {
 }
 
 bool SPIRVInstrInfo::isTypeDeclInstr(const MachineInstr &MI) const {
+  // TODO: maybe implement it in the same way as other is***Instr checkers.
   auto &MRI = MI.getMF()->getRegInfo();
   if (MI.getNumDefs() >= 1 && MI.getOperand(0).isReg()) {
     auto DefRegClass = MRI.getRegClassOrNull(MI.getOperand(0).getReg());
     return DefRegClass && DefRegClass->getID() == SPIRV::TYPERegClass.getID();
   } else {
-    return false;
+    return MI.getOpcode() == SPIRV::OpTypeForwardPointer;
   }
 }
 

--- a/llvm/test/CodeGen/SPIRV/layout.ll
+++ b/llvm/test/CodeGen/SPIRV/layout.ll
@@ -38,11 +38,11 @@
 ; CHECK-NOT: OpVariable
 ; CHECK-NOT: OpFunction
 
-; CHECK: %[[AFwdPtr:[0-9]+]] = OpTypeForwardPointer
+; CHECK-DAG: OpTypeForwardPointer %[[AFwdPtr:[0-9]+]]
 ; CHECK: %[[TypeInt:[0-9]+]] = OpTypeInt
+; CHECK-DAG: %[[TPointer:[0-9]+]] = OpTypePointer
 ; CHECK: %[[Two:[0-9]+]] = OpConstant %[[TypeInt]] 2
-; CHECK: %[[TPointer:[0-9]+]] = OpTypePointer
-; CHECK: %[[SConstOpType:[0-9]+]] = OpTypePointer
+; CHECK-DAG: %[[SConstOpType:[0-9]+]] = OpTypePointer
 ; CHECK: %[[TypeFloat:[0-9]+]] = OpTypeFloat
 ; CHECK: %[[TypeArray:[0-9]+]] = OpTypeArray %[[TypeFloat]] %[[Two]]
 ; CHECK: %[[TypeVectorInt3:[0-9]+]] = OpTypeVector %[[TypeInt]] 3

--- a/llvm/test/CodeGen/SPIRV/transcoding/RecursiveType.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/RecursiveType.ll
@@ -8,15 +8,15 @@ target triple = "spirv32-unknown-unknown"
 %struct.B = type { i32, %struct.A addrspace(4)* }
 %struct.Node = type { %struct.Node addrspace(1)*, i32 }
 
-; CHECK-SPIRV-DAG: %[[NodeFwdPtr:[0-9]+]] = OpTypeForwardPointer CrossWorkgroup
-; CHECK-SPIRV-DAG: %[[AFwdPtr:[0-9]+]] = OpTypeForwardPointer Generic
-; CHECK-SPIRV: %[[IntID:[0-9]+]] = OpTypeInt 32 0
+; CHECK-SPIRV-DAG: OpTypeForwardPointer %[[NodeFwdPtr:[0-9]+]] CrossWorkgroup
+; CHECK-SPIRV-DAG: OpTypeForwardPointer %[[AFwdPtr:[0-9]+]] Generic
+; CHECK-SPIRV-DAG: %[[IntID:[0-9]+]] = OpTypeInt 32 0
 ; CHECK-SPIRV: %[[BID:[0-9]+]] = OpTypeStruct %{{[0-9]+}} %[[AFwdPtr]]
 ; CHECK-SPIRV: %[[CID:[0-9]+]] = OpTypeStruct %{{[0-9]+}} %[[BID]]
 ; CHECK-SPIRV: %[[AID:[0-9]+]] = OpTypeStruct %{{[0-9]+}} %[[CID]]
-; CHECK-SPIRV: %[[AFwdPtr]] = OpTypePointer Generic %[[AID:[0-9]+]]
-; CHECK-SPIRV: %[[NodeID:[0-9]+]] = OpTypeStruct %[[NodeFwdPtr]]
-; CHECK-SPIRV: %[[NodeFwdPtr]] = OpTypePointer CrossWorkgroup %[[NodeID]]
+; CHECK-SPIRV-DAG: %[[AFwdPtr]] = OpTypePointer Generic %[[AID:[0-9]+]]
+; CHECK-SPIRV-DAG: %[[NodeID:[0-9]+]] = OpTypeStruct %[[NodeFwdPtr]]
+; CHECK-SPIRV-DAG: %[[NodeFwdPtr]] = OpTypePointer CrossWorkgroup %[[NodeID]]
 
 ; Function Attrs: nounwind
 define spir_kernel void @test(%struct.A addrspace(1)* %result, %struct.Node addrspace(1)* %node) #0 !kernel_arg_addr_space !1 !kernel_arg_access_qual !2 !kernel_arg_type !3 !kernel_arg_base_type !4 !kernel_arg_type_qual !5 {


### PR DESCRIPTION
This change implements simple support of recursive types. One LIT test (transcoding/RecursiveType.ll) should pass.

Also it ports small fix from the review of the 6th patch (an indentation issue in SPIRVModuleAnalysis.cpp).