### PR TITLE
[SPIR-V] implement EntryPoint wrappers

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVAsmPrinter.cpp
@@ -425,9 +425,9 @@ void SPIRVAsmPrinter::outputExecutionMode(const Module &M) {
   }
   for (auto FI = M.begin(), E = M.end(); FI != E; ++FI) {
     const Function &F = *FI;
-    if (F.isDeclaration())
+    if (F.isDeclaration() || !isKernel(&F))
       continue;
-    Register FReg = MAI->getFuncReg(F.getGlobalIdentifier());
+    Register FReg = MAI->getFuncReg(F.getName().str());
     assert(FReg.isValid());
     if (MDNode *Node = F.getMetadata("reqd_work_group_size"))
       outputExecutionModeFromMDNode(FReg, Node, ExecutionMode::LocalSize);
@@ -462,7 +462,7 @@ void SPIRVAsmPrinter::outputAnnotations(const Module &M) {
         Register Reg;
         if (isa<Function>(AnnotatedVar)) {
           auto *Func = cast<Function>(AnnotatedVar);
-          Reg = MAI->getFuncReg(Func->getGlobalIdentifier());
+          Reg = MAI->getFuncReg(Func->getName().str());
         } else {
           llvm_unreachable("Unsupported value in llvm.global.annotations");
         }

--- a/llvm/lib/Target/SPIRV/SPIRVMCInstLower.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVMCInstLower.cpp
@@ -34,7 +34,7 @@ void SPIRVMCInstLower::lower(const MachineInstr *MI, MCInst &OutMI,
       MI->print(errs());
       llvm_unreachable("unknown operand type");
     case MachineOperand::MO_GlobalAddress: {
-      Register FuncReg = MAI->getFuncReg(MO.getGlobal()->getGlobalIdentifier());
+      Register FuncReg = MAI->getFuncReg(MO.getGlobal()->getName().str());
       assert(FuncReg.isValid() && "Cannot find function Id");
       MCOp = MCOperand::createReg(FuncReg);
       break;

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -271,7 +271,7 @@ void SPIRVModuleAnalysis::collectFuncNames(MachineInstr &MI,
     Register GlobalReg = MAI.getRegisterAlias(MI.getMF(), Reg);
     assert(GlobalReg.isValid());
     // TODO: check that it does not conflict with existing entries.
-    MAI.FuncNameMap[F.getGlobalIdentifier()] = GlobalReg;
+    MAI.FuncNameMap[F.getName()] = GlobalReg;
   }
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -338,3 +338,7 @@ std::string isOclOrSpirvBuiltin(StringRef Name) {
       .getAsInteger(10, Len);
   return Name.substr(Start, Len).str();
 }
+
+bool isKernel(const Function *F) {
+  return F->getCallingConv() == CallingConv::SPIR_KERNEL;
+}

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -96,4 +96,7 @@ llvm::Type *getMDOperandAsType(const llvm::MDNode *N, unsigned I);
 // Return a demangled name with arg type info by itaniumDemangle().
 // If the parser fails, return only function name.
 std::string isOclOrSpirvBuiltin(llvm::StringRef Name);
+
+// Check if it is a kernel function.
+bool isKernel(const llvm::Function *F);
 #endif // LLVM_LIB_TARGET_SPIRV_SPIRVUTILS_H

--- a/llvm/test/CodeGen/SPIRV/entry_point_func.ll
+++ b/llvm/test/CodeGen/SPIRV/entry_point_func.ll
@@ -15,4 +15,4 @@ define spir_kernel void @testfunction() {
 ; CHECK-SPIRV: OpDecorate %[[FUNC]] LinkageAttributes "testfunction" Export
 ; CHECK-SPIRV: %[[FUNC]] = OpFunction %2 None %3
 ; CHECK-SPIRV: %[[EP]] = OpFunction %2 None %3
-; CHECK-SPIRV: %8 = OpFunctionCall %2 %[[FUNC]]
+; CHECK-SPIRV: OpFunctionCall %2 %[[FUNC]]

--- a/llvm/test/CodeGen/SPIRV/opencl/basic/get_global_offset.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl/basic/get_global_offset.ll
@@ -2,9 +2,9 @@
 
 target triple = "spirv64-unknown-unknown"
 
-; CHECK: OpEntryPoint Kernel %[[test_func:[0-9]+]] "test"
+; CHECK: OpEntryPoint Kernel %[[test_func_wrap:[0-9]+]] "test"
 ; CHECK: OpName %[[outOffsets:[0-9]+]] "outOffsets"
-; CHECK: OpName %[[test_func]] "test"
+; CHECK: OpName %[[test_func:[0-9]+]] "test"
 ; CHECK: OpName %[[f2_decl:[0-9]+]] "BuiltInGlobalOffset"
 ; CHECK: OpDecorate %[[f2_decl]] LinkageAttributes "BuiltInGlobalOffset" Import
 ; CHECK: %[[int_ty:[0-9]+]] = OpTypeInt 32 0


### PR DESCRIPTION
The change creates EntryPoint wrappers as the translator does, also it corrects 2 tests. Three LIT tests (entry_point_func.ll, llvm-intrinsics/assume.ll, transcoding/BitReversePref.ll) should pass.