### PR TITLE
[SPIR-V] fix spv_store issues and others

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -20,7 +20,7 @@ let TargetPrefix = "spv" in {
 
   def int_spv_gep : Intrinsic<[llvm_anyptr_ty], [llvm_i1_ty, llvm_any_ty, llvm_vararg_ty], [ImmArg<ArgIndex<0>>]>;
   def int_spv_load : Intrinsic<[llvm_i32_ty], [llvm_anyptr_ty, llvm_i16_ty, llvm_i8_ty], [ImmArg<ArgIndex<1>>, ImmArg<ArgIndex<2>>]>;
-  def int_spv_store : Intrinsic<[], [llvm_i32_ty, llvm_anyptr_ty, llvm_i16_ty, llvm_i8_ty], [ImmArg<ArgIndex<2>>, ImmArg<ArgIndex<3>>]>;
+  def int_spv_store : Intrinsic<[], [llvm_any_ty, llvm_anyptr_ty, llvm_i16_ty, llvm_i8_ty], [ImmArg<ArgIndex<2>>, ImmArg<ArgIndex<3>>]>;
   def int_spv_extractv : Intrinsic<[llvm_any_ty], [llvm_i32_ty, llvm_vararg_ty]>;
   def int_spv_insertv : Intrinsic<[llvm_i32_ty], [llvm_i32_ty, llvm_any_ty, llvm_vararg_ty]>;
   def int_spv_extractelt : Intrinsic<[llvm_any_ty], [llvm_any_ty, llvm_anyint_ty]>;

--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -72,6 +72,47 @@ static ConstantInt *getConstInt(MDNode *MD, unsigned NumOp) {
   return nullptr;
 }
 
+// This code restores function args/retvalue types for composite cases
+// because the final types should still be aggregate whereas they're i32
+// during the translation to cope with aggregate flattening etc.
+static FunctionType *getFuncType(const Function &F) {
+  auto *NamedMD = F.getParent()->getNamedMetadata("spv.cloned_funcs");
+  if (NamedMD == nullptr)
+    return F.getFunctionType();
+
+  Type *RetTy = F.getFunctionType()->getReturnType();
+  SmallVector<Type *, 4> ArgTypes;
+  for (auto &Arg : F.args())
+    ArgTypes.push_back(Arg.getType());
+
+  auto ThisFuncMDIt =
+      std::find_if(NamedMD->op_begin(), NamedMD->op_end(), [&F](MDNode *N) {
+        return isa<MDString>(N->getOperand(0)) &&
+               cast<MDString>(N->getOperand(0))->getString() == F.getName();
+      });
+  // TODO: probably one function can have numerous type mutations,
+  // so we should support this.
+  if (ThisFuncMDIt != NamedMD->op_end()) {
+    auto *ThisFuncMD = *ThisFuncMDIt;
+    MDNode *MD = dyn_cast<MDNode>(ThisFuncMD->getOperand(1));
+    assert(MD && "MDNode operand is expected");
+    ConstantInt *Const = getConstInt(MD, 0);
+    if (Const) {
+      auto *CMeta = dyn_cast<ConstantAsMetadata>(MD->getOperand(1));
+      assert(CMeta && "ConstantAsMetadata operand is expected");
+      assert(Const->getSExtValue() >= -1);
+      // Currently -1 indicates return value, greater values mean
+      // argument numbers.
+      if (Const->getSExtValue() == -1)
+        RetTy = CMeta->getType();
+      else
+        ArgTypes[Const->getSExtValue()] = CMeta->getType();
+    }
+  }
+
+  return FunctionType::get(RetTy, ArgTypes, F.isVarArg());
+}
+
 bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
                                              const Function &F,
                                              ArrayRef<ArrayRef<Register>> VRegs,
@@ -80,6 +121,7 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
   GR->setCurrentFunc(MIRBuilder.getMF());
 
   // Assign types and names to all args, and store their types for later.
+  FunctionType *FTy = getFuncType(F);
   SmallVector<Register, 4> ArgTypeVRegs;
   if (VRegs.size() > 0) {
     unsigned i = 0;
@@ -88,8 +130,8 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
       // auto *SpirvTy = GR->getOrCreateSPIRVType(Arg.getType(), MIRBuilder);
       // SPIRVType *SpirvTy = GR->getSPIRVTypeForVReg(VRegs[i][0]);
       // if (!SpirvTy)
-      auto *SpirvTy =
-          GR->assignTypeToVReg(Arg.getType(), VRegs[i][0], MIRBuilder);
+      Type *ArgTy = FTy->getParamType(i);
+      auto *SpirvTy = GR->assignTypeToVReg(ArgTy, VRegs[i][0], MIRBuilder);
       ArgTypeVRegs.push_back(GR->getSPIRVTypeID(SpirvTy));
 
       if (Arg.hasName())
@@ -155,41 +197,6 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
     GR->add(&F, &MIRBuilder.getMF(), FuncVReg);
   MRI->setRegClass(FuncVReg, &SPIRV::IDRegClass);
 
-  auto *FTy = F.getFunctionType();
-
-  // This code restores function args/retvalue types for composite cases
-  // because the final types should still be aggregate whereas they're i32
-  // during the translation to cope with aggregate flattening etc.
-  auto *NamedMD = F.getParent()->getNamedMetadata("spv.cloned_funcs");
-  if (NamedMD) {
-    Type *RetTy = F.getFunctionType()->getReturnType();
-    SmallVector<Type *, 4> ArgTypes;
-    auto ThisFuncMDIt =
-        std::find_if(NamedMD->op_begin(), NamedMD->op_end(), [&F](MDNode *N) {
-          return isa<MDString>(N->getOperand(0)) &&
-                 cast<MDString>(N->getOperand(0))->getString() == F.getName();
-        });
-
-    if (ThisFuncMDIt != NamedMD->op_end()) {
-      auto *ThisFuncMD = *ThisFuncMDIt;
-      MDNode *MD = dyn_cast<MDNode>(ThisFuncMD->getOperand(1));
-      assert(MD && "MDNode operand is expected");
-      ConstantInt *Const = getConstInt(MD, 0);
-      // TODO: currently -1 indicates return value, support this types
-      // renaming for arguments as well.
-      if (Const && Const->getSExtValue() == -1) {
-        auto *CMeta = dyn_cast<ConstantAsMetadata>(MD->getOperand(1));
-        assert(CMeta && "ConstantAsMetadata operand is expected");
-        RetTy = CMeta->getType();
-      }
-    }
-
-    for (auto &Arg : F.args())
-      ArgTypes.push_back(Arg.getType());
-
-    FTy = FunctionType::get(RetTy, ArgTypes, F.isVarArg());
-  }
-
   auto FuncTy = GR->assignTypeToVReg(FTy, FuncVReg, MIRBuilder);
 
   // Build the OpTypeFunction declaring it.
@@ -238,6 +245,7 @@ bool SPIRVCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
   auto FuncName = Info.Callee.getGlobal()->getGlobalIdentifier();
   auto &MF = MIRBuilder.getMF();
   GR->setCurrentFunc(MF);
+  FunctionType *FTy = nullptr;
 
   size_t n;
   int Status;
@@ -301,6 +309,7 @@ bool SPIRVCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
         FunctionLoweringInfo FuncInfo;
         lowerFormalArguments(FirstBlockBuilder, *CF, VRegArgs, FuncInfo);
       }
+      FTy = getFuncType(*CF);
     }
 
     // Make sure there's a valid return reg, even for functions returning void.
