### PR TITLE
[SPIR-V] support __spirv_SpecConstantComposite, fix errors

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -136,13 +136,14 @@ void SPIRVEmitIntrinsics::replaceMemInstrUses(Instruction *Old,
                                               Instruction *New) {
   while (!Old->user_empty()) {
     auto *U = Old->user_back();
-    if (isMemInstrToReplace(U) || isa<ReturnInst>(U)) {
-      U->replaceUsesOfWith(Old, New);
-    } else if (isAssignTypeInstr(U)) {
+    if (isAssignTypeInstr(U)) {
       IRB->SetInsertPoint(U);
       SmallVector<Value *, 2> Args = {New, U->getOperand(1)};
       IRB->CreateIntrinsic(Intrinsic::spv_assign_type, {New->getType()}, Args);
       U->eraseFromParent();
+    } else if (isMemInstrToReplace(U) || isa<ReturnInst>(U) ||
+               isa<CallInst>(U)) {
+      U->replaceUsesOfWith(Old, New);
     } else {
       llvm_unreachable("illegal aggregate intrinsic user");
     }

--- a/llvm/lib/Target/SPIRV/SPIRVPreTranslationLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreTranslationLegalizer.cpp
@@ -106,12 +106,7 @@ Function *SPIRVPreTranslationLegalizer::processFunctionSignature(Function *F) {
   auto *ThisFuncMD = MDNode::get(B.getContext(), MDArgs);
   FuncMD->addOperand(ThisFuncMD);
 
-  // Make a list of all uses, then modify the instructions, otherwise the uses
-  // may be corrupted by modifications.
-  SmallVector<User *, 4> AllUses;
-  for (auto *U : F->users())
-    AllUses.push_back(U);
-  for (auto *U : AllUses) {
+  for (auto *U : make_early_inc_range(F->users())) {
     if (auto *CI = dyn_cast<CallInst>(U))
       CI->mutateFunctionType(NewF->getFunctionType());
     U->replaceUsesOfWith(F, NewF);

--- a/llvm/lib/Target/SPIRV/SPIRVPreTranslationLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreTranslationLegalizer.cpp
@@ -53,8 +53,7 @@ char SPIRVPreTranslationLegalizer::ID = 0;
 INITIALIZE_PASS(SPIRVPreTranslationLegalizer, "pre-gisel-legalizer",
                 "SPIRV Pre-GISel Legalizer", false, false)
 
-Function *
-SPIRVPreTranslationLegalizer::processFunctionSignature(Function *F) {
+Function *SPIRVPreTranslationLegalizer::processFunctionSignature(Function *F) {
   IRBuilder<> B(F->getContext());
 
   bool IsRetAggr = F->getReturnType()->isAggregateType();
@@ -71,7 +70,7 @@ SPIRVPreTranslationLegalizer::processFunctionSignature(Function *F) {
     ChangedTypes.push_back(std::pair<int, Type *>(-1, F->getReturnType()));
   SmallVector<Type *, 4> ArgTypes;
   for (const auto &Arg : F->args()) {
-    if (Arg.getType()->isAggregateType() || Arg.getType()->isVectorTy()) {
+    if (Arg.getType()->isAggregateType()) {
       ArgTypes.push_back(B.getInt32Ty());
       ChangedTypes.push_back(
           std::pair<int, Type *>(Arg.getArgNo(), Arg.getType()));
@@ -107,12 +106,16 @@ SPIRVPreTranslationLegalizer::processFunctionSignature(Function *F) {
   auto *ThisFuncMD = MDNode::get(B.getContext(), MDArgs);
   FuncMD->addOperand(ThisFuncMD);
 
-  for (auto *U : F->users()) {
+  // Make a list of all uses, then modify the instructions, otherwise the uses
+  // may be corrupted by modifications.
+  SmallVector<User *, 4> AllUses;
+  for (auto *U : F->users())
+    AllUses.push_back(U);
+  for (auto *U : AllUses) {
     if (auto *CI = dyn_cast<CallInst>(U))
       CI->mutateFunctionType(NewF->getFunctionType());
     U->replaceUsesOfWith(F, NewF);
   }
-
   return NewF;
 }
 
@@ -139,7 +142,6 @@ bool SPIRVPreTranslationLegalizer::runOnModule(Module &M) {
   return Changed;
 }
 
-ModulePass *
-llvm::createSPIRVPreTranslationLegalizerPass() {
+ModulePass *llvm::createSPIRVPreTranslationLegalizerPass() {
   return new SPIRVPreTranslationLegalizer();
 }

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -18,6 +18,7 @@
 #include "llvm/CodeGen/GlobalISel/MachineIRBuilder.h"
 #include "llvm/CodeGen/MachineInstr.h"
 #include "llvm/CodeGen/MachineInstrBuilder.h"
+#include "llvm/Demangle/Demangle.h"
 #include "llvm/IR/IntrinsicsSPIRV.h"
 
 using namespace llvm;
@@ -244,4 +245,96 @@ bool isSpvIntrinsic(MachineInstr &MI, Intrinsic::ID IntrinsicID) {
 
 Type *getMDOperandAsType(const MDNode *N, unsigned I) {
   return cast<ValueAsMetadata>(N->getOperand(I))->getType();
+}
+
+// The set of names is borrowed from the SPIR-V translator.
+// TODO: may be implemented in SPIRVBuiltins.td.
+static bool isPipeOrAddressSpaceCastBI(const StringRef MangledName) {
+  return MangledName == "write_pipe_2" || MangledName == "read_pipe_2" ||
+         MangledName == "write_pipe_2_bl" || MangledName == "read_pipe_2_bl" ||
+         MangledName == "write_pipe_4" || MangledName == "read_pipe_4" ||
+         MangledName == "reserve_write_pipe" ||
+         MangledName == "reserve_read_pipe" ||
+         MangledName == "commit_write_pipe" ||
+         MangledName == "commit_read_pipe" ||
+         MangledName == "work_group_reserve_write_pipe" ||
+         MangledName == "work_group_reserve_read_pipe" ||
+         MangledName == "work_group_commit_write_pipe" ||
+         MangledName == "work_group_commit_read_pipe" ||
+         MangledName == "get_pipe_num_packets_ro" ||
+         MangledName == "get_pipe_max_packets_ro" ||
+         MangledName == "get_pipe_num_packets_wo" ||
+         MangledName == "get_pipe_max_packets_wo" ||
+         MangledName == "sub_group_reserve_write_pipe" ||
+         MangledName == "sub_group_reserve_read_pipe" ||
+         MangledName == "sub_group_commit_write_pipe" ||
+         MangledName == "sub_group_commit_read_pipe" ||
+         MangledName == "to_global" || MangledName == "to_local" ||
+         MangledName == "to_private";
+}
+
+static bool isEnqueueKernelBI(const StringRef MangledName) {
+  return MangledName == "__enqueue_kernel_basic" ||
+         MangledName == "__enqueue_kernel_basic_events" ||
+         MangledName == "__enqueue_kernel_varargs" ||
+         MangledName == "__enqueue_kernel_events_varargs";
+}
+
+static bool isKernelQueryBI(const StringRef MangledName) {
+  return MangledName == "__get_kernel_work_group_size_impl" ||
+         MangledName == "__get_kernel_sub_group_count_for_ndrange_impl" ||
+         MangledName == "__get_kernel_max_sub_group_size_for_ndrange_impl" ||
+         MangledName == "__get_kernel_preferred_work_group_size_multiple_impl";
+}
+
+static bool isNonMangledOCLBuiltin(StringRef Name) {
+  if (!Name.startswith("__"))
+    return false;
+
+  return isEnqueueKernelBI(Name) || isKernelQueryBI(Name) ||
+         isPipeOrAddressSpaceCastBI(Name.drop_front(2)) ||
+         Name == "__translate_sampler_initializer";
+}
+
+std::string isOclOrSpirvBuiltin(StringRef Name) {
+  bool IsNonMangledOCL = isNonMangledOCLBuiltin(Name);
+  bool IsNonMangledSPIRV = Name.startswith("__spirv_");
+  bool IsMangled = Name.startswith("_Z");
+
+  if (!IsNonMangledOCL && !IsNonMangledSPIRV && !IsMangled)
+    return std::string();
+
+  // Try to use the itanium demangler.
+  size_t n;
+  int Status;
+  char *DemangledName = itaniumDemangle(Name.data(), nullptr, &n, &Status);
+
+  if (Status == demangle_success) {
+    std::string Result = DemangledName;
+    free(DemangledName);
+    return Result;
+  }
+  free(DemangledName);
+  // Otherwise use simple demangling to return the function name.
+  if (IsNonMangledOCL || IsNonMangledSPIRV)
+    return Name.str();
+
+  // Autocheck C++, maybe need to do explicit check of the source language.
+  // OpenCL C++ built-ins are declared in cl namespace.
+  // TODO: consider using 'St' abbriviation for cl namespace mangling.
+  // Similar to ::std:: in C++.
+  size_t Start, Len = 0;
+  size_t DemangledNameLenStart = 2;
+  if (Name.startswith("_ZN")) {
+    // Skip CV and ref qualifiers.
+    size_t NameSpaceStart = Name.find_first_not_of("rVKRO", 3);
+    // All built-ins are in the ::cl:: namespace.
+    if (Name.substr(NameSpaceStart, 11) != "2cl7__spirv")
+      return std::string();
+    DemangledNameLenStart = NameSpaceStart + 11;
+  }
+  Start = Name.find_first_not_of("0123456789", DemangledNameLenStart);
+  Name.substr(DemangledNameLenStart, Start - DemangledNameLenStart)
+      .getAsInteger(10, Len);
+  return Name.substr(Start, Len).str();
 }

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -92,4 +92,8 @@ bool isSpvIntrinsic(llvm::MachineInstr &MI, llvm::Intrinsic::ID IntrinsicID);
 
 // Get type of i-th operand of the metadata node.
 llvm::Type *getMDOperandAsType(const llvm::MDNode *N, unsigned I);
+
+// Return a demangled name with arg type info by itaniumDemangle().
+// If the parser fails, return only function name.
+std::string isOclOrSpirvBuiltin(llvm::StringRef Name);
 #endif // LLVM_LIB_TARGET_SPIRV_SPIRVUTILS_H

--- a/llvm/test/CodeGen/SPIRV/instructions/call-complex-function.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/call-complex-function.ll
@@ -11,10 +11,10 @@ target triple = "spirv32-unknown-unknown"
 ; CHECK-DAG: [[I16:%.+]] = OpTypeInt 16
 ; CHECK-DAG: [[I32:%.+]] = OpTypeInt 32
 ; CHECK-DAG: [[I64:%.+]] = OpTypeInt 64
+; CHECK-DAG: [[FN3:%.+]] = OpTypeFunction [[I32]] [[I32]] [[I16]] [[I64]]
 ; CHECK-DAG: [[PAIR:%.+]] = OpTypeStruct [[I32]] [[I16]]
 ; CHECK-DAG: [[FN1:%.+]] = OpTypeFunction [[I32]] [[I32]]
 ; CHECK-DAG: [[FN2:%.+]] = OpTypeFunction [[I32]] [[PAIR]] [[I64]]
-; CHECK-DAG: [[FN3:%.+]] = OpTypeFunction [[I32]] [[I32]] [[I16]] [[I64]]
 ; According to the Specification, the OpUndef can be defined in Function.
 ; But the Specification also recommends defining it here. So we enforce that.
 ; CHECK-DAG: [[UNDEF:%.+]] = OpUndef [[PAIR]]
@@ -34,24 +34,6 @@ define i32 @foo({i32, i16} %in, i64 %unused) {
   ret i32 %bar
 }
 
-; CHECK: [[FOO]] = OpFunction [[I32]] None [[FN2]]
-; CHECK-NEXT: [[IN:%.+]] = OpFunctionParameter [[PAIR]]
-; CHECK-NEXT: OpFunctionParameter [[I64]]
-; CHECK: [[FIRST:%.+]] = OpCompositeExtract [[I32]] [[IN]] 0
-; CHECK: [[BAR:%.+]] = OpFunctionCall [[I32]] [[FUN]] [[FIRST]]
-; CHECK: OpReturnValue [[BAR]]
-; CHECK: OpFunctionEnd
-
-
-
-define i32 @goo(i32 %a, i16 %b, i64 %c) {
-  %agg1 = insertvalue {i32, i16} undef, i32 %a, 0
-  %agg2 = insertvalue {i32, i16} %agg1, i16 %b, 1
-  %ret = call i32 @foo({i32, i16} %agg2, i64 %c)
-  ret i32 %ret
-}
-
-
 ; CHECK: [[GOO]] = OpFunction [[I32]] None [[FN3]]
 ; CHECK-NEXT: [[A:%.+]] = OpFunctionParameter [[I32]]
 ; CHECK-NEXT: [[B:%.+]] = OpFunctionParameter [[I16]]
@@ -61,5 +43,20 @@ define i32 @goo(i32 %a, i16 %b, i64 %c) {
 ; CHECK: [[RET:%.+]] = OpFunctionCall [[I32]] [[FOO]] [[AGG2]] [[C]]
 ; CHECK: OpReturnValue [[RET]]
 ; CHECK: OpFunctionEnd
+
+; CHECK: [[FOO]] = OpFunction [[I32]] None [[FN2]]
+; CHECK-NEXT: [[IN:%.+]] = OpFunctionParameter [[PAIR]]
+; CHECK-NEXT: OpFunctionParameter [[I64]]
+; CHECK: [[FIRST:%.+]] = OpCompositeExtract [[I32]] [[IN]] 0
+; CHECK: [[BAR:%.+]] = OpFunctionCall [[I32]] [[FUN]] [[FIRST]]
+; CHECK: OpReturnValue [[BAR]]
+; CHECK: OpFunctionEnd
+
+define i32 @goo(i32 %a, i16 %b, i64 %c) {
+  %agg1 = insertvalue {i32, i16} undef, i32 %a, 0
+  %agg2 = insertvalue {i32, i16} %agg1, i16 %b, 1
+  %ret = call i32 @foo({i32, i16} %agg2, i64 %c)
+  ret i32 %ret
+}
 
 ; FIXME: test tailcall?


### PR DESCRIPTION
The change enables __spirv_SpecConstantComposite support, also it fixes several errors in SPIRVEmitIntrinsics.cpp and SPIRVPreTranslationLegalizer.cpp. Two LIT tests passed (transcoding/SpecConstantComposite.ll, instructions/call-complex-function.ll).