### PR TITLE
[SPIR-V] implement fsh* and umul.with.overflow intrinsics

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -14,9 +14,9 @@
 #include "SPIRVCallLowering.h"
 #include "MCTargetDesc/SPIRVBaseInfo.h"
 #include "SPIRV.h"
+#include "SPIRVBuiltins.h"
 #include "SPIRVGlobalRegistry.h"
 #include "SPIRVISelLowering.h"
-#include "SPIRVBuiltins.h"
 #include "SPIRVRegisterInfo.h"
 #include "SPIRVSubtarget.h"
 #include "SPIRVUtils.h"
@@ -273,7 +273,7 @@ bool SPIRVCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
       Info.OrigRet.Regs.empty() ? Register(0) : Info.OrigRet.Regs[0];
   std::string FuncName = Info.Callee.getGlobal()->getGlobalIdentifier();
   std::string DemangledName = isOclOrSpirvBuiltin(FuncName);
-  if (!DemangledName.empty()) {
+  if (!DemangledName.empty() && CF && CF->isDeclaration()) {
     // TODO: check that it's OCL builtin, then apply OpenCL_std.
     const auto *ST = static_cast<const SPIRVSubtarget *>(&MF.getSubtarget());
     if (ST->canUseExtInstSet(InstructionSet::OpenCL_std)) {

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/fshl.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/fshl.ll
@@ -7,18 +7,18 @@ target triple = "spirv64-unknown-unknown"
 ; CHECK-SPIRV: OpName %[[NAME_FSHL_FUNC_16:[0-9]+]] "spirv.llvm_fshl_i16"
 ; CHECK-SPIRV: OpName %[[NAME_FSHL_FUNC_VEC_INT_16:[0-9]+]] "spirv.llvm_fshl_v2i16"
 ; CHECK-SPIRV: %[[TYPE_INT_32:[0-9]+]] = OpTypeInt 32 0
-; CHECK-SPIRV: %[[TYPE_INT_16:[0-9]+]] = OpTypeInt 16 0
-; CHECK-SPIRV-DAG: %[[CONST_ROTATE_32:[0-9]+]] = OpConstant %[[TYPE_INT_32]] 8
-; CHECK-SPIRV-DAG: %[[CONST_ROTATE_16:[0-9]+]] = OpConstant %[[TYPE_INT_16]] 8
-; CHECK-SPIRV-DAG: %[[CONST_TYPE_SIZE_32:[0-9]+]] = OpConstant %[[TYPE_INT_32]] 32
 ; CHECK-SPIRV: %[[TYPE_ORIG_FUNC_32:[0-9]+]] = OpTypeFunction %[[TYPE_INT_32]] %[[TYPE_INT_32]] %[[TYPE_INT_32]]
-; CHECK-SPIRV: %[[TYPE_FSHL_FUNC_32:[0-9]+]] = OpTypeFunction %[[TYPE_INT_32]] %[[TYPE_INT_32]] %[[TYPE_INT_32]] %[[TYPE_INT_32]]
+; CHECK-SPIRV: %[[TYPE_INT_16:[0-9]+]] = OpTypeInt 16 0
 ; CHECK-SPIRV: %[[TYPE_ORIG_FUNC_16:[0-9]+]] = OpTypeFunction %[[TYPE_INT_16]] %[[TYPE_INT_16]] %[[TYPE_INT_16]]
-; CHECK-SPIRV: %[[TYPE_FSHL_FUNC_16:[0-9]+]] = OpTypeFunction %[[TYPE_INT_16]] %[[TYPE_INT_16]] %[[TYPE_INT_16]] %[[TYPE_INT_16]]
 ; CHECK-SPIRV: %[[TYPE_VEC_INT_16:[0-9]+]] = OpTypeVector %[[TYPE_INT_16]] 2
 ; CHECK-SPIRV: %[[TYPE_ORIG_FUNC_VEC_INT_16:[0-9]+]] = OpTypeFunction %[[TYPE_VEC_INT_16]] %[[TYPE_VEC_INT_16]] %[[TYPE_VEC_INT_16]]
+; CHECK-SPIRV: %[[TYPE_FSHL_FUNC_32:[0-9]+]] = OpTypeFunction %[[TYPE_INT_32]] %[[TYPE_INT_32]] %[[TYPE_INT_32]] %[[TYPE_INT_32]]
+; CHECK-SPIRV: %[[TYPE_FSHL_FUNC_16:[0-9]+]] = OpTypeFunction %[[TYPE_INT_16]] %[[TYPE_INT_16]] %[[TYPE_INT_16]] %[[TYPE_INT_16]]
 ; CHECK-SPIRV: %[[TYPE_FSHL_FUNC_VEC_INT_16:[0-9]+]] = OpTypeFunction %[[TYPE_VEC_INT_16]] %[[TYPE_VEC_INT_16]] %[[TYPE_VEC_INT_16]] %[[TYPE_VEC_INT_16]]
+; CHECK-SPIRV-DAG: %[[CONST_ROTATE_32:[0-9]+]] = OpConstant %[[TYPE_INT_32]] 8
+; CHECK-SPIRV-DAG: %[[CONST_ROTATE_16:[0-9]+]] = OpConstant %[[TYPE_INT_16]] 8
 ; CHECK-SPIRV: %[[CONST_ROTATE_VEC_INT_16:[0-9]+]] = OpConstantComposite %[[TYPE_VEC_INT_16]] %[[CONST_ROTATE_16]] %[[CONST_ROTATE_16]]
+; CHECK-SPIRV-DAG: %[[CONST_TYPE_SIZE_32:[0-9]+]] = OpConstant %[[TYPE_INT_32]] 32
 
 ; Function Attrs: nounwind readnone
 ; CHECK-SPIRV: %{{[0-9]+}} = OpFunction %[[TYPE_INT_32]] {{.*}} %[[TYPE_ORIG_FUNC_32]]
@@ -36,18 +36,6 @@ entry:
   ret i32 %sum
 }
 
-; CHECK-SPIRV: %[[NAME_FSHL_FUNC_32]] = OpFunction %[[TYPE_INT_32]] {{.*}} %[[TYPE_FSHL_FUNC_32]]
-; CHECK-SPIRV: %[[X_FSHL:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_32]]
-; CHECK-SPIRV: %[[Y_FSHL:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_32]]
-; CHECK-SPIRV: %[[ROT:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_32]]
-
-; CHECK-SPIRV: %[[ROTATE_MOD_SIZE:[0-9]+]] = OpUMod %[[TYPE_INT_32]] %[[ROT]] %[[CONST_TYPE_SIZE_32]]
-; CHECK-SPIRV: %[[X_SHIFT_LEFT:[0-9]+]] = OpShiftLeftLogical %[[TYPE_INT_32]] %[[X_FSHL]] %[[ROTATE_MOD_SIZE]]
-; CHECK-SPIRV: %[[NEG_ROTATE:[0-9]+]] = OpISub %[[TYPE_INT_32]] %[[CONST_TYPE_SIZE_32]] %[[ROTATE_MOD_SIZE]]
-; CHECK-SPIRV: %[[Y_SHIFT_RIGHT:[0-9]+]] = OpShiftRightLogical %[[TYPE_INT_32]] %[[Y_FSHL]] %[[NEG_ROTATE]]
-; CHECK-SPIRV: %[[FSHL_RESULT:[0-9]+]] = OpBitwiseOr %[[TYPE_INT_32]] %[[X_SHIFT_LEFT]] %[[Y_SHIFT_RIGHT]]
-; CHECK-SPIRV: OpReturnValue %[[FSHL_RESULT]]
-
 ; Function Attrs: nounwind readnone
 ; CHECK-SPIRV: %{{[0-9]+}} = OpFunction %[[TYPE_INT_16]] {{.*}} %[[TYPE_ORIG_FUNC_16]]
 ; CHECK-SPIRV: %[[X:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_16]]
@@ -60,12 +48,6 @@ entry:
   ret i16 %0
 }
 
-; Just check that the function for i16 was generated as such - we've checked the logic for another type.
-; CHECK-SPIRV: %[[NAME_FSHL_FUNC_16]] = OpFunction %[[TYPE_INT_16]] {{.*}} %[[TYPE_FSHL_FUNC_16]]
-; CHECK-SPIRV: %[[X_FSHL:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_16]]
-; CHECK-SPIRV: %[[Y_FSHL:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_16]]
-; CHECK-SPIRV: %[[ROT:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_16]]
-
 ; CHECK-SPIRV: %{{[0-9]+}} = OpFunction %[[TYPE_VEC_INT_16]] {{.*}} %[[TYPE_ORIG_FUNC_VEC_INT_16]]
 ; CHECK-SPIRV: %[[X:[0-9]+]] = OpFunctionParameter %[[TYPE_VEC_INT_16]]
 ; CHECK-SPIRV: %[[Y:[0-9]+]] = OpFunctionParameter %[[TYPE_VEC_INT_16]]
@@ -76,6 +58,24 @@ entry:
   ; CHECK-SPIRV: OpReturnValue %[[CALL_VEC_INT_16]]
   ret <2 x i16> %0
 }
