### PR TITLE
[SPIR-V] correct code for review 10

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.cpp
@@ -1,4 +1,4 @@
-//===-- SPIRVDuplicatesTracker.cpp - SPIR-V Duplicates Tracker --------------===//
+//===-- SPIRVDuplicatesTracker.cpp - SPIR-V Duplicates Tracker --*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,44 +6,58 @@
 //
 //===----------------------------------------------------------------------===//
 //
+// General infrastructure for keeping track of the values that according to
+// the SPIR-V binary layout should be global to the whole module.
 //
 //===----------------------------------------------------------------------===//
-
 
 #include "SPIRVDuplicatesTracker.h"
 
 using namespace llvm;
 
 template <typename T>
-const SPIRVDuplicatesTracker<T> *
-SPIRVGeneralDuplicatesTracker::get(T *Arg) {
-  llvm_unreachable("Querying duplicates of unsupported type");
-  return nullptr;
+void SPIRVGeneralDuplicatesTracker::prebuildReg2Entry(
+    SPIRVDuplicatesTracker<T> &DT, SPIRVReg2EntryTy &Reg2Entry) {
+  for (auto &TPair : DT.getAllUses()) {
+    for (auto &RegPair : TPair.second) {
+      const MachineFunction *MF = RegPair.first;
+      Register R = RegPair.second;
+      MachineInstr *MI = MF->getRegInfo().getVRegDef(R);
+      if (!MI)
+        continue;
+      Reg2Entry[&MI->getOperand(0)] = &TPair.second;
+    }
+  }
 }
 
-template <>
-const SPIRVTypeTracker *SPIRVGeneralDuplicatesTracker::get(Type *Arg) {
-  return &TT;
-}
+void SPIRVGeneralDuplicatesTracker::buildDepsGraph(
+    std::vector<SPIRV::DTSortableEntry *> &Graph) {
+  SPIRVReg2EntryTy Reg2Entry;
+  prebuildReg2Entry(TT, Reg2Entry);
+  prebuildReg2Entry(CT, Reg2Entry);
+  prebuildReg2Entry(GT, Reg2Entry);
+  prebuildReg2Entry(FT, Reg2Entry);
+  prebuildReg2Entry(ST, Reg2Entry);
 
-template <>
-const SPIRVConstantTracker *SPIRVGeneralDuplicatesTracker::get(Constant *Arg) {
-  return &CT;
+  for (auto &Op2E : Reg2Entry) {
+    auto *E = Op2E.second;
+    Graph.push_back(E);
+    for (auto &U : *E) {
+      const MachineRegisterInfo &MRI = U.first->getRegInfo();
+      MachineInstr *MI = MRI.getUniqueVRegDef(U.second);
+      if (!MI)
+        continue;
+      assert(MI && MI->getParent() && "No MachineInstr created yet");
+      for (auto i = MI->getNumDefs(); i < MI->getNumOperands(); i++) {
+        MachineOperand &Op = MI->getOperand(i);
+        if (!Op.isReg())
+          continue;
+        MachineOperand *RegOp = &MRI.getVRegDef(Op.getReg())->getOperand(0);
+        assert((MI->getOpcode() == SPIRV::OpVariable && i == 3) ||
+               Reg2Entry.count(RegOp));
+        if (Reg2Entry.count(RegOp))
+          E->getDeps().push_back(Reg2Entry[RegOp]);
+      }
+    }
+  }
 }
-
-template <>
-const SPIRVGlobalVariableTracker *
-SPIRVGeneralDuplicatesTracker::get(GlobalVariable *Arg) {
-  return &GT;
-}
-
-template <>
-const SPIRVFuncDeclsTracker *SPIRVGeneralDuplicatesTracker::get(Function *Arg) {
-  return &FT;
-}
-
-template <>
-const SPIRVSpecialDeclsTracker *SPIRVGeneralDuplicatesTracker::get(SpecialTypeDescriptor *Arg) {
-  return &ST;
-}
-  

--- a/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.h
+++ b/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.h
@@ -1,13 +1,13 @@
-//===-- SPIRVDuplicatesTracker.h - SPIR-V Duplicates Tracker --------------===//
+//===-- SPIRVDuplicatesTracker.h - SPIR-V Duplicates Tracker ----*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+//
 // General infrastructure for keeping track of the values that according to
 // the SPIR-V binary layout should be global to the whole module.
-// Actual hoisting happens in SPIRVGlobalTypesAndRegNum pass.
 //
 //===----------------------------------------------------------------------===//
 
@@ -16,31 +16,31 @@
 
 #include "MCTargetDesc/SPIRVBaseInfo.h"
 #include "MCTargetDesc/SPIRVMCTargetDesc.h"
-#include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 #include "llvm/ADT/DenseMap.h"
 #include "llvm/ADT/MapVector.h"
+#include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 
 #include <type_traits>
 
 namespace llvm {
-
+namespace SPIRV {
 // NOTE: using MapVector instead of DenseMap because it helps getting
 // everything ordered in a stable manner for a price of extra (NumKeys)*PtrSize
-// memory and expensive removals which do not happen anyway
+// memory and expensive removals which do not happen anyway.
 class DTSortableEntry : public MapVector<const MachineFunction *, Register> {
   SmallVector<DTSortableEntry *, 2> Deps;
 
   struct FlagsTy {
     unsigned IsFunc : 1;
     unsigned IsGV : 1;
-    // NOTE: bit-field default init is a C++20 feature
+    // NOTE: bit-field default init is a C++20 feature.
     FlagsTy() : IsFunc(0), IsGV(0) {}
   };
   FlagsTy Flags;
 
 public:
-  // common hoisting utility doesn't support
-  // function because their hoisting require hoisting of params as well
+  // Common hoisting utility doesn't support function, because their hoisting
+  // require hoisting of params as well.
   bool getIsFunc() const { return Flags.IsFunc; }
   bool getIsGV() const { return Flags.IsGV; }
   void setIsFunc(bool V) { Flags.IsFunc = V; }
@@ -61,18 +61,16 @@ struct SpecialTypeDescriptor {
   SpecialTypeKind Kind;
 
   unsigned Hash;
-  
-  SpecialTypeDescriptor() = delete;
-  SpecialTypeDescriptor(SpecialTypeKind K): Kind(K) { Hash = Kind; }
 
-  unsigned getHash() const {
-    return Hash;
-  }
+  SpecialTypeDescriptor() = delete;
+  SpecialTypeDescriptor(SpecialTypeKind K) : Kind(K) { Hash = Kind; }
+
+  unsigned getHash() const { return Hash; }
 
   virtual ~SpecialTypeDescriptor() {}
 };
 
-struct ImageTypeDescriptor: public SpecialTypeDescriptor {
+struct ImageTypeDescriptor : public SpecialTypeDescriptor {
   union ImageAttrs {
     struct BitFlags {
       unsigned Dim : 3;
@@ -99,7 +97,8 @@ struct ImageTypeDescriptor: public SpecialTypeDescriptor {
     Attrs.Flags.Sampled = Sampled;
     Attrs.Flags.ImageFormat = ImageFormat;
     Attrs.Flags.AQ = AQ;
-    Hash = (DenseMapInfo<Type*>().getHashValue(SampledTy) & 0xffff) ^ ((Attrs.Val << 8) | Kind);
+    Hash = (DenseMapInfo<Type *>().getHashValue(SampledTy) & 0xffff) ^
+           ((Attrs.Val << 8) | Kind);
   }
 
   static bool classof(const SpecialTypeDescriptor *TD) {
@@ -107,7 +106,7 @@ struct ImageTypeDescriptor: public SpecialTypeDescriptor {
   }
 };
 
-struct SampledImageTypeDescriptor: public SpecialTypeDescriptor {
+struct SampledImageTypeDescriptor : public SpecialTypeDescriptor {
   SampledImageTypeDescriptor(const Type *SampledTy, const MachineInstr *ImageTy)
       : SpecialTypeDescriptor(SpecialTypeKind::STK_SampledImage) {
     assert(ImageTy->getOpcode() == SPIRV::OpTypeImage);
@@ -124,8 +123,9 @@ struct SampledImageTypeDescriptor: public SpecialTypeDescriptor {
   }
 };
 
-struct SamplerTypeDescriptor: public SpecialTypeDescriptor {
-  SamplerTypeDescriptor(): SpecialTypeDescriptor(SpecialTypeKind::STK_Sampler) {
+struct SamplerTypeDescriptor : public SpecialTypeDescriptor {
+  SamplerTypeDescriptor()
+      : SpecialTypeDescriptor(SpecialTypeKind::STK_Sampler) {
     Hash = Kind;
   }
 
@@ -133,9 +133,11 @@ struct SamplerTypeDescriptor: public SpecialTypeDescriptor {
     return TD->Kind == SpecialTypeKind::STK_Sampler;
   }
 };
-struct PipeTypeDescriptor: public SpecialTypeDescriptor {
 
-  PipeTypeDescriptor(uint8_t AQ): SpecialTypeDescriptor(SpecialTypeKind::STK_Pipe) {
+struct PipeTypeDescriptor : public SpecialTypeDescriptor {
+
+  PipeTypeDescriptor(uint8_t AQ)
+      : SpecialTypeDescriptor(SpecialTypeKind::STK_Pipe) {
     Hash = (AQ << 8) | Kind;
   }
 
@@ -143,36 +145,36 @@ struct PipeTypeDescriptor: public SpecialTypeDescriptor {
     return TD->Kind == SpecialTypeKind::STK_Pipe;
   }
 };
+} // namespace SPIRV
 
-template <> struct DenseMapInfo<SpecialTypeDescriptor> {
-  static inline SpecialTypeDescriptor getEmptyKey() {
-    return SpecialTypeDescriptor(SpecialTypeDescriptor::STK_Empty);
+template <> struct DenseMapInfo<SPIRV::SpecialTypeDescriptor> {
+  static inline SPIRV::SpecialTypeDescriptor getEmptyKey() {
+    return SPIRV::SpecialTypeDescriptor(
+        SPIRV::SpecialTypeDescriptor::STK_Empty);
   }
-  static inline SpecialTypeDescriptor getTombstoneKey() {
-    return SpecialTypeDescriptor(SpecialTypeDescriptor::STK_Last);
+  static inline SPIRV::SpecialTypeDescriptor getTombstoneKey() {
+    return SPIRV::SpecialTypeDescriptor(SPIRV::SpecialTypeDescriptor::STK_Last);
   }
-  static unsigned getHashValue(SpecialTypeDescriptor Val) {
+  static unsigned getHashValue(SPIRV::SpecialTypeDescriptor Val) {
     return Val.getHash();
   }
-  static bool isEqual(SpecialTypeDescriptor LHS, SpecialTypeDescriptor RHS) {
+  static bool isEqual(SPIRV::SpecialTypeDescriptor LHS,
+                      SPIRV::SpecialTypeDescriptor RHS) {
     return getHashValue(LHS) == getHashValue(RHS);
   }
 };
 
-
 template <typename KeyTy> class SPIRVDuplicatesTrackerBase {
 public:
-  // NOTE: using MapVector instead of DenseMap helps getting
-  // everything ordered in a stable manner for a price of extra
-  // (NumKeys)*PtrSize memory and expensive removals which don't happen anyway
-  using StorageTy = MapVector<KeyTy, DTSortableEntry>;
+  // NOTE: using MapVector instead of DenseMap helps getting everything ordered
+  // in a stable manner for a price of extra (NumKeys)*PtrSize memory and
+  // expensive removals which don't happen anyway.
+  using StorageTy = MapVector<KeyTy, SPIRV::DTSortableEntry>;
 
 private:
   StorageTy Storage;
 
 public:
-  SPIRVDuplicatesTrackerBase() {}
-
   void add(KeyTy V, const MachineFunction *MF, Register R) {
     Register OldReg;
     if (find(V, MF, OldReg)) {
@@ -190,7 +192,7 @@ public:
       Storage[V].setIsGV(true);
   }
 
-  bool find(KeyTy V, const MachineFunction *MF, Register& R) const {
+  bool find(KeyTy V, const MachineFunction *MF, Register &R) const {
     auto iter = Storage.find(V);
     if (iter != Storage.end()) {
       auto Map = iter->second;
@@ -215,82 +217,38 @@ private:
   friend class SPIRVGeneralDuplicatesTracker;
 };
 
-template<typename T>
-class SPIRVDuplicatesTracker: public SPIRVDuplicatesTrackerBase<const T*> {};
+template <typename T>
+class SPIRVDuplicatesTracker : public SPIRVDuplicatesTrackerBase<const T *> {};
 
-template<>
-class SPIRVDuplicatesTracker<SpecialTypeDescriptor>: public SPIRVDuplicatesTrackerBase<SpecialTypeDescriptor> {};
-
-using SPIRVTypeTracker = SPIRVDuplicatesTracker<Type>;
-using SPIRVConstantTracker = SPIRVDuplicatesTracker<Constant>;
-using SPIRVGlobalVariableTracker = SPIRVDuplicatesTracker<GlobalVariable>;
-using SPIRVFuncDeclsTracker = SPIRVDuplicatesTracker<Function>;
-using SPIRVSpecialDeclsTracker = SPIRVDuplicatesTracker<SpecialTypeDescriptor>;
+template <>
+class SPIRVDuplicatesTracker<SPIRV::SpecialTypeDescriptor>
+    : public SPIRVDuplicatesTrackerBase<SPIRV::SpecialTypeDescriptor> {};
 
 class SPIRVGeneralDuplicatesTracker {
-  SPIRVTypeTracker TT;
-  SPIRVConstantTracker CT;
-  SPIRVGlobalVariableTracker GT;
-  SPIRVFuncDeclsTracker FT;
-  SPIRVSpecialDeclsTracker ST;
+  SPIRVDuplicatesTracker<Type> TT;
+  SPIRVDuplicatesTracker<Constant> CT;
+  SPIRVDuplicatesTracker<GlobalVariable> GT;
+  SPIRVDuplicatesTracker<Function> FT;
+  SPIRVDuplicatesTracker<SPIRV::SpecialTypeDescriptor> ST;
 
-  // NOTE: using MOs instead of regs to get rid of MF dependency
-  // to be able to use flat data structure
-  // NOTE: replacing DenseMap with MapVector doesn't affect overall
-  // correctness but makes LITs more stable, should prefer DenseMap still
-  // due to significant perf difference
-  using Reg2EntryTy = MapVector<MachineOperand *, DTSortableEntry *>;
+  // NOTE: using MOs instead of regs to get rid of MF dependency to be able
+  // to use flat data structure.
+  // NOTE: replacing DenseMap with MapVector doesn't affect overall correctness
+  // but makes LITs more stable, should prefer DenseMap still due to
+  // significant perf difference.
+  using SPIRVReg2EntryTy =
+      MapVector<MachineOperand *, SPIRV::DTSortableEntry *>;
 
-private:
   template <typename T>
   void prebuildReg2Entry(SPIRVDuplicatesTracker<T> &DT,
-                         Reg2EntryTy &Reg2Entry) {
-    for (auto &TPair : DT.getAllUses()) {
-      for (auto &RegPair : TPair.second) {
-        auto *MF = RegPair.first;
-        auto R = RegPair.second;
-        auto *MI = MF->getRegInfo().getVRegDef(R);
-        if (!MI)
-          continue;
-        Reg2Entry[&MI->getOperand(0)] = &TPair.second;
-      }
-    }
-  }
+                         SPIRVReg2EntryTy &Reg2Entry);
 
 public:
-  void buildDepsGraph(std::vector<DTSortableEntry *> &Graph) {
-    Reg2EntryTy Reg2Entry;
-    prebuildReg2Entry(TT, Reg2Entry);
-    prebuildReg2Entry(CT, Reg2Entry);
-    prebuildReg2Entry(GT, Reg2Entry);
-    prebuildReg2Entry(FT, Reg2Entry);
-    prebuildReg2Entry(ST, Reg2Entry);
+  void buildDepsGraph(std::vector<SPIRV::DTSortableEntry *> &Graph);
 
-    for (auto &Op2E : Reg2Entry) {
-      auto *E = Op2E.second;
-      Graph.push_back(E);
-      for (auto &U : *E) {
-        auto *MF = U.first;
-        auto R = U.second;
-
-        auto *MI = MF->getRegInfo().getVRegDef(R);
-        if (!MI)
-          continue;
-        assert(MI && MI->getParent() && "No MachineInstr created yet");
-        for (auto i = MI->getNumDefs(); i < MI->getNumOperands(); i++) {
-          auto Op = MI->getOperand(i);
-          if (!Op.isReg())
-            continue;
-          MachineOperand *RegOp = &MF->getRegInfo().getVRegDef(Op.getReg())->getOperand(0);
-          assert((MI->getOpcode() == SPIRV::OpVariable && i == 3) || Reg2Entry.count(RegOp));
-          if (Reg2Entry.count(RegOp))
-            E->getDeps().push_back(Reg2Entry[RegOp]);
-        }
-      }
-    }
+  void add(const Type *T, const MachineFunction *MF, Register R) {
+    TT.add(T, MF, R);
   }
-
-  void add(const Type *T, const MachineFunction *MF, Register R) { TT.add(T, MF, R); }
 
   void add(const Constant *C, const MachineFunction *MF, Register R) {
     CT.add(C, MF, R);
@@ -304,36 +262,34 @@ public:
     FT.add(F, MF, R);
   }
 
-  void add(const SpecialTypeDescriptor &TD, const MachineFunction *MF, Register R) {
+  void add(const SPIRV::SpecialTypeDescriptor &TD, const MachineFunction *MF,
+           Register R) {
     ST.add(TD, MF, R);
   }
 
-  bool find(const Type *T, const MachineFunction *MF, Register& R) {
-    return TT.find(const_cast<Type*>(T), MF, R);
+  bool find(const Type *T, const MachineFunction *MF, Register &R) {
+    return TT.find(const_cast<Type *>(T), MF, R);
   }
 
-  bool find(const Constant *C, const MachineFunction *MF, Register& R) {
-    return CT.find(const_cast<Constant*>(C), MF, R);
+  bool find(const Constant *C, const MachineFunction *MF, Register &R) {
+    return CT.find(const_cast<Constant *>(C), MF, R);
   }
 
   bool find(const GlobalVariable *GV, const MachineFunction *MF, Register &R) {
-    return GT.find(const_cast<GlobalVariable*>(GV), MF, R);
+    return GT.find(const_cast<GlobalVariable *>(GV), MF, R);
   }
 
-  bool find(const Function *F, const MachineFunction *MF, Register& R) {
-    return FT.find(const_cast<Function*>(F), MF, R);
+  bool find(const Function *F, const MachineFunction *MF, Register &R) {
+    return FT.find(const_cast<Function *>(F), MF, R);
   }
 
-  bool find(const SpecialTypeDescriptor &TD, const MachineFunction *MF, Register& R) {
+  bool find(const SPIRV::SpecialTypeDescriptor &TD, const MachineFunction *MF,
+            Register &R) {
     return ST.find(TD, MF, R);
   }
 
-
-  // NOTE:
-  // T *Arg = nullptr is added as compiler fails to infer T for specializations
-  // based just on templated return type
-  template <typename T> const SPIRVDuplicatesTracker<T> *get(T *Arg = nullptr);
+  const SPIRVDuplicatesTracker<Type> *getTypes() { return &TT; }
+  const SPIRVDuplicatesTracker<Function> *getFuncs() { return &FT; }
 };
-
-} // end namespace llvm
+} // namespace llvm
 #endif

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -92,15 +92,17 @@ void SPIRVModuleAnalysis::setBaseInfo(const Module &M) {
       Register::index2VirtReg(MAI.getNextID());
 }
 
-static void makeRegisterAliases(SPIRVGlobalRegistry *GR,
-                                std::vector<DTSortableEntry *> &DepsGraph,
-                                ModuleAnalysisInfo &MAI) {
-  std::set<DTSortableEntry *> Visited;
+// TODO: either merge with collectTypesConstsVars or factor the DFS code out.
+static void
+makeRegisterAliases(SPIRVGlobalRegistry *GR,
+                    std::vector<SPIRV::DTSortableEntry *> &DepsGraph,
+                    ModuleAnalysisInfo &MAI) {
+  DenseSet<SPIRV::DTSortableEntry *> Visited;
   for (auto *E : DepsGraph) {
-    std::function<void(DTSortableEntry *)> RecHoistUtil;
+    std::function<void(SPIRV::DTSortableEntry *)> RecHoistUtil;
     // NOTE: here we prefer recursive approach over iterative because
-    // we don't expect depchains long enough to cause SO
-    RecHoistUtil = [&Visited, &RecHoistUtil, &MAI](DTSortableEntry *E) {
+    // we don't expect depchains long enough to cause SO.
+    RecHoistUtil = [&Visited, &RecHoistUtil, &MAI](SPIRV::DTSortableEntry *E) {
       if (Visited.count(E))
         return;
       Visited.insert(E);
@@ -108,11 +110,8 @@ static void makeRegisterAliases(SPIRVGlobalRegistry *GR,
         RecHoistUtil(S);
 
       Register GlobalReg = Register::index2VirtReg(MAI.getNextID());
-      for (auto &U : *E) {
-        auto *MF = U.first;
-        auto Reg = U.second;
-        MAI.setRegisterAlias(MF, Reg, GlobalReg);
-      }
+      for (auto &U : *E)
+        MAI.setRegisterAlias(U.first, U.second, GlobalReg);
     };
     RecHoistUtil(E);
   }
@@ -141,13 +140,14 @@ static void collectDefInstr(Register Reg, const MachineFunction *MF,
   insertInstrToMS(GlobalReg, MI, MAI, MSType);
 }
 
-void SPIRVModuleAnalysis::collectTypesConstsVars() {
-  std::set<DTSortableEntry *> Visited;
+void SPIRVModuleAnalysis::collectTypesConstsVars(
+    std::vector<SPIRV::DTSortableEntry *> DepsGraph) {
+  DenseSet<SPIRV::DTSortableEntry *> Visited;
   for (auto *E : DepsGraph) {
-    std::function<void(DTSortableEntry *)> RecHoistUtil;
+    std::function<void(SPIRV::DTSortableEntry *)> RecHoistUtil;
     // NOTE: here we prefer recursive approach over iterative because
-    // we don't expect depchains long enough to cause SO
-    RecHoistUtil = [&Visited, &RecHoistUtil](DTSortableEntry *E) {
+    // we don't expect depchains long enough to cause SO.
+    RecHoistUtil = [&Visited, &RecHoistUtil](SPIRV::DTSortableEntry *E) {
       if (Visited.count(E) || E->getIsFunc())
         return;
       Visited.insert(E);
@@ -155,13 +155,13 @@ void SPIRVModuleAnalysis::collectTypesConstsVars() {
         RecHoistUtil(S);
 
       for (auto &U : *E) {
-        auto *MF = U.first;
-        auto Reg = U.second;
-        if (MF->getRegInfo().getVRegDef(Reg)) {
-          collectDefInstr(Reg, MF, &MAI, MB_TypeConstVars);
-          if (E->getIsGV())
-            MAI.GlobalVarList.push_back(MF->getRegInfo().getVRegDef(Reg));
-        }
+        const MachineFunction *MF = U.first;
+        Register Reg = U.second;
+        if (!MF->getRegInfo().getUniqueVRegDef(Reg))
+          continue;
+        collectDefInstr(Reg, MF, &MAI, MB_TypeConstVars);
+        if (E->getIsGV())
+          MAI.GlobalVarList.push_back(MF->getRegInfo().getUniqueVRegDef(Reg));
       }
     };
     RecHoistUtil(E);
@@ -173,10 +173,10 @@ void SPIRVModuleAnalysis::collectTypesConstsVars() {
 // TODO: maybe consider replacing this with explicit OpFunctionParameter
 // generation here instead handling it in CallLowering.
 static void collectFuncDecls(SPIRVGlobalRegistry *GR, ModuleAnalysisInfo *MAI) {
-  for (auto &CU : GR->getAllUses<Function>()) {
+  for (auto &CU : GR->getFuncAllUses()) {
     for (auto &U : CU.second) {
-      auto *MF = U.first;
-      auto Reg = U.second;
+      const MachineFunction *MF = U.first;
+      Register Reg = U.second;
       MachineInstr *MI = MF->getRegInfo().getVRegDef(Reg);
       while (MI && (MI->getOpcode() == SPIRV::OpFunction ||
                     MI->getOpcode() == SPIRV::OpFunctionParameter)) {
@@ -200,6 +200,7 @@ static void collectFuncDecls(SPIRVGlobalRegistry *GR, ModuleAnalysisInfo *MAI) {
 // at module level. Also it collects explicit OpExtension/OpCapability
 // instructions.
 void SPIRVModuleAnalysis::processDefInstrs(const Module &M) {
+  std::vector<SPIRV::DTSortableEntry *> DepsGraph;
   GR->buildDepsGraph(DepsGraph);
   // OpTypes and OpConstants can have cross references so at first we create
   // new global registers and map them to old regs, then walk the list of
@@ -207,25 +208,25 @@ void SPIRVModuleAnalysis::processDefInstrs(const Module &M) {
   // Also there are references to global values in constants.
   makeRegisterAliases(GR, DepsGraph, MAI);
 
-  collectTypesConstsVars();
+  collectTypesConstsVars(DepsGraph);
 
   for (auto F = M.begin(), E = M.end(); F != E; ++F) {
     MachineFunction *MF = MMI->getMachineFunction(*F);
-    if (MF) {
-      // Iterate through and hoist any instructions we can at this stage.
-      // bool hasSeenFirstOpFunction = false;
-      for (MachineBasicBlock &MBB : *MF) {
-        for (MachineInstr &MI : MBB) {
-          if (MI.getOpcode() == SPIRV::OpExtension) {
-            // Here, OpExtension just has a single enum operand, not a string.
-            auto Ext = Extension::Extension(MI.getOperand(0).getImm());
-            MAI.Reqs.addExtension(Ext);
-            MAI.setSkipEmission(&MI);
-          } else if (MI.getOpcode() == SPIRV::OpCapability) {
-            auto Cap = Capability::Capability(MI.getOperand(0).getImm());
-            MAI.Reqs.addCapability(Cap);
-            MAI.setSkipEmission(&MI);
-          }
+    if (!MF)
+      continue;
+    // Iterate through and hoist any instructions we can at this stage.
+    // bool hasSeenFirstOpFunction = false;
+    for (MachineBasicBlock &MBB : *MF) {
+      for (MachineInstr &MI : MBB) {
+        if (MI.getOpcode() == SPIRV::OpExtension) {
+          // Here, OpExtension just has a single enum operand, not a string.
+          auto Ext = Extension::Extension(MI.getOperand(0).getImm());
+          MAI.Reqs.addExtension(Ext);
+          MAI.setSkipEmission(&MI);
+        } else if (MI.getOpcode() == SPIRV::OpCapability) {
+          auto Cap = Capability::Capability(MI.getOperand(0).getImm());
+          MAI.Reqs.addCapability(Cap);
+          MAI.setSkipEmission(&MI);
         }
       }
     }
@@ -376,29 +377,29 @@ static void processSwitches(const Module &M, ModuleAnalysisInfo &MAI,
   DenseSet<Register> SwitchRegs;
   for (auto F = M.begin(), E = M.end(); F != E; ++F) {
     MachineFunction *MF = MMI->getMachineFunction(*F);
-    if (MF) {
-      for (MachineBasicBlock &MBB : *MF)
-        for (MachineInstr &MI : MBB) {
-          if (MAI.getSkipEmission(&MI))
-            continue;
-          if (MI.getOpcode() == SPIRV::OpSwitch) {
-            assert(MI.getOperand(0).isReg());
-            SwitchRegs.insert(MI.getOperand(0).getReg());
-          }
-          if (MI.getOpcode() == SPIRV::OpIEqual && MI.getOperand(2).isReg() &&
-              SwitchRegs.contains(MI.getOperand(2).getReg())) {
-            Register CmpReg = MI.getOperand(0).getReg();
-            MachineInstr *CBr = MI.getNextNode();
-            assert(CBr && CBr->getOpcode() == SPIRV::OpBranchConditional &&
-                   CBr->getOperand(0).isReg() &&
-                   CBr->getOperand(0).getReg() == CmpReg);
-            MAI.setSkipEmission(&MI);
-            MAI.setSkipEmission(CBr);
-            if (&MBB.front() == &MI && &MBB.back() == CBr)
-              MAI.MBBsToSkip.insert(&MBB);
-          }
+    if (!MF)
+      continue;
+    for (MachineBasicBlock &MBB : *MF)
+      for (MachineInstr &MI : MBB) {
+        if (MAI.getSkipEmission(&MI))
+          continue;
+        if (MI.getOpcode() == SPIRV::OpSwitch) {
+          assert(MI.getOperand(0).isReg());
+          SwitchRegs.insert(MI.getOperand(0).getReg());
         }
-    }
+        if (MI.getOpcode() == SPIRV::OpIEqual && MI.getOperand(2).isReg() &&
+            SwitchRegs.contains(MI.getOperand(2).getReg())) {
+          Register CmpReg = MI.getOperand(0).getReg();
+          MachineInstr *CBr = MI.getNextNode();
+          assert(CBr && CBr->getOpcode() == SPIRV::OpBranchConditional &&
+                 CBr->getOperand(0).isReg() &&
+                 CBr->getOperand(0).getReg() == CmpReg);
+          MAI.setSkipEmission(&MI);
+          MAI.setSkipEmission(CBr);
+          if (&MBB.front() == &MI && &MBB.back() == CBr)
+            MAI.MBBsToSkip.insert(&MBB);
+        }
+      }
   }
 }
 
@@ -732,11 +733,11 @@ static void collectReqs(const Module &M, ModuleAnalysisInfo &MAI,
   // Collect requirements for existing instructions.
   for (auto F = M.begin(), E = M.end(); F != E; ++F) {
     MachineFunction *MF = MMI->getMachineFunction(*F);
-    if (MF) {
-      for (const MachineBasicBlock &MBB : *MF)
-        for (const MachineInstr &MI : MBB)
-          addInstrRequirements(MI, MAI.Reqs, ST);
-    }
+    if (!MF)
+      continue;
+    for (const MachineBasicBlock &MBB : *MF)
+      for (const MachineInstr &MI : MBB)
+        addInstrRequirements(MI, MAI.Reqs, ST);
   }
   // Collect requirements for OpExecutionMode instructions.
   auto Node = M.getNamedMetadata("spirv.ExecutionMode");

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
@@ -133,7 +133,7 @@ public:
 
 private:
   void setBaseInfo(const Module &M);
-  void collectTypesConstsVars();
+  void collectTypesConstsVars(std::vector<SPIRV::DTSortableEntry *> DepsGraph);
   void processDefInstrs(const Module &M);
   void collectFuncNames(MachineInstr &MI, const Function &F);
   void processOtherInstrs(const Module &M);
@@ -143,8 +143,6 @@ private:
   SPIRVGlobalRegistry *GR;
   const SPIRVInstrInfo *TII;
   MachineModuleInfo *MMI;
-
-  std::vector<DTSortableEntry *> DepsGraph;
 };
 } // namespace llvm
 #endif // LLVM_LIB_TARGET_SPIRV_SPIRVMODULEANALYSIS_H

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -47,17 +47,15 @@ extern "C" LLVM_EXTERNAL_VISIBILITY void LLVMInitializeSPIRVTarget() {
 }
 
 static std::string computeDataLayout(const Triple &TT) {
-  std::string DataLayout = "e-m:e";
-
   const auto Arch = TT.getArch();
   // TODO: unify this with pointers legalization
   if (Arch == Triple::spirv32)
-    DataLayout += "-p:32:32";
+    return "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-"
+           "v96:128-v192:256-v256:256-v512:512-v1024:1024";
   else if (Arch == Triple::spirv64)
-    DataLayout += "-p:64:64";
-  else if (Arch == Triple::spirvlogical)
-    DataLayout += "-p:8:8";
-  return DataLayout;
+    return "e-i64:64-v16:16-v24:32-v32:32-v48:64-"
+           "v96:128-v192:256-v256:256-v512:512-v1024:1024";
+  return "e-m:e-p:8:8";
 }
 
 static Reloc::Model getEffectiveRelocModel(Optional<Reloc::Model> RM) {

--- a/llvm/test/CodeGen/SPIRV/opaque_pointers.ll
+++ b/llvm/test/CodeGen/SPIRV/opaque_pointers.ll
@@ -5,11 +5,11 @@
 ; CHECK: %[[Int64Ty:[0-9]+]] = OpTypeInt 64 0
 ; CHECK: %[[FTy:[0-9]+]] = OpTypeFunction %[[Int64Ty]] %[[PtrTy]]
 ; CHECK: %[[Int32Ty:[0-9]+]] = OpTypeInt 32 0
-; CHECK: %[[Const:[0-9]+]] = OpConstant %[[Int32Ty]] 0 
+; CHECK: %[[Const:[0-9]+]] = OpConstant %[[Int32Ty]] 0
 ; CHECK: OpFunction %[[Int64Ty]] None %[[FTy]]
 ; CHECK: %[[Parm:[0-9]+]] = OpFunctionParameter %[[PtrTy]]
 ; CHECK: OpStore %[[Parm]] %[[Const]] Aligned 4
-; CHECK: %[[Res:[0-9]+]] = OpLoad %[[Int64Ty]] %[[Parm]] Aligned 4
+; CHECK: %[[Res:[0-9]+]] = OpLoad %[[Int64Ty]] %[[Parm]] Aligned 8
 ; CHECK: OpReturnValue %[[Res]]
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"


### PR DESCRIPTION
The change prepares DuplicationTracker for promotion to llvm. Also it contains fixes for the code review of the 7th patch and the issue with DataLayout. Also it fixes opaque_pointer.ll test.