### PR TITLE
[SPIR-V] correct cmpxchg support

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -28,4 +28,5 @@ let TargetPrefix = "spv" in {
   def int_spv_const_composite : Intrinsic<[llvm_i32_ty], [llvm_vararg_ty]>;
   def int_spv_bitcast : Intrinsic<[llvm_any_ty], [llvm_any_ty]>;
   def int_spv_switch : Intrinsic<[], [llvm_any_ty, llvm_vararg_ty]>;
+  def int_spv_cmpxchg : Intrinsic<[llvm_i32_ty], [llvm_any_ty, llvm_vararg_ty]>;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -252,6 +252,8 @@ public:
                                 unsigned FilerMode,
                                 MachineIRBuilder &MIRBuilder,
                                 SPIRVType *SpvType);
+  Register getOrCreateUndef(MachineInstr &I, SPIRVType *SpvType,
+                            const SPIRVInstrInfo &TII);
   Register
   buildGlobalVariable(Register Reg, SPIRVType *BaseType, StringRef Name,
                       const GlobalValue *GV, StorageClass::StorageClass Storage,
@@ -265,6 +267,8 @@ public:
   SPIRVType *getOrCreateSPIRVIntegerType(unsigned BitWidth, MachineInstr &I,
                                          const SPIRVInstrInfo &TII);
   SPIRVType *getOrCreateSPIRVBoolType(MachineIRBuilder &MIRBuilder);
+  SPIRVType *getOrCreateSPIRVBoolType(MachineInstr &I,
+                                      const SPIRVInstrInfo &TII);
   SPIRVType *getOrCreateSPIRVVectorType(SPIRVType *BaseType,
                                         unsigned NumElements,
                                         MachineIRBuilder &MIRBuilder);

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -189,6 +189,23 @@ getMemSemanticsForStorageClass(StorageClass::StorageClass sc) {
   }
 }
 
+MemorySemantics::MemorySemantics getMemSemantics(AtomicOrdering Ord) {
+  switch (Ord) {
+  case AtomicOrdering::Acquire:
+    return MemorySemantics::Acquire;
+  case AtomicOrdering::Release:
+    return MemorySemantics::Release;
+  case AtomicOrdering::AcquireRelease:
+    return MemorySemantics::AcquireRelease;
+  case AtomicOrdering::SequentiallyConsistent:
+    return MemorySemantics::SequentiallyConsistent;
+  case AtomicOrdering::Unordered:
+  case AtomicOrdering::Monotonic:
+  case AtomicOrdering::NotAtomic:
+    return MemorySemantics::None;
+  }
+}
+
 bool constrainRegOperands(MachineInstrBuilder &MIB, MachineFunction *MF) {
   if (!MF)
     MF = MIB->getMF();

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -74,6 +74,8 @@ bool constrainRegOperands(llvm::MachineInstrBuilder &MIB,
 MemorySemantics::MemorySemantics
 getMemSemanticsForStorageClass(StorageClass::StorageClass sc);
 
+MemorySemantics::MemorySemantics getMemSemantics(llvm::AtomicOrdering Ord);
+
 // Find def instruction for the given ConstReg, walking through
 // spv_track_constant and ASSIGN_TYPE instructions. Updates ConstReg by def
 // of OpConstant instruction.


### PR DESCRIPTION
The change corrects cmpxchg support. One LIT test (AtomicCompareExchange.ll) is passed