+
+; CHECK-SPIRV: %[[NAME_FSHL_FUNC_32]] = OpFunction %[[TYPE_INT_32]] {{.*}} %[[TYPE_FSHL_FUNC_32]]
+; CHECK-SPIRV: %[[X_FSHL:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_32]]
+; CHECK-SPIRV: %[[Y_FSHL:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_32]]
+; CHECK-SPIRV: %[[ROT:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_32]]
+
+; CHECK-SPIRV: %[[ROTATE_MOD_SIZE:[0-9]+]] = OpUMod %[[TYPE_INT_32]] %[[ROT]] %[[CONST_TYPE_SIZE_32]]
+; CHECK-SPIRV: %[[X_SHIFT_LEFT:[0-9]+]] = OpShiftLeftLogical %[[TYPE_INT_32]] %[[X_FSHL]] %[[ROTATE_MOD_SIZE]]
+; CHECK-SPIRV: %[[NEG_ROTATE:[0-9]+]] = OpISub %[[TYPE_INT_32]] %[[CONST_TYPE_SIZE_32]] %[[ROTATE_MOD_SIZE]]
+; CHECK-SPIRV: %[[Y_SHIFT_RIGHT:[0-9]+]] = OpShiftRightLogical %[[TYPE_INT_32]] %[[Y_FSHL]] %[[NEG_ROTATE]]
+; CHECK-SPIRV: %[[FSHL_RESULT:[0-9]+]] = OpBitwiseOr %[[TYPE_INT_32]] %[[X_SHIFT_LEFT]] %[[Y_SHIFT_RIGHT]]
+; CHECK-SPIRV: OpReturnValue %[[FSHL_RESULT]]
+
+; Just check that the function for i16 was generated as such - we've checked the logic for another type.
+; CHECK-SPIRV: %[[NAME_FSHL_FUNC_16]] = OpFunction %[[TYPE_INT_16]] {{.*}} %[[TYPE_FSHL_FUNC_16]]
+; CHECK-SPIRV: %[[X_FSHL:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_16]]
+; CHECK-SPIRV: %[[Y_FSHL:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_16]]
+; CHECK-SPIRV: %[[ROT:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_16]]
 
 ; Just check that the function for v2i16 was generated as such - we've checked the logic for another type.
 ; CHECK-SPIRV: %[[NAME_FSHL_FUNC_VEC_INT_16]] = OpFunction %[[TYPE_VEC_INT_16]] {{.*}} %[[TYPE_FSHL_FUNC_VEC_INT_16]]

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/fshr.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/fshr.ll
@@ -7,18 +7,18 @@ target triple = "spirv64-unknown-unknown"
 ; CHECK-SPIRV: OpName %[[NAME_FSHR_FUNC_16:[0-9]+]] "spirv.llvm_fshr_i16"
 ; CHECK-SPIRV: OpName %[[NAME_FSHR_FUNC_VEC_INT_16:[0-9]+]] "spirv.llvm_fshr_v2i16"
 ; CHECK-SPIRV: %[[TYPE_INT_32:[0-9]+]] = OpTypeInt 32 0
