### PR TITLE
[SPIR-V] add alloca intrinsic and correct ndrange_* builtins

### DIFF
--- a/llvm/include/llvm/IR/IntrinsicsSPIRV.td
+++ b/llvm/include/llvm/IR/IntrinsicsSPIRV.td
@@ -30,4 +30,5 @@ let TargetPrefix = "spv" in {
   def int_spv_switch : Intrinsic<[], [llvm_any_ty, llvm_vararg_ty]>;
   def int_spv_cmpxchg : Intrinsic<[llvm_i32_ty], [llvm_any_ty, llvm_vararg_ty]>;
   def int_spv_unreachable : Intrinsic<[], []>;
+  def int_spv_alloca : Intrinsic<[llvm_any_ty], []>;
 }

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -248,6 +248,11 @@ private:
                                          const SPIRVInstrInfo &TII,
                                          Constant *CA, unsigned BitWidth,
                                          unsigned ElemCnt);
+  Register getOrCreateIntCompositeOrNull(uint64_t Val,
+                                         MachineIRBuilder &MIRBuilder,
+                                         SPIRVType *SpvType, bool EmitIR,
+                                         Constant *CA, unsigned BitWidth,
+                                         unsigned ElemCnt);
 
 public:
   Register buildConstantInt(uint64_t Val, MachineIRBuilder &MIRBuilder,
@@ -256,14 +261,16 @@ public:
                                SPIRVType *SpvType, const SPIRVInstrInfo &TII);
   Register buildConstantFP(APFloat Val, MachineIRBuilder &MIRBuilder,
                            SPIRVType *SpvType = nullptr);
-  Register buildConstantIntVector(uint64_t Val, MachineIRBuilder &MIRBuilder,
-                                  SPIRVType *SpvType, bool EmitIR = true);
   Register getOrCreateConsIntVector(uint64_t Val, MachineInstr &I,
                                     SPIRVType *SpvType,
                                     const SPIRVInstrInfo &TII);
   Register getOrCreateConsIntArray(uint64_t Val, MachineInstr &I,
                                    SPIRVType *SpvType,
                                    const SPIRVInstrInfo &TII);
