### PR TITLE
[SPIR-V] fix small issues and tests

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -881,15 +881,18 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateOpenCLOpaqueType(
                  : DimC == '2' ? Dim::DIM_2D
                                : Dim::DIM_3D;
       unsigned Arrayed = 0;
+      unsigned Depth = 0;
       if (TypeName.contains("buffer"))
         Dim = Dim::DIM_Buffer;
       if (TypeName.contains("array"))
         Arrayed = 1;
+      if (TypeName.contains("depth"))
+        Depth = 1;
       auto *VoidTy = getOrCreateSPIRVType(
           Type::getVoidTy(MIRBuilder.getMF().getFunction().getContext()),
           MIRBuilder);
-      return getOrCreateOpTypeImage(MIRBuilder, VoidTy, Dim, 0, Arrayed, 0, 0,
-                                    ImageFormat::Unknown, AccessQual);
+      return getOrCreateOpTypeImage(MIRBuilder, VoidTy, Dim, Depth, Arrayed, 0,
+                                    0, ImageFormat::Unknown, AccessQual);
     }
   } else if (TypeName.startswith("clk_event_t")) {
     return getOpTypeByOpcode(MIRBuilder, SPIRV::OpTypeDeviceEvent);

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -458,6 +458,7 @@ bool SPIRVInstructionSelector::spvSelect(Register ResVReg,
     Register GV = I.getOperand(1).getReg();
     MachineRegisterInfo::def_instr_iterator II = MRI->def_instr_begin(GV);
     assert(((*II).getOpcode() == TargetOpcode::G_GLOBAL_VALUE ||
+            (*II).getOpcode() == TargetOpcode::COPY ||
             (*II).getOpcode() == SPIRV::OpVariable) &&
            isImm(I.getOperand(2), MRI));
     Register Idx = buildZerosVal(GR.getOrCreateSPIRVIntegerType(32, I, TII), I);
@@ -699,7 +700,7 @@ bool SPIRVInstructionSelector::selectMemOperation(Register ResVReg,
                                                   MachineInstr &I) const {
   MachineBasicBlock &BB = *I.getParent();
   auto MIB = BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpCopyMemorySized))
-                 .addDef(I.getOperand(0).getReg())
+                 .addUse(I.getOperand(0).getReg())
                  .addUse(I.getOperand(1).getReg())
                  .addUse(I.getOperand(2).getReg());
   if (I.getNumMemOperands())

--- a/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
@@ -171,6 +171,7 @@ static SPIRVType *propagateSPIRVType(MachineInstr *MI, SPIRVGlobalRegistry *GR,
       }
       case TargetOpcode::G_TRUNC:
       case TargetOpcode::G_ADDRSPACE_CAST:
+      case TargetOpcode::G_PTR_ADD:
       case TargetOpcode::COPY: {
         MachineOperand &Op = MI->getOperand(1);
         MachineInstr *Def = Op.isReg() ? MRI.getVRegDef(Op.getReg()) : nullptr;

--- a/llvm/test/CodeGen/SPIRV/transcoding/OpenCL/barrier.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/OpenCL/barrier.ll
@@ -38,11 +38,10 @@ target triple = "spirv32-unknown-unknown"
 ; memory order for OpControlBarrier and therefore, constants below include a
 ; bit more information than original source
 ;
-; 0x2 Workgroup
-; CHECK-SPIRV-DAG: %[[WG:[0-9]+]] = OpConstant %[[UINT]] 2
-;
 ; 0x10 SequentiallyConsistent + 0x100 WorkgroupMemory
-; CHECK-SPIRV-DAG: %[[LOCAL:[0-9]+]] = OpConstant %[[UINT]] 272
+; CHECK-SPIRV: %[[LOCAL:[0-9]+]] = OpConstant %[[UINT]] 272
+; 0x2 Workgroup
+; CHECK-SPIRV: %[[WG:[0-9]+]] = OpConstant %[[UINT]] 2
 ; 0x10 SequentiallyConsistent + 0x200 CrossWorkgroupMemory
 ; CHECK-SPIRV-DAG: %[[GLOBAL:[0-9]+]] = OpConstant %[[UINT]] 528
 ; 0x10 SequentiallyConsistent + 0x800 ImageMemory

--- a/llvm/test/CodeGen/SPIRV/transcoding/RelationalOperatorsFUnord.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/RelationalOperatorsFUnord.ll
@@ -6,20 +6,22 @@
 target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spirv32-unknown-unknown"
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV-NEXT: %[[A:[0-9]+]] = OpFunctionParameter %{{[0-9]+}}
 ; CHECK-SPIRV-NEXT: %[[B:[0-9]+]] = OpFunctionParameter %{{[0-9]+}}
 ; CHECK-SPIRV: %{{[0-9]+}} = OpFUnordEqual %[[bool2]] %[[A]] %[[B]]
 ; CHECK-SPIRV: OpFunctionEnd
 
+@var = addrspace(1) global <2 x i1> zeroinitializer
 ; Function Attrs: nounwind
 define spir_kernel void @testFUnordEqual(<2 x float> %a, <2 x float> %b) #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !3 !kernel_arg_type !4 !kernel_arg_type_qual !5 !kernel_arg_base_type !4 {
 entry:
   %0 = fcmp ueq <2 x float> %a, %b
+  store <2 x i1> %0, <2 x i1> addrspace(1)* @var
   ret void
 }
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV-NEXT: %[[A:[0-9]+]] = OpFunctionParameter %{{[0-9]+}}
 ; CHECK-SPIRV-NEXT: %[[B:[0-9]+]] = OpFunctionParameter %{{[0-9]+}}
 ; CHECK-SPIRV: %{{[0-9]+}} = OpFUnordGreaterThan %[[bool2]] %[[A]] %[[B]]
@@ -29,10 +31,11 @@ entry:
 define spir_kernel void @testFUnordGreaterThan(<2 x float> %a, <2 x float> %b) #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !3 !kernel_arg_type !4 !kernel_arg_type_qual !5 !kernel_arg_base_type !4 {
 entry:
   %0 = fcmp ugt <2 x float> %a, %b
+  store <2 x i1> %0, <2 x i1> addrspace(1)* @var
   ret void
 }
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV-NEXT: %[[A:[0-9]+]] = OpFunctionParameter %{{[0-9]+}}
 ; CHECK-SPIRV-NEXT: %[[B:[0-9]+]] = OpFunctionParameter %{{[0-9]+}}
 ; CHECK-SPIRV: %{{[0-9]+}} = OpFUnordGreaterThanEqual %[[bool2]] %[[A]] %[[B]]