-; CHECK-SPIRV: %[[TYPE_INT_16:[0-9]+]] = OpTypeInt 16 0
-; CHECK-SPIRV-DAG: %[[CONST_ROTATE_32:[0-9]+]] = OpConstant %[[TYPE_INT_32]] 8
-; CHECK-SPIRV-DAG: %[[CONST_ROTATE_16:[0-9]+]] = OpConstant %[[TYPE_INT_16]] 8
-; CHECK-SPIRV-DAG: %[[CONST_TYPE_SIZE_32:[0-9]+]] = OpConstant %[[TYPE_INT_32]] 32
 ; CHECK-SPIRV: %[[TYPE_ORIG_FUNC_32:[0-9]+]] = OpTypeFunction %[[TYPE_INT_32]] %[[TYPE_INT_32]] %[[TYPE_INT_32]]
-; CHECK-SPIRV: %[[TYPE_FSHR_FUNC_32:[0-9]+]] = OpTypeFunction %[[TYPE_INT_32]] %[[TYPE_INT_32]] %[[TYPE_INT_32]] %[[TYPE_INT_32]]
+; CHECK-SPIRV: %[[TYPE_INT_16:[0-9]+]] = OpTypeInt 16 0
 ; CHECK-SPIRV: %[[TYPE_ORIG_FUNC_16:[0-9]+]] = OpTypeFunction %[[TYPE_INT_16]] %[[TYPE_INT_16]] %[[TYPE_INT_16]]
