### PR TITLE
[SPIR-V] substitute llvm.memset and llvm.bswap intrinsics

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -243,6 +243,11 @@ private:
       uint64_t Val, SPIRVType *SpvType, MachineIRBuilder *MIRBuilder,
       MachineInstr *I = nullptr, const SPIRVInstrInfo *TII = nullptr);
   SPIRVType *finishCreatingSPIRVType(const Type *LLVMTy, SPIRVType *SpirvType);
+  Register getOrCreateIntCompositeOrNull(uint64_t Val, MachineInstr &I,
+                                         SPIRVType *SpvType,
+                                         const SPIRVInstrInfo &TII,
+                                         Constant *CA, unsigned BitWidth,
+                                         unsigned ElemCnt);
 
 public:
   Register buildConstantInt(uint64_t Val, MachineIRBuilder &MIRBuilder,
@@ -256,18 +261,23 @@ public:
   Register getOrCreateConsIntVector(uint64_t Val, MachineInstr &I,
                                     SPIRVType *SpvType,
                                     const SPIRVInstrInfo &TII);
+  Register getOrCreateConsIntArray(uint64_t Val, MachineInstr &I,
+                                   SPIRVType *SpvType,
+                                   const SPIRVInstrInfo &TII);
   Register buildConstantSampler(Register Res, unsigned AddrMode, unsigned Param,
                                 unsigned FilerMode,
                                 MachineIRBuilder &MIRBuilder,
                                 SPIRVType *SpvType);
   Register getOrCreateUndef(MachineInstr &I, SPIRVType *SpvType,
                             const SPIRVInstrInfo &TII);
-  Register
-  buildGlobalVariable(Register Reg, SPIRVType *BaseType, StringRef Name,
-                      const GlobalValue *GV, SPIRV::StorageClass::StorageClass Storage,
-                      const MachineInstr *Init, bool IsConst, bool HasLinkageTy,
-                      SPIRV::LinkageType::LinkageType LinkageType,
-                      MachineIRBuilder &MIRBuilder, bool IsInstSelector);
+  Register buildGlobalVariable(Register Reg, SPIRVType *BaseType,
+                               StringRef Name, const GlobalValue *GV,
+                               SPIRV::StorageClass::StorageClass Storage,
+                               const MachineInstr *Init, bool IsConst,
+                               bool HasLinkageTy,
+                               SPIRV::LinkageType::LinkageType LinkageType,
+                               MachineIRBuilder &MIRBuilder,
+                               bool IsInstSelector);
 
   // Convenient helpers for getting types with check for duplicates.
   SPIRVType *getOrCreateSPIRVIntegerType(unsigned BitWidth,
@@ -283,6 +293,10 @@ public:
   SPIRVType *getOrCreateSPIRVVectorType(SPIRVType *BaseType,
                                         unsigned NumElements, MachineInstr &I,
                                         const SPIRVInstrInfo &TII);
+  SPIRVType *getOrCreateSPIRVArrayType(SPIRVType *BaseType,
+                                       unsigned NumElements, MachineInstr &I,
+                                       const SPIRVInstrInfo &TII);
+
   SPIRVType *getOrCreateSPIRVPointerType(
       SPIRVType *BaseType, MachineIRBuilder &MIRBuilder,
       SPIRV::StorageClass::StorageClass SClass = SPIRV::StorageClass::Function);

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -162,6 +162,9 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
   getActionDefinitionsBuilder({G_MEMCPY, G_MEMMOVE})
       .legalIf(all(typeInSet(0, allWritablePtrs), typeInSet(1, allPtrs)));
 
+  getActionDefinitionsBuilder(G_MEMSET)
+      .legalIf(all(typeInSet(0, allWritablePtrs), typeInSet(1, allIntScalars)));
+
   getActionDefinitionsBuilder(G_ADDRSPACE_CAST)
       .legalForCartesianProduct(allPtrs, allPtrs);
 

--- a/llvm/lib/Target/SPIRV/SPIRVPrepareFunctions.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPrepareFunctions.cpp
@@ -18,6 +18,7 @@
 #include "SPIRV.h"
 #include "SPIRVTargetMachine.h"
 #include "SPIRVUtils.h"
+#include "llvm/CodeGen/IntrinsicLowering.h"
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/Utils/LowerMemIntrinsics.h"
@@ -140,6 +141,69 @@ static Function *getOrCreateFunction(Module *M, Type *RetTy,
   return NewF;
 }
 
+static void lowerIntrinsicToFunction(Module *M, IntrinsicInst *Intrinsic) {
+  // For @llvm.memset.* intrinsic cases with constant value and length arguments
+  // are emulated via "storing" a constant array to the destination. For other
+  // cases we wrap the intrinsic in @spirv.llvm_memset_* function and expand the
+  // intrinsic to a loop via expandMemSetAsLoop().
+  if (auto *MSI = dyn_cast<MemSetInst>(Intrinsic))
+    if (isa<Constant>(MSI->getValue()) && isa<ConstantInt>(MSI->getLength()))
+      return; // It is handled later using OpCopyMemorySized.
+
+  std::string FuncName = lowerLLVMIntrinsicName(Intrinsic);
+  if (Intrinsic->isVolatile())
+    FuncName += ".volatile";
+  // Redirect @llvm.intrinsic.* call to @spirv.llvm_intrinsic_*
+  Function *F = M->getFunction(FuncName);
+  if (F) {
+    Intrinsic->setCalledFunction(F);
+    return;
+  }
+  // TODO copy arguments attributes: nocapture writeonly.
+  FunctionCallee FC =
+      M->getOrInsertFunction(FuncName, Intrinsic->getFunctionType());
+  auto IntrinsicID = Intrinsic->getIntrinsicID();
+  Intrinsic->setCalledFunction(FC);
+
+  F = dyn_cast<Function>(FC.getCallee());
+  assert(F && "Callee must be a function");
+
+  switch (IntrinsicID) {
+  case Intrinsic::memset: {
+    auto *MSI = static_cast<MemSetInst *>(Intrinsic);
+    Argument *Dest = F->getArg(0);
+    Argument *Val = F->getArg(1);
+    Argument *Len = F->getArg(2);
+    Argument *IsVolatile = F->getArg(3);
+    Dest->setName("dest");
+    Val->setName("val");
+    Len->setName("len");
+    IsVolatile->setName("isvolatile");
+    BasicBlock *EntryBB = BasicBlock::Create(M->getContext(), "entry", F);
+    IRBuilder<> IRB(EntryBB);
+    auto *MemSet = IRB.CreateMemSet(Dest, Val, Len, MSI->getDestAlign(),
+                                    MSI->isVolatile());
+    IRB.CreateRetVoid();
+    expandMemSetAsLoop(cast<MemSetInst>(MemSet));
+    MemSet->eraseFromParent();
+    break;
+  }
+  case Intrinsic::bswap: {
+    BasicBlock *EntryBB = BasicBlock::Create(M->getContext(), "entry", F);
+    IRBuilder<> IRB(EntryBB);
+    auto *BSwap = IRB.CreateIntrinsic(Intrinsic::bswap, Intrinsic->getType(),
+                                      F->getArg(0));
+    IRB.CreateRet(BSwap);
+    IntrinsicLowering IL(M->getDataLayout());
+    IL.LowerIntrinsicCall(BSwap);
+    break;
+  }
+  default:
+    break;
+  }
+  return;
+}
+
 static void lowerFunnelShifts(Module *M, IntrinsicInst *FSHIntrinsic) {
   // Get a separate function - otherwise, we'd have to rework the CFG of the
   // current one. Then simply replace the intrinsic uses with a call to the new
@@ -247,8 +311,11 @@ static void substituteIntrinsicCalls(Module *M, Function *F) {
       if (!CF || !CF->isIntrinsic())
         continue;
       auto *II = cast<IntrinsicInst>(Call);
-      if (II->getIntrinsicID() == Intrinsic::fshl ||
-          II->getIntrinsicID() == Intrinsic::fshr)
+      if (II->getIntrinsicID() == Intrinsic::memset ||
+          II->getIntrinsicID() == Intrinsic::bswap)
+        lowerIntrinsicToFunction(M, II);
+      else if (II->getIntrinsicID() == Intrinsic::fshl ||
+               II->getIntrinsicID() == Intrinsic::fshr)
         lowerFunnelShifts(M, II);
       else if (II->getIntrinsicID() == Intrinsic::umul_with_overflow)
         lowerUMulWithOverflow(M, II);

--- a/llvm/test/CodeGen/SPIRV/llvm-intrinsics/memset.ll
+++ b/llvm/test/CodeGen/SPIRV/llvm-intrinsics/memset.ll
@@ -1,20 +1,20 @@
 ; RUN: llc -O0 %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
 ; CHECK-SPIRV: OpDecorate %[[#NonConstMemset:]] LinkageAttributes "spirv.llvm_memset_p3i8_i32"
+; CHECK-SPIRV: %[[Int32:[0-9]+]] = OpTypeInt 32 0
 ; CHECK-SPIRV: %[[Int8:[0-9]+]] = OpTypeInt 8 0
-; CHECK-SPIRV: %[[Lenmemset21:[0-9]+]] = OpConstant %{{[0-9]+}} 4
-; CHECK-SPIRV: %[[Lenmemset0:[0-9]+]] = OpConstant %{{[0-9]+}} 12
-; CHECK-SPIRV: %[[Const21:[0-9]+]] = OpConstant %{{[0-9]+}} 21
-; CHECK-SPIRV: %[[Int8x4:[0-9]+]] = OpTypeArray %[[Int8]] %[[Lenmemset21]]
 ; CHECK-SPIRV: %[[Int8Ptr:[0-9]+]] = OpTypePointer Generic %[[Int8]]
-; CHECK-SPIRV: %[[Int8x12:[0-9]+]] = OpTypeArray %[[Int8]] %[[Lenmemset0]]
+; CHECK-SPIRV: %[[Lenmemset21:[0-9]+]] = OpConstant %{{[0-9]+}} 4
+; CHECK-SPIRV: %[[Int8x4:[0-9]+]] = OpTypeArray %[[Int8]] %[[Lenmemset21]]
 ; CHECK-SPIRV: %[[Int8PtrConst:[0-9]+]] = OpTypePointer UniformConstant %[[Int8]]
-
-; CHECK-SPIRV: %[[Init:[0-9]+]] = OpConstantNull %[[Int8x12]]
-; CHECK-SPIRV: %[[Val:[0-9]+]] = OpVariable %{{[0-9]+}} UniformConstant %[[Init]]
-; CHECK-SPIRV: %[[InitComp:[0-9]+]] = OpConstantComposite %[[Int8x4]] %[[Const21]] %[[Const21]] %[[Const21]] %[[Const21]]
-; CHECK-SPIRV: %[[ValComp:[0-9]+]] = OpVariable %{{[0-9]+}} UniformConstant %[[InitComp]]
+; CHECK-SPIRV: %[[Lenmemset0:[0-9]+]] = OpConstant %[[Int32]] 12
+; CHECK-SPIRV: %[[Int8x12:[0-9]+]] = OpTypeArray %[[Int8]] %[[Lenmemset0]]
+; CHECK-SPIRV: %[[Const21:[0-9]+]] = OpConstant %{{[0-9]+}} 21
 ; CHECK-SPIRV: %[[#False:]] = OpConstantFalse %[[#]]
+; CHECK-SPIRV: %[[InitComp:[0-9]+]] = OpConstantComposite %[[Int8x4]] %[[Const21]] %[[Const21]] %[[Const21]] %[[Const21]]
+; CHECK-SPIRV: %[[Init:[0-9]+]] = OpConstantNull %[[Int8x12]]
+; CHECK-SPIRV: %[[ValComp:[0-9]+]] = OpVariable %{{[0-9]+}} UniformConstant %[[InitComp]]
+; CHECK-SPIRV: %[[Val:[0-9]+]] = OpVariable %{{[0-9]+}} UniformConstant %[[Init]]
 
 ; CHECK-SPIRV: %[[Target:[0-9]+]] = OpBitcast %[[Int8Ptr]] %{{[0-9]+}}
 ; CHECK-SPIRV: %[[Source:[0-9]+]] = OpBitcast %[[Int8PtrConst]] %[[Val]]


### PR DESCRIPTION
The patch adds support for llvm.memset and llvm.bswap intrinsics as it's done in the translator. Missed format errors were fixed in SPIRVGlobalRegistry. Also one LIT test (llvm-intrinsics/memset.ll) is corrected.

Two LIT tests (llvm-intrinsics/bswap.ll, llvm-intrinsics/memset.ll) are expected to pass.