### PR TITLE
[SPIR-V] correct SPIRVBaseInfo for upstream

### DIFF
--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.cpp
@@ -59,39 +59,34 @@ getSymbolicOperandMnemonic(SPIRV::OperandCategory::OperandCategory Category,
                            int32_t Value) {
   const SPIRV::SymbolicOperand *Lookup =
       SPIRV::lookupSymbolicOperandByCategoryAndValue(Category, Value);
-
-  if (Lookup) {
-    // Value that encodes just one enum value
+  // Value that encodes just one enum value.
+  if (Lookup)
     return Lookup->Mnemonic.str();
-  } else if (Category == SPIRV::OperandCategory::ImageOperandOperand ||
-             Category == SPIRV::OperandCategory::FPFastMathModeOperand ||
-             Category == SPIRV::OperandCategory::SelectionControlOperand ||
-             Category == SPIRV::OperandCategory::LoopControlOperand ||
-             Category == SPIRV::OperandCategory::FunctionControlOperand ||
-             Category == SPIRV::OperandCategory::MemorySemanticsOperand ||
-             Category == SPIRV::OperandCategory::MemoryOperandOperand ||
-             Category == SPIRV::OperandCategory::KernelProfilingInfoOperand) {
-    // Value that encodes many enum values (one bit per enum value)
-    std::string Name;
-    std::string Separator;
+  if (Category != SPIRV::OperandCategory::ImageOperandOperand &&
+      Category != SPIRV::OperandCategory::FPFastMathModeOperand &&
+      Category != SPIRV::OperandCategory::SelectionControlOperand &&
+      Category != SPIRV::OperandCategory::LoopControlOperand &&
+      Category != SPIRV::OperandCategory::FunctionControlOperand &&
+      Category != SPIRV::OperandCategory::MemorySemanticsOperand &&
+      Category != SPIRV::OperandCategory::MemoryOperandOperand &&
+      Category != SPIRV::OperandCategory::KernelProfilingInfoOperand)
+    return "UNKNOWN";
+  // Value that encodes many enum values (one bit per enum value).
+  std::string Name;
+  std::string Separator;
+  const SPIRV::SymbolicOperand *EnumValueInCategory =
+      SPIRV::lookupSymbolicOperandByCategory(Category);
 
-    const SPIRV::SymbolicOperand *EnumValueInCategory =
-        SPIRV::lookupSymbolicOperandByCategory(Category);
-
-    while (EnumValueInCategory && EnumValueInCategory->Category == Category) {
-      if ((EnumValueInCategory->Value != 0) &&
-          (Value & EnumValueInCategory->Value)) {
-        Name += Separator + EnumValueInCategory->Mnemonic.str();
-        Separator = "|";
-      }
-
-      ++EnumValueInCategory;
+  while (EnumValueInCategory && EnumValueInCategory->Category == Category) {
+    if ((EnumValueInCategory->Value != 0) &&
+        (Value & EnumValueInCategory->Value)) {
+      Name += Separator + EnumValueInCategory->Mnemonic.str();
+      Separator = "|";
     }
-
-    return Name;
+    ++EnumValueInCategory;
   }
 
-  return "UNKNOWN";
+  return Name;
 }
 
 uint32_t
@@ -159,8 +154,7 @@ std::string getLinkStringForBuiltIn(SPIRV::BuiltIn::BuiltIn BuiltInValue) {
 
   if (Lookup)
     return "__spirv_BuiltIn" + Lookup->Mnemonic.str();
-  else
-    return "UNKNOWN_BUILTIN";
+  return "UNKNOWN_BUILTIN";
 }
 
 // TODO: Remove function after new SPIRVOpenCLBIFs is merged

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.cpp
@@ -18,11 +18,6 @@
 
 namespace llvm {
 namespace SPIRV {
-using namespace OperandCategory;
-using namespace Extension;
-using namespace Capability;
-using namespace InstructionSet;
-
 struct SymbolicOperand {
   OperandCategory::OperandCategory Category;
   uint32_t Value;
@@ -43,6 +38,10 @@ struct CapabilityEntry {
   Capability::Capability ReqCapability;
 };
 
+using namespace OperandCategory;
+using namespace Extension;
+using namespace Capability;
+using namespace InstructionSet;
 #define GET_SymbolicOperands_DECL
 #define GET_SymbolicOperands_IMPL
 #define GET_ExtensionEntries_DECL

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.h
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.h
@@ -206,7 +206,6 @@ struct ExtendedBuiltin {
   InstructionSet::InstructionSet Set;
   uint32_t Number;
 };
-#define GET_ExtendedBuiltins_DECL
 } // namespace SPIRV
 
 using CapabilityList = SmallVector<SPIRV::Capability::Capability, 8>;
@@ -257,9 +256,8 @@ std::string getSPIRVStringOperand(const InstType &MI, unsigned StartIndex) {
       if (c == 0) { // Stop if we hit a null-terminator character.
         IsFinished = true;
         break;
-      } else {
-        s += c; // Otherwise, append the character to the result string.
       }
+      s += c; // Otherwise, append the character to the result string.
     }
   }
   return s;

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.h
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVInstPrinter.h
@@ -52,4 +52,4 @@ public:
 };
 } // namespace llvm
 
-#endif
+#endif // LLVM_LIB_TARGET_SPIRV_INSTPRINTER_SPIRVINSTPRINTER_H

--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -131,6 +131,7 @@ using namespace InstructionSet;
 #define GET_CLMemoryScope_DECL
 #define GET_CLSamplerAddressingMode_DECL
 #define GET_CLMemoryFenceFlags_DECL
+#define GET_ExtendedBuiltins_DECL
 #include "SPIRVGenTables.inc"
 } // namespace SPIRV
 

