### PR TITLE
[SPIR-V] prepare SPIRVBuiltins for upstraming

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.cpp
@@ -22,7 +22,7 @@ void SPIRVGeneralDuplicatesTracker::prebuildReg2Entry(
     for (auto &RegPair : TPair.second) {
       const MachineFunction *MF = RegPair.first;
       Register R = RegPair.second;
-      MachineInstr *MI = MF->getRegInfo().getVRegDef(R);
+      MachineInstr *MI = MF->getRegInfo().getUniqueVRegDef(R);
       if (!MI)
         continue;
       Reg2Entry[&MI->getOperand(0)] = &TPair.second;
@@ -71,6 +71,7 @@ void SPIRVGeneralDuplicatesTracker::buildDepsGraph(
     }
   }
 
+#if !defined(NDEBUG) || defined(LLVM_ENABLE_DUMP)
   if (MMI) {
     const Module *M = MMI->getModule();
     for (auto F = M->begin(), E = M->end(); F != E; ++F) {
@@ -93,4 +94,5 @@ void SPIRVGeneralDuplicatesTracker::buildDepsGraph(
       }
     }
   }
+#endif
 }

--- a/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.h
+++ b/llvm/lib/Target/SPIRV/SPIRVDuplicatesTracker.h
@@ -302,4 +302,4 @@ public:
   const SPIRVDuplicatesTracker<Type> *getTypes() { return &TT; }
 };
 } // namespace llvm
-#endif
+#endif // LLVM_LIB_TARGET_SPIRV_SPIRVDUPLICATESTRACKER_H

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.cpp
@@ -416,7 +416,6 @@ Register SPIRVGlobalRegistry::buildConstantSampler(
                  .addImm(AddrMode)
                  .addImm(Param)
                  .addImm(FilerMode);
-  constrainRegOperands(Res);
   assert(Res->getOperand(0).isReg());
   return Res->getOperand(0).getReg();
 }
@@ -908,7 +907,6 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateOpTypeSampledImage(
   auto MIB = MIRBuilder.buildInstr(SPIRV::OpTypeSampledImage)
                  .addDef(ResVReg)
                  .addUse(getSPIRVTypeID(ImageType));
-  constrainRegOperands(MIB);
   DT.add(TD, &MIRBuilder.getMF(), ResVReg);
 
   return MIB;
@@ -1008,6 +1006,7 @@ SPIRVType *SPIRVGlobalRegistry::getOrCreateOpenCLOpaqueType(
   }
 }
 
+// TODO: maybe use tablegen to implement this.
 SPIRVType *
 SPIRVGlobalRegistry::getOrCreateSPIRVTypeByName(StringRef TypeStr,
                                                 MachineIRBuilder &MIRBuilder) {

--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -238,11 +238,12 @@ bool SPIRVInstructionSelector::select(MachineInstr &I) {
       }
       MRI->replaceRegWith(I.getOperand(1).getReg(), I.getOperand(0).getReg());
       I.removeFromParent();
+      return true;
     } else if (I.getNumDefs() == 1) {
       // Make all vregs 32 bits (for SPIR-V IDs).
       MRI->setType(I.getOperand(0).getReg(), LLT::scalar(32));
     }
-    return true;
+    return constrainSelectedInstRegOperands(I, TII, TRI, RBI);
   }
 
   if (I.getNumOperands() != I.getNumExplicitOperands()) {
@@ -1515,7 +1516,6 @@ bool SPIRVInstructionSelector::selectBranchCond(MachineInstr &I) const {
   // basic block that LLVM would fall through to.
   const MachineInstr *NextI = I.getNextNode();
   // Check if this has already been successfully selected.
-  //   }d
   if (NextI != nullptr && NextI->getOpcode() == SPIRV::OpBranchConditional)
     return true;
   // Must be relying on implicit block fallthrough, so generate an

--- a/llvm/lib/Target/SPIRV/SPIRVSubtarget.h
+++ b/llvm/lib/Target/SPIRV/SPIRVSubtarget.h
@@ -42,9 +42,8 @@ private:
   bool OpenCLFullProfile;
   bool OpenCLImageSupport;
 
-  std::set<SPIRV::Extension::Extension> AvailableExtensions;
-  std::set<SPIRV::InstructionSet::InstructionSet> AvailableExtInstSets;
-
+  SmallSet<SPIRV::Extension::Extension, 4> AvailableExtensions;
+  SmallSet<SPIRV::InstructionSet::InstructionSet, 4> AvailableExtInstSets;
   std::unique_ptr<SPIRVGlobalRegistry> GR;
 
   SPIRVInstrInfo InstrInfo;
@@ -57,15 +56,10 @@ private:
   std::unique_ptr<LegalizerInfo> Legalizer;
   std::unique_ptr<InstructionSelector> InstSelector;
 
-private:
-  // Initialise the available extensions, extended instruction sets
-  // based on the environment settings (i.e. the previous properties of
-  // SPIRVSubtarget).
-  //
-  // These functions must be called in the order they are declared to satisfy
-  // dependencies during initialisation.
-  void initAvailableExtensions(const Triple &TT);
-  void initAvailableExtInstSets(const Triple &TT);
+  // TODO: Initialise the available extensions, extended instruction sets
+  // based on the environment settings.
+  void initAvailableExtensions();
+  void initAvailableExtInstSets();
 
 public:
   // This constructor initializes the data members to match that


### PR DESCRIPTION
The patch prepared SPIRVBuiltins.cpp for upstraming. Also it unifies some code between llvm-project and this repo. No changes in testing are expected.