@@ -308,7 +317,7 @@ bool SPIRVCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
       ResVReg = MIRBuilder.getMRI()->createVirtualRegister(&SPIRV::IDRegClass);
     }
     SPIRVType *RetType =
-        GR->assignTypeToVReg(Info.OrigRet.Ty, ResVReg, MIRBuilder);
+        GR->assignTypeToVReg(FTy->getReturnType(), ResVReg, MIRBuilder);
 
     // Emit the OpFunctionCall and its args.
     auto MIB = MIRBuilder.buildInstr(SPIRV::OpFunctionCall)

--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -75,7 +75,7 @@ static ConstantInt *getConstInt(MDNode *MD, unsigned NumOp) {
 // This code restores function args/retvalue types for composite cases
 // because the final types should still be aggregate whereas they're i32
 // during the translation to cope with aggregate flattening etc.
-static FunctionType *getFuncType(const Function &F) {
+static FunctionType *getOriginalFunctionType(const Function &F) {
   auto *NamedMD = F.getParent()->getNamedMetadata("spv.cloned_funcs");
   if (NamedMD == nullptr)
     return F.getFunctionType();
@@ -121,7 +121,7 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
   GR->setCurrentFunc(MIRBuilder.getMF());
 
   // Assign types and names to all args, and store their types for later.
-  FunctionType *FTy = getFuncType(F);
+  FunctionType *FTy = getOriginalFunctionType(F);
   SmallVector<Register, 4> ArgTypeVRegs;
   if (VRegs.size() > 0) {
     unsigned i = 0;
@@ -309,7 +309,7 @@ bool SPIRVCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
         FunctionLoweringInfo FuncInfo;
         lowerFormalArguments(FirstBlockBuilder, *CF, VRegArgs, FuncInfo);
       }
-      FTy = getFuncType(*CF);
+      FTy = getOriginalFunctionType(*CF);
     }
 
     // Make sure there's a valid return reg, even for functions returning void.

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -1279,29 +1279,29 @@ bool SPIRVInstructionSelector::selectInsertVal(Register ResVReg,
                                                const SPIRVType *ResType,
                                                MachineInstr &I) const {
   MachineBasicBlock &BB = *I.getParent();
-  return BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpCompositeInsert))
-      .addDef(ResVReg)
-      .addUse(GR.getSPIRVTypeID(ResType))
-      // object to insert
-      .addUse(I.getOperand(3).getReg())
-      // composite to insert into
-      .addUse(I.getOperand(2).getReg())
-      // TODO: support arbitrary number of indices
-      .addImm(foldImm(I.getOperand(4), MRI))
-      .constrainAllUses(TII, TRI, RBI);
+  auto MIB = BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpCompositeInsert))
+                 .addDef(ResVReg)
+                 .addUse(GR.getSPIRVTypeID(ResType))
+                 // object to insert
+                 .addUse(I.getOperand(3).getReg())
+                 // composite to insert into
+                 .addUse(I.getOperand(2).getReg());
+  for (unsigned i = 4; i < I.getNumOperands(); i++)
+    MIB.addImm(foldImm(I.getOperand(i), MRI));
+  return MIB.constrainAllUses(TII, TRI, RBI);
 }
 
 bool SPIRVInstructionSelector::selectExtractVal(Register ResVReg,
                                                 const SPIRVType *ResType,
                                                 MachineInstr &I) const {
   MachineBasicBlock &BB = *I.getParent();
-  return BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpCompositeExtract))
-      .addDef(ResVReg)
-      .addUse(GR.getSPIRVTypeID(ResType))
-      .addUse(I.getOperand(2).getReg())
-      // TODO: support arbitrary number of indices
-      .addImm(foldImm(I.getOperand(3), MRI))
-      .constrainAllUses(TII, TRI, RBI);
+  auto MIB = BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpCompositeExtract))
+                 .addDef(ResVReg)
+                 .addUse(GR.getSPIRVTypeID(ResType))
+                 .addUse(I.getOperand(2).getReg());
+  for (unsigned i = 3; i < I.getNumOperands(); i++)
+    MIB.addImm(foldImm(I.getOperand(i), MRI));
+  return MIB.constrainAllUses(TII, TRI, RBI);
 }
 
 bool SPIRVInstructionSelector::selectInsertElt(Register ResVReg,

--- a/llvm/test/CodeGen/SPIRV/opencl/basic/vstore_private.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl/basic/vstore_private.ll
@@ -1,0 +1,117 @@
+; RUN: llc -O0 %s -o - | FileCheck %s
+
+target triple = "spirv64-unknown-unknown"
+
+; CHECK: %[[#i16_ty:]] = OpTypeInt 16 0
+; CHECK: %[[#v4xi16_ty:]] = OpTypeVector %[[#i16_ty]] 4
+; CHECK: %[[#pv4xi16_ty:]] = OpTypePointer Function %[[#v4xi16_ty]]
+; CHECK: %[[#i16_const0:]] = OpConstant %[[#i16_ty]] 0
+; CHECK: %[[#i16_undef:]] = OpUndef %[[#i16_ty]]
+; CHECK: %[[#comp_const:]] = OpConstantComposite %[[#v4xi16_ty]] %[[#i16_const0]] %[[#i16_const0]] %[[#i16_const0]] %[[#i16_undef]]
+
+; CHECK: %[[#r:]] = OpInBoundsPtrAccessChain
+; CHECK: %[[#r2:]] = OpBitcast %[[#pv4xi16_ty]] %[[#r]]
+; CHECK: OpStore %[[#r2]] %[[#comp_const]] Aligned 8
+
+; Function Attrs: nounwind
+define spir_kernel void @test_fn(i16 addrspace(1)* %srcValues, i32 addrspace(1)* %offsets, <3 x i16> addrspace(1)* %destBuffer, i32 %alignmentOffset) #0 {
+entry:
+  %sPrivateStorage = alloca [42 x <3 x i16>], align 8
+  %0 = bitcast [42 x <3 x i16>]* %sPrivateStorage to i8*
+  %1 = bitcast i8* %0 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 336, i8* %1)
+  %2 = call spir_func <3 x i64> @BuiltInGlobalInvocationId() #2
+  %call = extractelement <3 x i64> %2, i32 0
+  %conv = trunc i64 %call to i32
+  %idxprom = sext i32 %conv to i64
+  %arrayidx = getelementptr inbounds [42 x <3 x i16>], [42 x <3 x i16>]* %sPrivateStorage, i64 0, i64 %idxprom
+  %storetmp = bitcast <3 x i16>* %arrayidx to <4 x i16>*
+  store <4 x i16> <i16 0, i16 0, i16 0, i16 undef>, <4 x i16>* %storetmp, align 8
+  %conv1 = sext i32 %conv to i64
+  %call2 = call spir_func <3 x i16> @OpenCL_vload3_i64_p1i16_i32(i64 %conv1, i16 addrspace(1)* %srcValues, i32 3) #0
+  %idxprom3 = sext i32 %conv to i64
+  %arrayidx4 = getelementptr inbounds i32, i32 addrspace(1)* %offsets, i64 %idxprom3
+  %3 = load i32, i32 addrspace(1)* %arrayidx4, align 4
+  %conv5 = zext i32 %3 to i64
+  %arraydecay = getelementptr inbounds [42 x <3 x i16>], [42 x <3 x i16>]* %sPrivateStorage, i64 0, i64 0
+  %4 = bitcast <3 x i16>* %arraydecay to i16*
+  %idx.ext = zext i32 %alignmentOffset to i64
+  %add.ptr = getelementptr inbounds i16, i16* %4, i64 %idx.ext
+  call spir_func void @OpenCL_vstore3_v3i16_i64_p0i16(<3 x i16> %call2, i64 %conv5, i16* %add.ptr) #0
+  %arraydecay6 = getelementptr inbounds [42 x <3 x i16>], [42 x <3 x i16>]* %sPrivateStorage, i64 0, i64 0
+  %5 = bitcast <3 x i16>* %arraydecay6 to i16*
+  %idxprom7 = sext i32 %conv to i64
+  %arrayidx8 = getelementptr inbounds i32, i32 addrspace(1)* %offsets, i64 %idxprom7
+  %6 = load i32, i32 addrspace(1)* %arrayidx8, align 4
+  %mul = mul i32 3, %6
+  %idx.ext9 = zext i32 %mul to i64
+  %add.ptr10 = getelementptr inbounds i16, i16* %5, i64 %idx.ext9
+  %idx.ext11 = zext i32 %alignmentOffset to i64
+  %add.ptr12 = getelementptr inbounds i16, i16* %add.ptr10, i64 %idx.ext11
+  %7 = bitcast <3 x i16> addrspace(1)* %destBuffer to i16 addrspace(1)*
+  %idxprom13 = sext i32 %conv to i64
+  %arrayidx14 = getelementptr inbounds i32, i32 addrspace(1)* %offsets, i64 %idxprom13
+  %8 = load i32, i32 addrspace(1)* %arrayidx14, align 4
+  %mul15 = mul i32 3, %8
+  %idx.ext16 = zext i32 %mul15 to i64
+  %add.ptr17 = getelementptr inbounds i16, i16 addrspace(1)* %7, i64 %idx.ext16
+  %idx.ext18 = zext i32 %alignmentOffset to i64
+  %add.ptr19 = getelementptr inbounds i16, i16 addrspace(1)* %add.ptr17, i64 %idx.ext18
+  br label %for.cond
+
+for.cond:                                         ; preds = %for.inc, %entry
+  %i.0 = phi i32 [ 0, %entry ], [ %inc, %for.inc ]
+  %cmp = icmp ult i32 %i.0, 3
+  br i1 %cmp, label %for.body, label %for.end
+
+for.body:                                         ; preds = %for.cond
+  %idxprom21 = zext i32 %i.0 to i64
+  %arrayidx22 = getelementptr inbounds i16, i16* %add.ptr12, i64 %idxprom21
+  %9 = load i16, i16* %arrayidx22, align 2
+  %idxprom23 = zext i32 %i.0 to i64
+  %arrayidx24 = getelementptr inbounds i16, i16 addrspace(1)* %add.ptr19, i64 %idxprom23
+  store i16 %9, i16 addrspace(1)* %arrayidx24, align 2
+  br label %for.inc
+
+for.inc:                                          ; preds = %for.body
+  %inc = add i32 %i.0, 1
+  br label %for.cond
+
+for.end:                                          ; preds = %for.cond
+  %10 = bitcast [42 x <3 x i16>]* %sPrivateStorage to i8*
+  %11 = bitcast i8* %10 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 336, i8* %11)
+  ret void
+}
+
+; Function Attrs: argmemonly nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
+
+; Function Attrs: nounwind
+declare spir_func <3 x i16> @OpenCL_vload3_i64_p1i16_i32(i64, i16 addrspace(1)*, i32) #0
+
+; Function Attrs: nounwind
+declare spir_func void @OpenCL_vstore3_v3i16_i64_p0i16(<3 x i16>, i64, i16*) #0
+
+; Function Attrs: argmemonly nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
+
+; Function Attrs: nounwind readnone
+declare spir_func <3 x i64> @BuiltInGlobalInvocationId() #2
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind willreturn }
+attributes #2 = { nounwind readnone }
+
+!opencl.kernels = !{!0}
+!opencl.spir.version = !{!166}
+!opencl.ocl.version = !{!166}
+
+!0 = !{void (i16 addrspace(1)*, i32 addrspace(1)*, <3 x i16> addrspace(1)*, i32)* @test_fn, !1, !2, !3, !4, !5, !6}
+!1 = !{!"kernel_arg_addr_space", i32 1, i32 1, i32 1, i32 0}
+!2 = !{!"kernel_arg_access_qual", !"none", !"none", !"none", !"none"}
+!3 = !{!"kernel_arg_type", !"short*", !"uint*", !"short3*", !"uint"}
+!4 = !{!"kernel_arg_type_qual", !"", !"", !"", !""}
+!5 = !{!"kernel_arg_base_type", !"short*", !"int*", !"short3*", !"int"}
+!6 = !{!"kernel_arg_name", !"srcValues", !"offsets", !"destBuffer", !"alignmentOffset"}
+!166 = !{i32 3, i32 0}


### PR DESCRIPTION
The change fixes StoreInst conversion to spv_store intrinsic and some other issues. One LIT test (instructions/nested-composites.ll) passed, improvements in CTS are also expected.