+  Register getOrCreateConsIntVector(uint64_t Val, MachineIRBuilder &MIRBuilder,
+                                    SPIRVType *SpvType, bool EmitIR = true);
+  Register getOrCreateConsIntArray(uint64_t Val, MachineIRBuilder &MIRBuilder,
+                                   SPIRVType *SpvType, bool EmitIR = true);
   Register buildConstantSampler(Register Res, unsigned AddrMode, unsigned Param,
                                 unsigned FilerMode,
                                 MachineIRBuilder &MIRBuilder,

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -1464,6 +1464,9 @@ bool SPIRVInstructionSelector::selectIntrinsic(Register ResVReg,
   case Intrinsic::spv_unreachable:
     BuildMI(BB, I, I.getDebugLoc(), TII.get(SPIRV::OpUnreachable));
     break;
+  case Intrinsic::spv_alloca:
+    return selectFrameIndex(ResVReg, ResType, I);
+    break;
   default:
     llvm_unreachable("Intrinsic selection not implemented");
   }

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -283,8 +283,8 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
   // Pointer-handling.
   getActionDefinitionsBuilder(G_FRAME_INDEX).legalFor({p0});
 
-  // Control-flow.
-  getActionDefinitionsBuilder(G_BRCOND).legalFor({s1});
+  // Control-flow. In some cases (e.g. constants) s1 may be promoted to s32
+  getActionDefinitionsBuilder(G_BRCOND).legalFor({s1, s32});
 
   getActionDefinitionsBuilder({G_FPOW,
                                G_FEXP,

--- a/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
+++ b/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
@@ -1533,3 +1533,4 @@ multiclass OpcodeOperand<bits<32> value> {
 // TODO: implement other mnemonics.
 defm InBoundsPtrAccessChain : OpcodeOperand<70>;
 defm PtrCastToGeneric : OpcodeOperand<121>;
+defm Bitcast : OpcodeOperand<124>;

--- a/llvm/test/CodeGen/SPIRV/opencl/device_execution/execute_block.ll
+++ b/llvm/test/CodeGen/SPIRV/opencl/device_execution/execute_block.ll
@@ -1,0 +1,120 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s
+
+; CHECK: %[[#bool:]] = OpTypeBool
+; CHECK: %[[#true:]] = OpConstantTrue %[[#bool]]
+; CHECK: OpBranchConditional %[[#true]]
+
+%structtype = type { i32, i32, i8 addrspace(4)* }
+%structtype.0 = type <{ i32, i32, i8 addrspace(4)* }>
+
+@__block_literal_global = internal addrspace(1) constant %structtype { i32 16, i32 8, i8 addrspace(4)* addrspacecast (i8* null to i8 addrspace(4)*) }, align 8
+@__block_literal_global.1 = internal addrspace(1) constant %structtype { i32 16, i32 8, i8 addrspace(4)* addrspacecast (i8* null to i8 addrspace(4)*) }, align 8
+@__block_literal_global.2 = internal addrspace(1) constant %structtype { i32 16, i32 8, i8 addrspace(4)* addrspacecast (i8* null to i8 addrspace(4)*) }, align 8
+
+; Function Attrs: nounwind
+define spir_kernel void @block_typedef_mltpl_stmnt(i32 addrspace(1)* %res) #0 {
+entry:
+  %0 = call spir_func <3 x i64> @BuiltInGlobalInvocationId() #1
+  %call = extractelement <3 x i64> %0, i32 0
+  %arrayidx = getelementptr inbounds i32, i32 addrspace(1)* %res, i64 %call
+  store i32 -1, i32 addrspace(1)* %arrayidx, align 4
+  %1 = bitcast %structtype addrspace(1)* @__block_literal_global to i8 addrspace(1)*
+  %2 = addrspacecast i8 addrspace(1)* %1 to i8 addrspace(4)*
+  %3 = bitcast %structtype addrspace(1)* @__block_literal_global.1 to i8 addrspace(1)*
+  %4 = addrspacecast i8 addrspace(1)* %3 to i8 addrspace(4)*
+  %5 = bitcast %structtype addrspace(1)* @__block_literal_global.2 to i8 addrspace(1)*
+  %6 = addrspacecast i8 addrspace(1)* %5 to i8 addrspace(4)*
+  br label %do.body
+
+do.body:                                          ; preds = %do.cond, %entry
+  %a.0 = phi i32 [ undef, %entry ], [ %a.1, %do.cond ]
+  %call1 = call spir_func float @__block_typedef_mltpl_stmnt_block_invoke(i8 addrspace(4)* %2, float 0.000000e+00) #0
+  %call2 = call spir_func i32 @__block_typedef_mltpl_stmnt_block_invoke_2(i8 addrspace(4)* %4, i32 0) #0
+  %conv = sitofp i32 %call2 to float
+  %sub = fsub float %call1, %conv
+  %cmp = fcmp ogt float %sub, 0.000000e+00
+  br i1 %cmp, label %if.then, label %if.end
+
+if.then:                                          ; preds = %do.body
+  %call4 = call spir_func i32 @__block_typedef_mltpl_stmnt_block_invoke_3(i8 addrspace(4)* %6, i32 1) #0
+  %call5 = call spir_func i32 @__block_typedef_mltpl_stmnt_block_invoke_3(i8 addrspace(4)* %6, i32 2) #0
+  %add = add i32 %call4, %call5
+  br label %cleanup
+
+if.end:                                           ; preds = %do.body
+  br label %cleanup
+
+cleanup:                                          ; preds = %if.end, %if.then
+  %a.1 = phi i32 [ %add, %if.then ], [ %a.0, %if.end ]
+  %cleanup.dest.slot.0 = phi i32 [ 2, %if.then ], [ 0, %if.end ]
+  switch i32 %cleanup.dest.slot.0, label %unreachable [
+    i32 0, label %cleanup.cont
+    i32 2, label %do.end
+  ]
+
+cleanup.cont:                                     ; preds = %cleanup
+  br label %do.cond
+
+do.cond:                                          ; preds = %cleanup.cont
+  br i1 true, label %do.body, label %do.end
+
+do.end:                                           ; preds = %do.cond, %cleanup
+  %sub7 = sub nsw i32 %a.1, 11
+  %arrayidx8 = getelementptr inbounds i32, i32 addrspace(1)* %res, i64 %call
+  store i32 %sub7, i32 addrspace(1)* %arrayidx8, align 4
+  ret void
+
+unreachable:                                      ; preds = %cleanup
+  unreachable
+}
+
+; Function Attrs: nounwind
+define internal spir_func float @__block_typedef_mltpl_stmnt_block_invoke(i8 addrspace(4)* %.block_descriptor, float %bi) #0 {
+entry:
+  %block = bitcast i8 addrspace(4)* %.block_descriptor to %structtype.0 addrspace(4)*
+  %conv = fpext float %bi to double
+  %add = fadd double %conv, 3.300000e+00
+  %conv1 = fptrunc double %add to float
+  ret float %conv1
+}
+
+; Function Attrs: nounwind
+define internal spir_func i32 @__block_typedef_mltpl_stmnt_block_invoke_2(i8 addrspace(4)* %.block_descriptor, i32 %bi) #0 {
+entry:
+  %block = bitcast i8 addrspace(4)* %.block_descriptor to %structtype.0 addrspace(4)*
+  %add = add nsw i32 %bi, 2
+  ret i32 %add
+}
+
+; Function Attrs: nounwind
+define internal spir_func i32 @__block_typedef_mltpl_stmnt_block_invoke_3(i8 addrspace(4)* %.block_descriptor, i32 %bi) #0 {
+entry:
+  %block = bitcast i8 addrspace(4)* %.block_descriptor to %structtype.0 addrspace(4)*
+  %add = add i32 %bi, 4
+  ret i32 %add
+}
+
+; Function Attrs: nounwind readnone
+declare spir_func <3 x i64> @BuiltInGlobalInvocationId() #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nounwind readnone }
+
+!opencl.kernels = !{!0}
+!opencl.spir.version = !{!166}
+!opencl.ocl.version = !{!166}
+!opencl.used.extensions = !{!167}
+!opencl.used.optional.core.features = !{!168}
+!opencl.compiler.options = !{!169}
+
+!0 = !{void (i32 addrspace(1)*)* @block_typedef_mltpl_stmnt, !1, !2, !3, !4, !5, !6}
+!1 = !{!"kernel_arg_addr_space", i32 1}
+!2 = !{!"kernel_arg_access_qual", !"none"}
+!3 = !{!"kernel_arg_type", !"int*"}
+!4 = !{!"kernel_arg_type_qual", !""}
+!5 = !{!"kernel_arg_base_type", !"int*"}
+!6 = !{!"kernel_arg_name", !"res"}
+!166 = !{i32 3, i32 0}
+!167 = !{}
+!168 = !{!"cl_doubles"}
+!169 = !{!"-cl-std=CL3.0"}


### PR DESCRIPTION
The change adds alloca intrinsic which is required to ir-translate alloca of composite objects. Also it fixes ndrange_2D/3D builtin functions support to produce the code similar to the  translator's. One LIT test is passed (transcoding/BuildNDRange_2.ll).