--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -112,10 +112,6 @@ struct ConvertBuiltin {
   FPRoundingMode::FPRoundingMode RoundingMode;
 };
 
-using namespace FPRoundingMode;
-#define GET_ConvertBuiltins_DECL
-#define GET_ConvertBuiltins_IMPL
-
 struct VectorLoadStoreBuiltin {
   StringRef Name;
   InstructionSet::InstructionSet Set;
@@ -123,6 +119,10 @@ struct VectorLoadStoreBuiltin {
   bool IsRounded;
   FPRoundingMode::FPRoundingMode RoundingMode;
 };
+
+using namespace FPRoundingMode;
+#define GET_ConvertBuiltins_DECL
+#define GET_ConvertBuiltins_IMPL
 
 using namespace InstructionSet;
 #define GET_VectorLoadStoreBuiltins_DECL

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -907,16 +907,15 @@ struct ImageType {
   bool Depth;
 };
 
-using namespace AccessQualifier;
-using namespace Dim;
-#define GET_ImageTypes_DECL
-#define GET_ImageTypes_IMPL
-
 struct PipeType {
   StringRef Name;
   AccessQualifier::AccessQualifier Qualifier;
 };
 
+using namespace AccessQualifier;
+using namespace Dim;
+#define GET_ImageTypes_DECL
+#define GET_ImageTypes_IMPL
 #define GET_PipeTypes_DECL
 #define GET_PipeTypes_IMPL
 #include "SPIRVGenTables.inc"

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.cpp
@@ -21,7 +21,7 @@
 #include "llvm/Demangle/Demangle.h"
 #include "llvm/IR/IntrinsicsSPIRV.h"
 
-using namespace llvm;
+namespace llvm {
 
 // The following functions are used to add these string literals as a series of
 // 32-bit integer operands with the correct format, and unpack them if necessary
@@ -173,8 +173,8 @@ addressSpaceToStorageClass(unsigned AddrSpace) {
 }
 
 SPIRV::MemorySemantics::MemorySemantics
-getMemSemanticsForStorageClass(SPIRV::StorageClass::StorageClass sc) {
-  switch (sc) {
+getMemSemanticsForStorageClass(SPIRV::StorageClass::StorageClass SC) {
+  switch (SC) {
   case SPIRV::StorageClass::StorageBuffer:
   case SPIRV::StorageClass::Uniform:
     return SPIRV::MemorySemantics::UniformMemory;
@@ -204,6 +204,7 @@ SPIRV::MemorySemantics::MemorySemantics getMemSemantics(AtomicOrdering Ord) {
   case AtomicOrdering::Unordered:
   case AtomicOrdering::Monotonic:
   case AtomicOrdering::NotAtomic:
+  default:
     return SPIRV::MemorySemantics::None;
   }
 }
@@ -339,3 +340,4 @@ std::string isOclOrSpirvBuiltin(StringRef Name) {
       .getAsInteger(10, Len);
   return Name.substr(Start, Len).str();
 }
+} // namespace llvm

--- a/llvm/lib/Target/SPIRV/SPIRVUtils.h
+++ b/llvm/lib/Target/SPIRV/SPIRVUtils.h
@@ -27,75 +27,71 @@ class MachineRegisterInfo;
 class Register;
 class StringRef;
 class SPIRVInstrInfo;
-} // namespace llvm
 
 // Add the given string as a series of integer operand, inserting null
 // terminators and padding to make sure the operands all have 32-bit
 // little-endian words.
-void addStringImm(const llvm::StringRef &Str, llvm::MCInst &Inst);
-void addStringImm(const llvm::StringRef &Str, llvm::MachineInstrBuilder &MIB);
-void addStringImm(const llvm::StringRef &Str, llvm::IRBuilder<> &B,
-                  std::vector<llvm::Value *> &Args);
+void addStringImm(const StringRef &Str, MCInst &Inst);
+void addStringImm(const StringRef &Str, MachineInstrBuilder &MIB);
+void addStringImm(const StringRef &Str, IRBuilder<> &B,
+                  std::vector<Value *> &Args);
 
 // Read the series of integer operands back as a null-terminated string using
 // the reverse of the logic in addStringImm.
-std::string getStringImm(const llvm::MachineInstr &MI, unsigned StartIndex);
+std::string getStringImm(const MachineInstr &MI, unsigned StartIndex);
 
 // Add the given numerical immediate to MIB.
-void addNumImm(const llvm::APInt &Imm, llvm::MachineInstrBuilder &MIB);
+void addNumImm(const APInt &Imm, MachineInstrBuilder &MIB);
 
 // Add an OpName instruction for the given target register.
-void buildOpName(llvm::Register Target, const llvm::StringRef &Name,
-                 llvm::MachineIRBuilder &MIRBuilder);
+void buildOpName(Register Target, const StringRef &Name,
+                 MachineIRBuilder &MIRBuilder);
 
 // Add an OpDecorate instruction for the given Reg.
-void buildOpDecorate(llvm::Register Reg, llvm::MachineIRBuilder &MIRBuilder,
-                     llvm::SPIRV::Decoration::Decoration Dec,
+void buildOpDecorate(Register Reg, MachineIRBuilder &MIRBuilder,
+                     SPIRV::Decoration::Decoration Dec,
                      const std::vector<uint32_t> &DecArgs,
-                     llvm::StringRef StrImm = "");
-void buildOpDecorate(llvm::Register Reg, llvm::MachineInstr &I,
-                     const llvm::SPIRVInstrInfo &TII,
-                     llvm::SPIRV::Decoration::Decoration Dec,
+                     StringRef StrImm = "");
+void buildOpDecorate(Register Reg, MachineInstr &I, const SPIRVInstrInfo &TII,
+                     SPIRV::Decoration::Decoration Dec,
                      const std::vector<uint32_t> &DecArgs,
-                     llvm::StringRef StrImm = "");
+                     StringRef StrImm = "");
 
 // Convert a SPIR-V storage class to the corresponding LLVM IR address space.
-unsigned storageClassToAddressSpace(llvm::SPIRV::StorageClass::StorageClass SC);
+unsigned storageClassToAddressSpace(SPIRV::StorageClass::StorageClass SC);
 
 // Convert an LLVM IR address space to a SPIR-V storage class.
-llvm::SPIRV::StorageClass::StorageClass
+SPIRV::StorageClass::StorageClass
 addressSpaceToStorageClass(unsigned AddrSpace);
 
 // Utility method to constrain an instruction's operands to the correct
 // register classes, and return true if this worked.
 // TODO: get rid of using this function.
-bool constrainRegOperands(llvm::MachineInstrBuilder &MIB,
-                          llvm::MachineFunction *MF = nullptr);
+bool constrainRegOperands(MachineInstrBuilder &MIB,
+                          MachineFunction *MF = nullptr);
 
-llvm::SPIRV::MemorySemantics::MemorySemantics
-getMemSemanticsForStorageClass(llvm::SPIRV::StorageClass::StorageClass SC);
+SPIRV::MemorySemantics::MemorySemantics
+getMemSemanticsForStorageClass(SPIRV::StorageClass::StorageClass SC);
 
-llvm::SPIRV::MemorySemantics::MemorySemantics
-getMemSemantics(llvm::AtomicOrdering Ord);
+SPIRV::MemorySemantics::MemorySemantics getMemSemantics(AtomicOrdering Ord);
 
 // Find def instruction for the given ConstReg, walking through
 // spv_track_constant and ASSIGN_TYPE instructions. Updates ConstReg by def
 // of OpConstant instruction.
-llvm::MachineInstr *
-getDefInstrMaybeConstant(llvm::Register &ConstReg,
-                         const llvm::MachineRegisterInfo *MRI);
+MachineInstr *getDefInstrMaybeConstant(Register &ConstReg,
+                                       const MachineRegisterInfo *MRI);
 
 // Get constant integer value of the given ConstReg.
-uint64_t getIConstVal(llvm::Register ConstReg,
-                      const llvm::MachineRegisterInfo *MRI);
+uint64_t getIConstVal(Register ConstReg, const MachineRegisterInfo *MRI);
 
 // Check if MI is a SPIR-V specific intrinsic call.
-bool isSpvIntrinsic(llvm::MachineInstr &MI, llvm::Intrinsic::ID IntrinsicID);
+bool isSpvIntrinsic(MachineInstr &MI, Intrinsic::ID IntrinsicID);
 
 // Get type of i-th operand of the metadata node.
-llvm::Type *getMDOperandAsType(const llvm::MDNode *N, unsigned I);
+Type *getMDOperandAsType(const MDNode *N, unsigned I);
 
 // Return a demangled name with arg type info by itaniumDemangle().
 // If the parser fails, return only function name.
-std::string isOclOrSpirvBuiltin(llvm::StringRef Name);
+std::string isOclOrSpirvBuiltin(StringRef Name);
+} // namespace llvm
 #endif // LLVM_LIB_TARGET_SPIRV_SPIRVUTILS_H


### PR DESCRIPTION
The patch contains the changes in SPIRVBaseInfo.* I'm going to apply for upstreaming SPIRVSymbolicOperands.td to llvm-project. Also, functions in SPIRVUtils are moved to llvm namespace. No new passed tests are expected. 