### PR TITLE
Parsing OpenCL types using TableGen records

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -32,7 +32,6 @@ namespace {
 #define GET_BuiltinGroup_DECL
 #include "SPIRVGenTables.inc"
 
-// Struct holding a demangled builtin record.
 struct DemangledBuiltin {
   StringRef Name;
   InstructionSet Set;

--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.td
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.td
@@ -1196,7 +1196,7 @@ multiclass DemangledPipeType<string name> {
   def : PipeType<name>;
 }
 
-foreach aq = ["_ro_t", "_wo_t", "_rw_t"] in {
+foreach aq = ["_t", "_ro_t", "_wo_t", "_rw_t"] in {
   defm : DemangledPipeType<!strconcat("opencl.pipe", aq)>;
 }
 

--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.td
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.td
@@ -65,7 +65,6 @@ def VectorLoadStore : BuiltinGroup;
 // minNumArgs is the minimum required number of arguments for lowering.
 // maxNumArgs specifies the maximum used number of arguments for lowering.
 //===----------------------------------------------------------------------===//
-
 class DemangledBuiltin<string name, InstructionSet set, BuiltinGroup group, bits<8> minNumArgs, bits<8> maxNumArgs> {
   string Name = name;
   InstructionSet Set = set;
@@ -1080,6 +1079,125 @@ foreach i = ["", "2", "3", "4", "8", "16"] in {
     }   
     defm : DemangledVectorLoadStoreBuiltin<!strconcat("vstorea_half", i, j), 3, 3, 181>; 
   }
+}
+
+//===----------------------------------------------------------------------===//
+// Class defining implementation details of demangled builtin types. The info
+// in the record is used for lowering into OpType.
+//
+// name is the demangled name of the given builtin.
+// operation specifies the SPIR-V opcode the StructType should be lowered to.
+//===----------------------------------------------------------------------===//
+class DemangledType<string name, Op operation> {
+  string Name = name;
+  Op Opcode = operation;
+}
+
+// Table gathering all the demangled type records.
+def DemangledTypes : GenericTable {
+  let FilterClass = "DemangledType";
+  let Fields = ["Name", "Opcode"];
+}
+
+// Function to lookup builtin types by their demangled name.
+def lookupType : SearchIndex {
+  let Table = DemangledTypes;
+  let Key = ["Name"];
+}
+
+// OpenCL builtin types:
+def : DemangledType<"opencl.reserve_id_t", OpTypeReserveId>;
+def : DemangledType<"opencl.event_t", OpTypeEvent>;
+def : DemangledType<"opencl.queue_t", OpTypeQueue>;
+def : DemangledType<"opencl.sampler_t", OpTypeSampler>;
+def : DemangledType<"opencl.clk_event_t", OpTypeDeviceEvent>;
+def : DemangledType<"opencl.clk_event_t", OpTypeDeviceEvent>;
+
+// Class definining lowering details for various variants of image type indentifiers.
+class ImageType<string name> {
+  string Name = name;
+  AccessQualifier Qualifier = !cond(!not(!eq(!find(name, "_ro_t"), -1)) : ReadOnly,
+                                  !not(!eq(!find(name, "_wo_t"), -1)) : WriteOnly,
+                                  !not(!eq(!find(name, "_rw_t"), -1)) : ReadWrite,
+                                  true : ReadOnly);
+  Dim Dimensionality = !cond(!not(!eq(!find(name, "buffer"), -1)) : DIM_Buffer,
+                                  !not(!eq(!find(name, "image1"), -1)) : DIM_1D,
+                                  !not(!eq(!find(name, "image2"), -1)) : DIM_2D,
+                                  !not(!eq(!find(name, "image3"), -1)) : DIM_3D);
+  bit Arrayed = !not(!eq(!find(name, "array"), -1));
+  bit Depth = !not(!eq(!find(name, "depth"), -1));
+}
+
+// Table gathering all the image type records.
+def ImageTypes : GenericTable {
+  let FilterClass = "ImageType";
+  let Fields = ["Name", "Qualifier", "Dimensionality", "Arrayed", "Depth"];
+  string TypeOf_Qualifier = "AccessQualifier";
+  string TypeOf_Dimensionality = "Dim";
+}
+
+// Function to lookup builtin image types by their demangled name.
+def lookupImageType : SearchIndex {
+  let Table = ImageTypes;
+  let Key = ["Name"];
+}
+
+// Multiclass used to define at the same time a DemangledType record used
+// for matching an incoming demangled string to the OpTypeImage opcode and
+// ImageType conatining the lowering details.
+multiclass DemangledImageType<string name> {
+  def : DemangledType<name, OpTypeImage>;
+  def : ImageType<name>;
+}
+
+foreach aq = ["_t", "_ro_t", "_wo_t", "_rw_t"] in {
+  defm : DemangledImageType<!strconcat("opencl.image1d", aq)>;
+  defm : DemangledImageType<!strconcat("opencl.image1d_array", aq)>;
+  defm : DemangledImageType<!strconcat("opencl.image1d_buffer", aq)>;
+
+  foreach a1 = ["", "_array"] in {
+    foreach a2 = ["", "_msaa"] in {
+      foreach a3 = ["", "_depth"] in {
+        defm : DemangledImageType<!strconcat("opencl.image2d", a1, a2, a3, aq)>;
+      }
+    }
+  }
+
+  defm : DemangledImageType<!strconcat("opencl.image3d", aq)>;
+}
+
+// Class definining lowering details for various variants of pipe type indentifiers.
+class PipeType<string name> {
+  string Name = name;
+  AccessQualifier Qualifier = !cond(!not(!eq(!find(name, "_ro_t"), -1)) : ReadOnly,
+                                  !not(!eq(!find(name, "_wo_t"), -1)) : WriteOnly,
+                                  !not(!eq(!find(name, "_rw_t"), -1)) : ReadWrite,
+                                  true : ReadOnly);
+}
+
+// Table gathering all the pipe type records.
+def PipeTypes : GenericTable {
+  let FilterClass = "PipeType";
+  let Fields = ["Name", "Qualifier"];
+  string TypeOf_Qualifier = "AccessQualifier";
+}
+
+// Function to lookup builtin pipe types by their demangled name.
+def lookupPipeType : SearchIndex {
+  let Table = PipeTypes;
+  let Key = ["Name"];
+}
+
+// Multiclass used to define at the same time a DemangledType record used
+// for matching an incoming demangled string to the OpTypePipe opcode and
+// PipeType conatining the lowering details.
+multiclass DemangledPipeType<string name> {
+  def : DemangledType<name, OpTypePipe>;
+  def : PipeType<name>;
+}
+
+foreach aq = ["_ro_t", "_wo_t", "_rw_t"] in {
+  defm : DemangledPipeType<!strconcat("opencl.pipe", aq)>;
 }
 
 //===----------------------------------------------------------------------===//

--- a/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
+++ b/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
@@ -651,7 +651,7 @@ class Dim<string name, bits<32> value> {
 }
 
 multiclass DimOperand<bits<32> value, string mnemonic, list<Capability> reqCapabilities> {
-  def : Dim<NAME, value>;
+  def NAME : Dim<NAME, value>;
   defm : SymbolicOperandWithRequirements<DimOperand, value, mnemonic, 0, 0, [], reqCapabilities>;
 }
 
@@ -999,7 +999,7 @@ class AccessQualifier<string name, bits<32> value> {
 }
 
 multiclass AccessQualifierOperand<bits<32> value, list<Capability> reqCapabilities> {
-  def : AccessQualifier<NAME, value>;
+  def NAME : AccessQualifier<NAME, value>;
   defm : SymbolicOperandWithRequirements<AccessQualifierOperand, value, NAME, 0, 0, [], reqCapabilities>;
 }
 


### PR DESCRIPTION
This pull request improves OpenCL builtin type recognition/detection and eliminates hardcoded demangled string parsing inside _getOrCreateOpenCLOpaqueType_. 

The changes can be merged in the current state. Next the _getOrCreateSPIRVOpaqueType_ method should also be redesigned in a similar fashion. However, I am not sure if containing all the combinations of SPIR-V builtin types in TableGen records is sensible.

```
%spirv.Image._type_i_i_i_i_i_i_i
```

The example above represents an incoming demangled image type. Each integer _i_ represents an attribute and TableGen records would need to contain all possible combinations.

I propose to parse only the beginning of the more complex SPIR-V type names using TableGen and move the rest of parsing logic to hand-written functions per each type. Also _getOrCreateOpenCLOpaqueType_, _getOrCreateSPIRVOpaqueType_, and all the parsing functions should probably be moved from the SPIRVGlobalRegistry.cpp to either a new SPIRVTypes.cpp file or the existing SPIRVBuiltins.cpp. I will have a patch with this proposal ready by the end of the week.