### PR TITLE
[SPIR-V] support opencl.clk_event_t and related builtins

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -887,6 +887,8 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateOpenCLOpaqueType(
       return getOrCreateOpTypeImage(MIRBuilder, VoidTy, Dim, 0, Arrayed, 0, 0,
                                     ImageFormat::Unknown, AccessQual);
     }
+  } else if (TypeName.startswith("clk_event_t")) {
+    return getOpTypeByOpcode(MIRBuilder, SPIRV::OpTypeDeviceEvent);
   } else if (TypeName.startswith("sampler_t")) {
     return getOrCreateOpTypeSampler(MIRBuilder);
   } else if (TypeName.startswith("pipe")) {
@@ -960,7 +962,7 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateSPIRVOpaqueType(
     const StructType *Ty, MachineIRBuilder &MIRBuilder,
     AQ::AccessQualifier AccessQual) {
   const StringRef Name = Ty->getName();
-  assert(Name.startswith("spirv.") && "CL types should start with 'opencl.'");
+  assert(Name.startswith("spirv.") && "CL types should start with 'spirv.'");
   auto TypeName = Name.substr(strlen("spirv."));
 
   if (TypeName.startswith("Image.")) {

--- a/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
+++ b/llvm/lib/Target/SPIRV/SPIRVInstrInfo.td
@@ -687,6 +687,18 @@ def OpGroupUMax: OpGroup<"UMax", 270>;
 def OpGroupSMax: OpGroup<"SMax", 271>;
 
 // TODO: 3.42.22. Device-Side Enqueue Instructions
+def OpRetainEvent: Op<297, (outs), (ins ID:$event), "OpRetainEvent $event">;
+def OpReleaseEvent: Op<298, (outs), (ins ID:$event), "OpReleaseEvent $event">;
+def OpCreateUserEvent: Op<299, (outs ID:$res), (ins TYPE:$type),
+                  "$res = OpCreateUserEvent $type">;
+def OpIsValidEvent: Op<300, (outs ID:$res), (ins TYPE:$type, ID:$event),
+                  "$res = OpIsValidEvent $type $event ">;
+def OpSetUserEventStatus: Op<301, (outs), (ins ID:$event, ID:$status),
+                  "OpSetUserEventStatus $event $status">;
+def OpCaptureEventProfilingInfo: Op<302, (outs),
+                  (ins ID:$event, ID:$info, ID:$value),
+                  "OpCaptureEventProfilingInfo $event $info $value">;
+
 // TODO: 3.42.23. Pipe Instructions
 
 // 3.42.24. Non-Uniform Instructions

--- a/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVOpenCLBIFs.cpp
@@ -89,6 +89,13 @@ static StringMap<unsigned> OpenCLBIToOperationMap({
 #define _SPIRV_OP(x, y) {#x, SPIRV::Op##y},
   _SPIRV_OP(__spirv_Select, SelectSISCond)
   _SPIRV_OP(__spirv_SpecConstant, SpecConstant)
+  // CL 2.0 kernel enqueue builtins
+  _SPIRV_OP(retain_event, RetainEvent)
+  _SPIRV_OP(release_event, ReleaseEvent)
+  _SPIRV_OP(create_user_event, CreateUserEvent)
+  _SPIRV_OP(is_valid_event, IsValidEvent)
+  _SPIRV_OP(set_user_event_status, SetUserEventStatus)
+  _SPIRV_OP(capture_event_profiling_info, CaptureEventProfilingInfo)
   // CL 2.0 workgroup builtins
   _SPIRV_OP(group_all, GroupAll)
   _SPIRV_OP(group_any, GroupAny)
@@ -1447,6 +1454,20 @@ bool llvm::generateOpenCLBuiltinCall(const StringRef demangledName,
     return MIRBuilder.buildSelect(OrigRet, args[0], args[1], args[2]);
   case OpSpecConstant:
     return buildSpecConstant(MIRBuilder, opcode, OrigRet, retTy, args, GR);
+  case OpRetainEvent:
+  case OpReleaseEvent:
+    return MIRBuilder.buildInstr(opcode).addUse(args[0]);
+  case OpCreateUserEvent:
+    return MIRBuilder.buildInstr(opcode).addDef(OrigRet)
+        .addUse(GR->getSPIRVTypeID(retTy));
+  case OpIsValidEvent:
+    return MIRBuilder.buildInstr(opcode).addDef(OrigRet)
+        .addUse(GR->getSPIRVTypeID(retTy)).addUse(args[0]);
+  case OpSetUserEventStatus:
+    return MIRBuilder.buildInstr(opcode).addUse(args[0]).addUse(args[1]);
+  case OpCaptureEventProfilingInfo:
+    return MIRBuilder.buildInstr(opcode).addUse(args[0]).addUse(args[1])
+        .addUse(args[2]);
   case OpGroupAll:
   case OpGroupAny:
   case OpGroupBroadcast:


### PR DESCRIPTION
The change adds support of opencl.clk_event_t builtin type and several related builtin functions (retain_event, release_event, create_user_event, is_valid_event, set_user_event_status, capture_event_profiling_info). Also it adds some of missed Device-Side Enqueue Instructions (3.42.22). One LIT test (transcoding/clk_event_t.ll) is passed.