@@ -42,10 +45,11 @@ entry:
 define spir_kernel void @testFUnordGreaterThanEqual(<2 x float> %a, <2 x float> %b) #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !3 !kernel_arg_type !4 !kernel_arg_type_qual !5 !kernel_arg_base_type !4 {
 entry:
   %0 = fcmp uge <2 x float> %a, %b
+  store <2 x i1> %0, <2 x i1> addrspace(1)* @var
   ret void
 }
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV-NEXT: %[[A:[0-9]+]] = OpFunctionParameter %{{[0-9]+}}
 ; CHECK-SPIRV-NEXT: %[[B:[0-9]+]] = OpFunctionParameter %{{[0-9]+}}
 ; CHECK-SPIRV: %{{[0-9]+}} = OpFUnordLessThan %[[bool2]] %[[A]] %[[B]]
@@ -55,10 +59,11 @@ entry:
 define spir_kernel void @testFUnordLessThan(<2 x float> %a, <2 x float> %b) #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !3 !kernel_arg_type !4 !kernel_arg_type_qual !5 !kernel_arg_base_type !4 {
 entry:
   %0 = fcmp ult <2 x float> %a, %b
+  store <2 x i1> %0, <2 x i1> addrspace(1)* @var
   ret void
 }
 
-; CHECK-SPIRV-LABEL: OpFunction
+; CHECK-SPIRV: OpFunction
 ; CHECK-SPIRV-NEXT: %[[A:[0-9]+]] = OpFunctionParameter %{{[0-9]+}}
 ; CHECK-SPIRV-NEXT: %[[B:[0-9]+]] = OpFunctionParameter %{{[0-9]+}}
 ; CHECK-SPIRV: %{{[0-9]+}} = OpFUnordLessThanEqual %[[bool2]] %[[A]] %[[B]]