-; CHECK-SPIRV: %[[TYPE_FSHR_FUNC_16:[0-9]+]] = OpTypeFunction %[[TYPE_INT_16]] %[[TYPE_INT_16]] %[[TYPE_INT_16]] %[[TYPE_INT_16]]
 ; CHECK-SPIRV: %[[TYPE_VEC_INT_16:[0-9]+]] = OpTypeVector %[[TYPE_INT_16]] 2
 ; CHECK-SPIRV: %[[TYPE_ORIG_FUNC_VEC_INT_16:[0-9]+]] = OpTypeFunction %[[TYPE_VEC_INT_16]] %[[TYPE_VEC_INT_16]] %[[TYPE_VEC_INT_16]]
+; CHECK-SPIRV: %[[TYPE_FSHR_FUNC_32:[0-9]+]] = OpTypeFunction %[[TYPE_INT_32]] %[[TYPE_INT_32]] %[[TYPE_INT_32]] %[[TYPE_INT_32]]
+; CHECK-SPIRV: %[[TYPE_FSHR_FUNC_16:[0-9]+]] = OpTypeFunction %[[TYPE_INT_16]] %[[TYPE_INT_16]] %[[TYPE_INT_16]] %[[TYPE_INT_16]]
 ; CHECK-SPIRV: %[[TYPE_FSHR_FUNC_VEC_INT_16:[0-9]+]] = OpTypeFunction %[[TYPE_VEC_INT_16]] %[[TYPE_VEC_INT_16]] %[[TYPE_VEC_INT_16]] %[[TYPE_VEC_INT_16]]
+; CHECK-SPIRV-DAG: %[[CONST_ROTATE_32:[0-9]+]] = OpConstant %[[TYPE_INT_32]] 8
+; CHECK-SPIRV-DAG: %[[CONST_ROTATE_16:[0-9]+]] = OpConstant %[[TYPE_INT_16]] 8
 ; CHECK-SPIRV: %[[CONST_ROTATE_VEC_INT_16:[0-9]+]] = OpConstantComposite %[[TYPE_VEC_INT_16]] %[[CONST_ROTATE_16]] %[[CONST_ROTATE_16]]
+; CHECK-SPIRV-DAG: %[[CONST_TYPE_SIZE_32:[0-9]+]] = OpConstant %[[TYPE_INT_32]] 32
 
 ; Function Attrs: nounwind readnone
 ; CHECK-SPIRV: %{{[0-9]+}} = OpFunction %[[TYPE_INT_32]] {{.*}} %[[TYPE_ORIG_FUNC_32]]
@@ -36,18 +36,6 @@ entry:
   ret i32 %sum
 }
 
