### PR TITLE
[SPIR-V] prepare SPIRVBuiltins for upstraming 2

### DIFF
--- a/llvm/lib/Target/SPIRV/CMakeLists.txt
+++ b/llvm/lib/Target/SPIRV/CMakeLists.txt
@@ -38,10 +38,12 @@ add_llvm_target(SPIRVCodeGen
   SPIRVUtils.cpp
 
   LINK_COMPONENTS
-  AsmPrinter
   Analysis
+  AsmPrinter
   CodeGen
   Core
+  Demangle
+  GlobalISel
   MC
   SPIRVDesc
   SPIRVInfo
@@ -49,8 +51,6 @@ add_llvm_target(SPIRVCodeGen
   Support
   Target
   TransformUtils
-  GlobalISel
-  Demangle
 
   ADD_TO_COMPONENT
   SPIRV

--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.h
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.h
@@ -21,18 +21,18 @@ namespace llvm {
 /// Lowers a builtin funtion call using the provided \p DemangledCall skeleton
 /// and external instruction \p Set.
 ///
-/// \return True if the lowering has succeeded, false otherwise.
+/// \return a pair of boolean values, the first true means the call recognized
+/// as a builtin, the second one indicates the successful lowering.
 ///
 /// \p DemangledCall is the skeleton of the lowered builtin function call.
 /// \p Set is the external instruction set containing the given builtin.
 /// \p OrigRet is the single original virtual return register if defined,
 /// Register(0) otherwise. \p OrigRetTy is the type of the \p OrigRet. \p Args
 /// are the arguments of the lowered builtin call.
-bool lowerBuiltin(const StringRef DemangledCall,
-                  SPIRV::InstructionSet::InstructionSet Set,
-                  MachineIRBuilder &MIRBuilder, const Register OrigRet,
-                  const Type *OrigRetTy, const SmallVectorImpl<Register> &Args,
-                  SPIRVGlobalRegistry *GR);
+std::pair<bool, bool> lowerBuiltin(
+    const StringRef DemangledCall, SPIRV::InstructionSet::InstructionSet Set,
+    MachineIRBuilder &MIRBuilder, const Register OrigRet, const Type *OrigRetTy,
+    const SmallVectorImpl<Register> &Args, SPIRVGlobalRegistry *GR);
 
 } // end namespace llvm
 #endif // LLVM_LIB_TARGET_SPIRV_SPIRVBUILTINS_H

--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -292,13 +292,14 @@ bool SPIRVCallLowering::lowerCall(MachineIRBuilder &MIRBuilder,
       for (auto Arg : Info.OrigArgs) {
         assert(Arg.Regs.size() == 1 && "Call arg has multiple VRegs");
         ArgVRegs.push_back(Arg.Regs[0]);
-        auto SPIRVTy = GR->getOrCreateSPIRVType(Arg.Ty, MIRBuilder);
+        SPIRVType *SPIRVTy = GR->getOrCreateSPIRVType(Arg.Ty, MIRBuilder);
         GR->assignSPIRVTypeToVReg(SPIRVTy, Arg.Regs[0], MIRBuilder.getMF());
       }
-      return lowerBuiltin(DemangledName, SPIRV::InstructionSet::OpenCL_std,
-                          MIRBuilder, ResVReg, OrigRetTy, ArgVRegs, GR);
+      auto Res = lowerBuiltin(DemangledName, SPIRV::InstructionSet::OpenCL_std,
+                              MIRBuilder, ResVReg, OrigRetTy, ArgVRegs, GR);
+      if (Res.first)
+        return Res.second;
     }
-    llvm_unreachable("Unable to handle this environment's built-in funcs.");
   }
 
   if (CF && CF->isDeclaration() &&


### PR DESCRIPTION
The patch contains additional changes in SPIRVBuiltins for upstreaming. Also it changes lowerBuiltin() interface to return a pair of boolean values. If a DemangledCall is not found in the TableGen records, it is processed as a regular function call. Two LIT tests are passed (llvm-intrinsics/expect.ll, mangled_function.ll).
