### PR TITLE
Pre-legalize switch range-compare and add support for unreachable instruction 

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -29,4 +29,5 @@ let TargetPrefix = "spv" in {
   def int_spv_bitcast : Intrinsic<[llvm_any_ty], [llvm_any_ty]>;
   def int_spv_switch : Intrinsic<[], [llvm_any_ty, llvm_vararg_ty]>;
   def int_spv_cmpxchg : Intrinsic<[llvm_i32_ty], [llvm_any_ty, llvm_vararg_ty]>;
+  def int_spv_unreachable : Intrinsic<[], []>;
 }

--- a/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.cpp
+++ b/llvm/lib/Target/SPIRV/MCTargetDesc/SPIRVBaseInfo.cpp
@@ -18,11 +18,6 @@
 
 namespace llvm {
 namespace SPIRV {
-using namespace OperandCategory;
-using namespace Extension;
-using namespace Capability;
-using namespace InstructionSet;
-
 struct SymbolicOperand {
   OperandCategory::OperandCategory Category;
   uint32_t Value;
@@ -43,6 +38,10 @@ struct CapabilityEntry {
   Capability::Capability ReqCapability;
 };
 
+using namespace OperandCategory;
+using namespace Extension;
+using namespace Capability;
+using namespace InstructionSet;
 #define GET_SymbolicOperands_DECL
 #define GET_SymbolicOperands_IMPL
 #define GET_ExtensionEntries_DECL

--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -112,10 +112,6 @@ struct ConvertBuiltin {
   FPRoundingMode::FPRoundingMode RoundingMode;
 };
 
-using namespace FPRoundingMode;
-#define GET_ConvertBuiltins_DECL
-#define GET_ConvertBuiltins_IMPL
-
 struct VectorLoadStoreBuiltin {
   StringRef Name;
   InstructionSet::InstructionSet Set;
@@ -123,6 +119,10 @@ struct VectorLoadStoreBuiltin {
   bool IsRounded;
   FPRoundingMode::FPRoundingMode RoundingMode;
 };
+
+using namespace FPRoundingMode;
+#define GET_ConvertBuiltins_DECL
+#define GET_ConvertBuiltins_IMPL
 
 using namespace InstructionSet;
 #define GET_VectorLoadStoreBuiltins_DECL

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -88,6 +88,7 @@ public:
   Instruction *visitStoreInst(StoreInst &I);
   Instruction *visitAllocaInst(AllocaInst &I);
   Instruction *visitAtomicCmpXchgInst(AtomicCmpXchgInst &I);
+  Instruction *visitUnreachableInst(UnreachableInst &I);
   bool runOnFunction(Function &F) override;
 };
 } // namespace
@@ -334,6 +335,12 @@ Instruction *SPIRVEmitIntrinsics::visitAtomicCmpXchgInst(AtomicCmpXchgInst &I) {
                                     {I.getPointerOperand()->getType()}, {Args});
   replaceMemInstrUses(&I, NewI);
   return NewI;
+}
+
+Instruction *SPIRVEmitIntrinsics::visitUnreachableInst(UnreachableInst &I) {
+  IRB->SetInsertPoint(&I);
+  IRB->CreateIntrinsic(Intrinsic::spv_unreachable, {}, {});
+  return &I;
 }
 
 void SPIRVEmitIntrinsics::processGlobalValue(GlobalVariable &GV) {

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -907,16 +907,15 @@ struct ImageType {
   bool Depth;
 };
 
-using namespace AccessQualifier;
-using namespace Dim;
-#define GET_ImageTypes_DECL
-#define GET_ImageTypes_IMPL
-
 struct PipeType {
   StringRef Name;
   AccessQualifier::AccessQualifier Qualifier;
 };
 
+using namespace AccessQualifier;
+using namespace Dim;
+#define GET_ImageTypes_DECL
+#define GET_ImageTypes_IMPL
 #define GET_PipeTypes_DECL
 #define GET_PipeTypes_IMPL
 #include "SPIRVGenTables.inc"

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -1430,6 +1430,9 @@ bool SPIRVInstructionSelector::selectIntrinsic(Register ResVReg,
   case Intrinsic::spv_cmpxchg:
     return selectAtomicCmpXchg(ResVReg, ResType, I);
     break;
+  case Intrinsic::spv_unreachable:
+    BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpUnreachable));
+    break;
   default:
     llvm_unreachable("Intrinsic selection not implemented");
   }

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -404,7 +404,14 @@ static void processSwitches(const Module &M, SPIRV::ModuleAnalysisInfo &MAI,
           assert(MI.getOperand(0).isReg());
           SwitchRegs.insert(MI.getOperand(0).getReg());
         }
-        if (MI.getOpcode() != SPIRV::OpIEqual || !MI.getOperand(2).isReg() ||
+        if (MI.getOpcode() == SPIRV::OpISubS &&
+            SwitchRegs.contains(MI.getOperand(2).getReg())) {
+          SwitchRegs.insert(MI.getOperand(0).getReg());
+          MAI.setSkipEmission(&MI);
+        }
+        if ((MI.getOpcode() != SPIRV::OpIEqual &&
+             MI.getOpcode() != SPIRV::OpULessThanEqual) ||
+            !MI.getOperand(2).isReg() ||
             !SwitchRegs.contains(MI.getOperand(2).getReg()))
           continue;
         Register CmpReg = MI.getOperand(0).getReg();

--- a/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
@@ -484,6 +484,8 @@ static void processSwitches(MachineFunction &MF, SPIRVGlobalRegistry *GR,
         Register CReg = MI.getOperand(i).getReg();
         uint64_t Val = getIConstVal(CReg, &MRI);
         MachineInstr *ConstInstr = getDefInstrMaybeConstant(CReg, &MRI);
+        if (!SwitchRegToMBB[Reg][Val])
+          continue;
         Vals.push_back(ConstInstr->getOperand(1).getCImm());
         MBBs.push_back(SwitchRegToMBB[Reg][Val]);
       }


### PR DESCRIPTION
This pull request:
- Adds support for switches lowered to range-based compare instructions (IRTranslator emits an additional G_SUB calculating the range before G_ICMP).
- Adds a new _spv_unreachable_ intrinsic for preserving unreachable terminators in basic blocks. Those are later selected into OpUnreachable. This mimics the behavior of the LLVM-SPIRV translator and makes sure some SPIR-V consumers (including IGC) are able to translate blocks terminated with _unreachable_ to valid LLVM basic blocks.

These changes should make the _test_pipes/pipe_max_active_reservations_ CTS test pass.