-; CHECK-SPIRV: %[[NAME_FSHR_FUNC_32]] = OpFunction %[[TYPE_INT_32]] {{.*}} %[[TYPE_FSHR_FUNC_32]]
-; CHECK-SPIRV: %[[X_ARG:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_32]]
-; CHECK-SPIRV: %[[Y_ARG:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_32]]
-; CHECK-SPIRV: %[[ROT:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_32]]
-
-; CHECK-SPIRV: %[[ROTATE_MOD_SIZE:[0-9]+]] = OpUMod %[[TYPE_INT_32]] %[[ROT]] %[[CONST_TYPE_SIZE_32]]
-; CHECK-SPIRV: %[[Y_SHIFT_RIGHT:[0-9]+]] = OpShiftRightLogical %[[TYPE_INT_32]] %[[Y_ARG]] %[[ROTATE_MOD_SIZE]]
-; CHECK-SPIRV: %[[NEG_ROTATE:[0-9]+]] = OpISub %[[TYPE_INT_32]] %[[CONST_TYPE_SIZE_32]] %[[ROTATE_MOD_SIZE]]
-; CHECK-SPIRV: %[[X_SHIFT_LEFT:[0-9]+]] = OpShiftLeftLogical %[[TYPE_INT_32]] %[[X_ARG]] %[[NEG_ROTATE]]
-; CHECK-SPIRV: %[[FSHR_RESULT:[0-9]+]] = OpBitwiseOr %[[TYPE_INT_32]] %[[Y_SHIFT_RIGHT]] %[[X_SHIFT_LEFT]]
-; CHECK-SPIRV: OpReturnValue %[[FSHR_RESULT]]
-
 ; Function Attrs: nounwind readnone
 ; CHECK-SPIRV: %{{[0-9]+}} = OpFunction %[[TYPE_INT_16]] {{.*}} %[[TYPE_ORIG_FUNC_16]]
 ; CHECK-SPIRV: %[[X:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_16]]
@@ -60,12 +48,6 @@ entry:
   ret i16 %0
 }
 
-; Just check that the function for i16 was generated as such - we've checked the logic for another type.
-; CHECK-SPIRV: %[[NAME_FSHR_FUNC_16]] = OpFunction %[[TYPE_INT_16]] {{.*}} %[[TYPE_FSHR_FUNC_16]]
-; CHECK-SPIRV: %[[X_ARG:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_16]]
-; CHECK-SPIRV: %[[Y_ARG:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_16]]
-; CHECK-SPIRV: %[[ROT:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_16]]
-
 ; CHECK-SPIRV: %{{[0-9]+}} = OpFunction %[[TYPE_VEC_INT_16]] {{.*}} %[[TYPE_ORIG_FUNC_VEC_INT_16]]
 ; CHECK-SPIRV: %[[X:[0-9]+]] = OpFunctionParameter %[[TYPE_VEC_INT_16]]
 ; CHECK-SPIRV: %[[Y:[0-9]+]] = OpFunctionParameter %[[TYPE_VEC_INT_16]]
@@ -76,6 +58,24 @@ entry:
   ; CHECK-SPIRV: OpReturnValue %[[CALL_VEC_INT_16]]
   ret <2 x i16> %0
 }
+
+; CHECK-SPIRV: %[[NAME_FSHR_FUNC_32]] = OpFunction %[[TYPE_INT_32]] {{.*}} %[[TYPE_FSHR_FUNC_32]]
+; CHECK-SPIRV: %[[X_ARG:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_32]]
+; CHECK-SPIRV: %[[Y_ARG:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_32]]
+; CHECK-SPIRV: %[[ROT:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_32]]
+
+; CHECK-SPIRV: %[[ROTATE_MOD_SIZE:[0-9]+]] = OpUMod %[[TYPE_INT_32]] %[[ROT]] %[[CONST_TYPE_SIZE_32]]
+; CHECK-SPIRV: %[[Y_SHIFT_RIGHT:[0-9]+]] = OpShiftRightLogical %[[TYPE_INT_32]] %[[Y_ARG]] %[[ROTATE_MOD_SIZE]]
+; CHECK-SPIRV: %[[NEG_ROTATE:[0-9]+]] = OpISub %[[TYPE_INT_32]] %[[CONST_TYPE_SIZE_32]] %[[ROTATE_MOD_SIZE]]
+; CHECK-SPIRV: %[[X_SHIFT_LEFT:[0-9]+]] = OpShiftLeftLogical %[[TYPE_INT_32]] %[[X_ARG]] %[[NEG_ROTATE]]
+; CHECK-SPIRV: %[[FSHR_RESULT:[0-9]+]] = OpBitwiseOr %[[TYPE_INT_32]] %[[Y_SHIFT_RIGHT]] %[[X_SHIFT_LEFT]]
+; CHECK-SPIRV: OpReturnValue %[[FSHR_RESULT]]
+
+; Just check that the function for i16 was generated as such - we've checked the logic for another type.
+; CHECK-SPIRV: %[[NAME_FSHR_FUNC_16]] = OpFunction %[[TYPE_INT_16]] {{.*}} %[[TYPE_FSHR_FUNC_16]]
+; CHECK-SPIRV: %[[X_ARG:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_16]]
+; CHECK-SPIRV: %[[Y_ARG:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_16]]
+; CHECK-SPIRV: %[[ROT:[0-9]+]] = OpFunctionParameter %[[TYPE_INT_16]]
 
 ; Just check that the function for v2i16 was generated as such - we've checked the logic for another type.
 ; CHECK-SPIRV: %[[NAME_FSHR_FUNC_VEC_INT_16]] = OpFunction %[[TYPE_VEC_INT_16]] {{.*}} %[[TYPE_FSHR_FUNC_VEC_INT_16]]

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/umul.with.overflow.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/umul.with.overflow.ll
@@ -19,16 +19,6 @@ entry:
   ret void
 }
 