@@ -68,6 +73,7 @@ entry:
 define spir_kernel void @testFUnordLessThanEqual(<2 x float> %a, <2 x float> %b) #0 !kernel_arg_addr_space !2 !kernel_arg_access_qual !3 !kernel_arg_type !4 !kernel_arg_type_qual !5 !kernel_arg_base_type !4 {
 entry:
   %0 = fcmp ule <2 x float> %a, %b
+  store <2 x i1> %0, <2 x i1> addrspace(1)* @var
   ret void
 }
 

--- a/llvm/test/CodeGen/SPIRV/transcoding/spirv-private-array-initialization.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/spirv-private-array-initialization.ll
@@ -5,15 +5,15 @@
 ; CHECK-SPIRV-DAG: %[[one:[0-9]+]] = OpConstant %[[i32]] 1
 ; CHECK-SPIRV-DAG: %[[two:[0-9]+]] = OpConstant %[[i32]] 2
 ; CHECK-SPIRV-DAG: %[[three:[0-9]+]] = OpConstant %[[i32]] 3
-; CHECK-SPIRV-DAG: %[[twelve:[0-9]+]] = OpConstant %[[i32]] 12
 ; CHECK-SPIRV-DAG: %[[i32x3:[0-9]+]] = OpTypeArray %[[i32]] %[[three]]
 ; CHECK-SPIRV-DAG: %[[i32x3_ptr:[0-9]+]] = OpTypePointer Function %[[i32x3]]
 ; CHECK-SPIRV-DAG: %[[const_i32x3_ptr:[0-9]+]] = OpTypePointer UniformConstant %[[i32x3]]
 ; CHECK-SPIRV-DAG: %[[i8_ptr:[0-9]+]] = OpTypePointer Function %[[i8]]
 ; CHECK-SPIRV-DAG: %[[const_i8_ptr:[0-9]+]] = OpTypePointer UniformConstant %[[i8]]
 ; CHECK-SPIRV: %[[test_arr_init:[0-9]+]] = OpConstantComposite %[[i32x3]] %[[one]] %[[two]] %[[three]]
-; CHECK-SPIRV: %[[test_arr:[0-9]+]] = OpVariable %[[const_i32x3_ptr]] UniformConstant %[[test_arr_init]]
+; CHECK-SPIRV: %[[twelve:[0-9]+]] = OpConstant %[[i32]] 12
 ; CHECK-SPIRV: %[[test_arr2:[0-9]+]] = OpVariable %[[const_i32x3_ptr]] UniformConstant %[[test_arr_init]]
+; CHECK-SPIRV: %[[test_arr:[0-9]+]] = OpVariable %[[const_i32x3_ptr]] UniformConstant %[[test_arr_init]]
 ;
 ; CHECK-SPIRV: %[[arr:[0-9]+]] = OpVariable %[[i32x3_ptr]] Function
 ; CHECK-SPIRV: %[[arr2:[0-9]+]] = OpVariable %[[i32x3_ptr]] Function


### PR DESCRIPTION
The change fixes several small issues and 3 tests. As a result 4 LIT tests passed (transcoding/OpImageWrite.ll, transcoding/OpenCL/barrier.ll, transcoding/RelationalOperatorsFUnord.ll, transcoding/spirv-private-array-initialization.ll).