### PR TITLE
[SPIR-V] prepare SPIRVPrepareFunctions for upstream

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRV.h
+++ b/llvm/lib/Target/SPIRV/SPIRV.h
@@ -19,7 +19,7 @@ class SPIRVSubtarget;
 class InstructionSelector;
 class RegisterBankInfo;
 
-ModulePass *createSPIRVPreTranslationLegalizerPass();
+ModulePass *createSPIRVPrepareFunctionsPass();
 FunctionPass *createSPIRVOCLRegularizerPass();
 FunctionPass *createSPIRVBasicBlockDominancePass();
 ModulePass *createSPIRVLowerConstExprLegacyPass();

--- a/llvm/lib/Target/SPIRV/SPIRVGenerateDecorations.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGenerateDecorations.cpp
@@ -71,9 +71,6 @@ static uint32_t getFastMathFlags(const MachineInstr &I) {
   return flags;
 }
 
-// Defined in SPIRVLegalizerInfo.cpp
-extern bool isTypeFoldingSupported(unsigned Opcode);
-
 bool SPIRVGenerateDecorations::runOnMachineFunction(MachineFunction &MF) {
   MachineIRBuilder MIRBuilder(MF);
   auto &MRI = MF.getRegInfo();
@@ -93,23 +90,6 @@ bool SPIRVGenerateDecorations::runOnMachineFunction(MachineFunction &MF) {
             .addUse(NewReg)
             .addImm(Decoration::FPFastMathMode)
             .addImm(FMFlags);
-      }
-    }
-  }
-
-  for (auto &MBB : MF) {
-    for (auto &MI : MBB) {
-      // We need to rewrite dst types for ASSIGN_TYPE instrs to be able
-      // to perform tblgen'erated selection and we can't do that on Legalizer
-      // as it operates on gMIR only.
-      if (MI.getOpcode() == SPIRV::ASSIGN_TYPE) {
-        Register SrcReg = MI.getOperand(1).getReg();
-        if (isTypeFoldingSupported(MRI.getVRegDef(SrcReg)->getOpcode())) {
-          Register DstReg = MI.getOperand(0).getReg();
-          if (MRI.getType(DstReg).isVector())
-            MRI.setRegClass(DstReg, &SPIRV::IDRegClass);
-          MRI.setType(DstReg, LLT::scalar(32));
-        }
       }
     }
   }

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -188,7 +188,7 @@ Register SPIRVGlobalRegistry::buildConstantInt(uint64_t Val,
   // Find a constant in DT or build a new one.
   const auto ConstInt =
       ConstantInt::get(const_cast<IntegerType *>(LLVMIntTy), Val);
-  Register Res = DT.find(ConstInt, &MIRBuilder.getMF());
+  Register Res = DT.find(ConstInt, &MF);
   if (!Res.isValid()) {
     unsigned BitWidth = SpvType ? getScalarOrVectorBitWidth(SpvType) : 32;
     LLT LLTy = LLT::scalar(EmitIR ? BitWidth : 32);
@@ -233,12 +233,12 @@ Register SPIRVGlobalRegistry::buildConstantFP(APFloat Val,
   }
   // Find a constant in DT or build a new one.
   const auto ConstFP = ConstantFP::get(LLVMFPTy->getContext(), Val);
-  Register Res = DT.find(ConstFP, &MIRBuilder.getMF());
+  Register Res = DT.find(ConstFP, &MF);
   if (!Res.isValid()) {
     unsigned BitWidth = SpvType ? getScalarOrVectorBitWidth(SpvType) : 32;
     Res = MF.getRegInfo().createGenericVirtualRegister(LLT::scalar(BitWidth));
     assignTypeToVReg(LLVMFPTy, Res, MIRBuilder);
-    DT.add(ConstFP, &MIRBuilder.getMF(), Res);
+    DT.add(ConstFP, &MF, Res);
     MIRBuilder.buildFConstant(Res, *ConstFP);
   }
   return Res;

--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -152,7 +152,7 @@ void SPIRVPassConfig::addIRPasses() {
   TargetPassConfig::addIRPasses();
   addPass(createSPIRVLowerConstExprLegacyPass());
   addPass(createSPIRVOCLRegularizerPass());
-  addPass(createSPIRVPreTranslationLegalizerPass());
+  addPass(createSPIRVPrepareFunctionsPass());
 }
 
 void SPIRVPassConfig::addISelPrepare() {


### PR DESCRIPTION
The patch prepares SPIRVPrepareFunctions pass for upstream to llvm-project. Also it moves rewriting of register types from SPIRVGenerateDecorations pass to SPIRVPreLegalizer pass. Small changes were also made to unify with llvm-project.