-; CHECK-SPIRV: %[[NAME_UMUL_FUNC_8]] = OpFunction %[[#]]
-; CHECK-SPIRV: %[[VAR_A:[0-9]+]] = OpFunctionParameter %[[#]]
-; CHECK-SPIRV: %[[VAR_B:[0-9]+]] = OpFunctionParameter %[[#]]
-; CHECK-SPIRV: %[[MUL_RES:[0-9]+]] = OpIMul %[[#]] %[[VAR_A]] %[[VAR_B]]
-; CHECK-SPIRV: %[[DIV_RES:[0-9]+]] = OpUDiv %[[#]] %[[MUL_RES]] %[[VAR_A]]
-; CHECK-SPIRV: %[[CMP_RES:[0-9]+]] = OpINotEqual %[[#]] %[[VAR_A]] %[[DIV_RES]]
-; CHECK-SPIRV: %[[INSERT_RES:[0-9]+]] = OpCompositeInsert %[[#]] %[[MUL_RES]]
-; CHECK-SPIRV: %[[INSERT_RES_1:[0-9]+]] = OpCompositeInsert %[[#]] %[[CMP_RES]] %[[INSERT_RES]]
-; CHECK-SPIRV: OpReturnValue %[[INSERT_RES_1]]
-
 ; Function Attrs: nofree nounwind writeonly
 define dso_local spir_func void @_Z5foo32jjPj(i32 %a, i32 %b, i32* nocapture %c) local_unnamed_addr #0 {
 entry:
@@ -52,6 +42,16 @@ define dso_local spir_func void @umulo_v2i64(<2 x i64> %a, <2 x i64> %b, <2 x i6
   store <2 x i64> %spec.select, <2 x i64>* %p
   ret void
 }
+
+; CHECK-SPIRV: %[[NAME_UMUL_FUNC_8]] = OpFunction %[[#]]
+; CHECK-SPIRV: %[[VAR_A:[0-9]+]] = OpFunctionParameter %[[#]]
+; CHECK-SPIRV: %[[VAR_B:[0-9]+]] = OpFunctionParameter %[[#]]
+; CHECK-SPIRV: %[[MUL_RES:[0-9]+]] = OpIMul %[[#]] %[[VAR_A]] %[[VAR_B]]
+; CHECK-SPIRV: %[[DIV_RES:[0-9]+]] = OpUDiv %[[#]] %[[MUL_RES]] %[[VAR_A]]
+; CHECK-SPIRV: %[[CMP_RES:[0-9]+]] = OpINotEqual %[[#]] %[[VAR_A]] %[[DIV_RES]]
+; CHECK-SPIRV: %[[INSERT_RES:[0-9]+]] = OpCompositeInsert %[[#]] %[[MUL_RES]]
+; CHECK-SPIRV: %[[INSERT_RES_1:[0-9]+]] = OpCompositeInsert %[[#]] %[[CMP_RES]] %[[INSERT_RES]]
+; CHECK-SPIRV: OpReturnValue %[[INSERT_RES_1]]
 
 ; Function Attrs: nounwind readnone speculatable willreturn
 declare { i8, i1 } @llvm.umul.with.overflow.i8(i8, i8) #1


### PR DESCRIPTION
The change implements several llvm intrinsics (`llvm.fsh*.*`, `llvm.umul.with.overflow.*`), creating new separate functions and calling them as, it's done in the translator. Also the tests were corrected. 5 LIT tests should pass.