### PR TITLE
[SPIR-V] process more module-level metadata

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -249,6 +249,13 @@ void SPIRVAsmPrinter::outputModuleSection(SPIRV::ModuleSectionType MSType) {
 }
 
 void SPIRVAsmPrinter::outputDebugSourceAndStrings(const Module &M) {
+  // Output OpSourceExtensions.
+  for (auto &Str : MAI->SrcExt) {
+    MCInst Inst;
+    Inst.setOpcode(SPIRV::OpSourceExtension);
+    addStringImm(Str.first(), Inst);
+    outputMCInst(Inst);
+  }
   // Output OpSource.
   MCInst Inst;
   Inst.setOpcode(SPIRV::OpSource);

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.h
@@ -57,6 +57,7 @@ struct ModuleAnalysisInfo {
   AddressingModel::AddressingModel Addr;
   SourceLanguage::SourceLanguage SrcLang;
   unsigned SrcLangVersion;
+  StringSet<> SrcExt;
   // Maps ExtInstSet to corresponding ID register.
   DenseMap<unsigned, Register> ExtInstSetMap;
   // Contains the list of all global OpVariables in the module.

--- a/llvm/test/CodeGen/SPIRV/AtomicCompareExchange_cl20.ll
+++ b/llvm/test/CodeGen/SPIRV/AtomicCompareExchange_cl20.ll
@@ -3,7 +3,7 @@
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv32-unknown-unknown"
 
-; CHECK: OpSource OpenCL_C 131072
+; CHECK: OpSource OpenCL_C 200000
 
 ; Int64Atomics capability must be declared only if atomic builtins have 64-bit integers arguments.
 ; CHECK-NOT: OpCapability Int64Atomics

--- a/llvm/test/CodeGen/SPIRV/metadata-opencl12.ll
+++ b/llvm/test/CodeGen/SPIRV/metadata-opencl12.ll
@@ -5,5 +5,4 @@ target triple = "spirv32-unknown-unknown"
 !opencl.ocl.version = !{!0}
 !0 = !{i32 1, i32 2}
 
-; We assume the SPIR-V 2.2 environment spec's version format: 0|Maj|Min|Rev|
-; CHECK: OpSource OpenCL_C 66048
+; CHECK: OpSource OpenCL_C 102000

--- a/llvm/test/CodeGen/SPIRV/metadata-opencl20.ll
+++ b/llvm/test/CodeGen/SPIRV/metadata-opencl20.ll
@@ -5,5 +5,4 @@ target triple = "spirv32-unknown-unknown"
 !opencl.ocl.version = !{!0}
 !0 = !{i32 2, i32 0}
 
-; We assume the SPIR-V 2.2 environment spec's version format: 0|Maj|Min|Rev|
-; CHECK: OpSource OpenCL_C 131072
+; CHECK: OpSource OpenCL_C 200000

--- a/llvm/test/CodeGen/SPIRV/metadata-opencl22.ll
+++ b/llvm/test/CodeGen/SPIRV/metadata-opencl22.ll
@@ -5,5 +5,4 @@ target triple = "spirv32-unknown-unknown"
 !opencl.ocl.version = !{!0}
 !0 = !{i32 2, i32 2}
 
-; We assume the SPIR-V 2.2 environment spec's version format: 0|Maj|Min|Rev|
-; CHECK: OpSource OpenCL_C 131584
+; CHECK: OpSource OpenCL_C 202000


### PR DESCRIPTION
The change adds processing of spirv.MemoryModel and opencl.used.extensions metadata. Also it corrects SrcLangVersion evaluation (as it's done in the translator) and corresponding checks in tests. 3 LIT tests should pass.