### PR TITLE
[SPIR-V] Parse builtin opaque types using TableGen

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.cpp
@@ -1612,4 +1612,234 @@ std::pair<bool, bool> lowerBuiltin(
   }
   return {true, false};
 }
+
+namespace SPIRV {
+struct DemangledType {
+  StringRef Name;
+  uint32_t Opcode;
+};
+
+#define GET_DemangledTypes_DECL
+#define GET_DemangledTypes_IMPL
+
+struct ImageType {
+  StringRef Name;
+  StringRef SampledType;
+  AccessQualifier::AccessQualifier Qualifier;
+  Dim::Dim Dimensionality;
+  bool Arrayed;
+  bool Depth;
+  bool Multisampled;
+  bool Sampled;
+  ImageFormat::ImageFormat Format;
+};
+
+struct PipeType {
+  StringRef Name;
+  AccessQualifier::AccessQualifier Qualifier;
+};
+
+using namespace AccessQualifier;
+using namespace Dim;
+using namespace ImageFormat;
+#define GET_ImageTypes_DECL
+#define GET_ImageTypes_IMPL
+#define GET_PipeTypes_DECL
+#define GET_PipeTypes_IMPL
+#include "SPIRVGenTables.inc"
+} // namespace SPIRV
+
+//===----------------------------------------------------------------------===//
+// Misc functions for parsing builtin types and looking up implementation
+// details in TableGenerated tables.
+//===----------------------------------------------------------------------===//
+
+static const SPIRV::DemangledType *lookupBuiltinType(StringRef Name) {
+  if (Name.startswith("opencl.")) {
+    return SPIRV::lookupBuiltinType(Name);
+  } else if (Name.startswith("spirv.")) {
+    // Some SPIR-V builtin types have a complex list of parameters as part of
+    // their name (e.g. spirv.Image._void_1_0_0_0_0_0_0). Those parameters often
+    // are numeric literals which cannot be easily represented by TableGen
+    // records and should be parsed instead.
+    unsigned BaseTypeNameLength =
+        Name.contains('_') ? Name.find('_') - 1 : Name.size();
+    return SPIRV::lookupBuiltinType(Name.substr(0, BaseTypeNameLength).str());
+  }
+  return nullptr;
+}
+
+static std::unique_ptr<const SPIRV::ImageType>
+lookupOrParseBuiltinImageType(StringRef Name) {
+  if (Name.startswith("opencl.")) {
+    // Lookup OpenCL builtin image type lowering details in TableGen records.
+    const SPIRV::ImageType *Record = SPIRV::lookupImageType(Name);
+    return std::unique_ptr<SPIRV::ImageType>(new SPIRV::ImageType(*Record));
+  } else if (Name.startswith("spirv.")) {
+    // Parse the literals of SPIR-V image builtin parameters. The name should
+    // have the following format:
+    // spirv.Image._Type_Dim_Depth_Arrayed_MS_Sampled_ImageFormat_AccessQualifier
+    // e.g. %spirv.Image._void_1_0_0_0_0_0_0
+    StringRef TypeParametersString = Name.substr(strlen("spirv.Image."));
+    SmallVector<StringRef> TypeParameters;
+    SplitString(TypeParametersString, TypeParameters, "_");
+    assert(TypeParameters.size() == 8 &&
+           "Wrong number of literals in SPIR-V builtin image type");
+
+    StringRef SampledType = TypeParameters[0];
+    unsigned Dim, Depth, Arrayed, Multisampled, Sampled, Format, AccessQual;
+    bool AreParameterLiteralsValid =
+        !(TypeParameters[1].getAsInteger(10, Dim) ||
+          TypeParameters[2].getAsInteger(10, Depth) ||
+          TypeParameters[3].getAsInteger(10, Arrayed) ||
+          TypeParameters[4].getAsInteger(10, Multisampled) ||
+          TypeParameters[5].getAsInteger(10, Sampled) ||
+          TypeParameters[6].getAsInteger(10, Format) ||
+          TypeParameters[7].getAsInteger(10, AccessQual));
+    assert(AreParameterLiteralsValid &&
+           "Invalid format of SPIR-V image type parameter literals.");
+
+    return std::unique_ptr<SPIRV::ImageType>(new SPIRV::ImageType{
+        Name, SampledType, SPIRV::AccessQualifier::AccessQualifier(AccessQual),
+        SPIRV::Dim::Dim(Dim), static_cast<bool>(Arrayed),
+        static_cast<bool>(Depth), static_cast<bool>(Multisampled),
+        static_cast<bool>(Sampled), SPIRV::ImageFormat::ImageFormat(Format)});
+  }
+  llvm_unreachable("Unknown builtin image type name/literal");
+}
+
+static std::unique_ptr<const SPIRV::PipeType>
+lookupOrParseBuiltinPipeType(StringRef Name) {
+  if (Name.startswith("opencl.")) {
+    // Lookup OpenCL builtin pipe type lowering details in TableGen records.
+    const SPIRV::PipeType *Record = SPIRV::lookupPipeType(Name);
+    return std::unique_ptr<SPIRV::PipeType>(new SPIRV::PipeType(*Record));
+  } else if (Name.startswith("spirv.")) {
+    // Parse the access qualifier literal in the name of the SPIR-V pipe type.
+    // The name should have the following format:
+    // spirv.Pipe._AccessQualifier
+    // e.g. %spirv.Pipe._1
+    if (Name.endswith("_0"))
+      return std::unique_ptr<SPIRV::PipeType>(
+          new SPIRV::PipeType{Name, SPIRV::AccessQualifier::ReadOnly});
+    else if (Name.endswith("_1"))
+      return std::unique_ptr<SPIRV::PipeType>(
+          new SPIRV::PipeType{Name, SPIRV::AccessQualifier::WriteOnly});
+    else if (Name.endswith("_2"))
+      return std::unique_ptr<SPIRV::PipeType>(
+          new SPIRV::PipeType{Name, SPIRV::AccessQualifier::ReadWrite});
+    else
+      llvm_unreachable("Unknown pipe type access qualifier literal");
+  }
+  llvm_unreachable("Unknown builtin pipe type name/literal");
+}
+
+//===----------------------------------------------------------------------===//
+// Implementation functions for builtin types.
+//===----------------------------------------------------------------------===//
+
+SPIRVType *getNonParametrizedType(const StructType *OpaqueType,
+                                  const SPIRV::DemangledType *TypeRecord,
+                                  MachineIRBuilder &MIRBuilder,
+                                  SPIRVGlobalRegistry *GR) {
+  unsigned Opcode = TypeRecord->Opcode;
+  // Create or get an existing type from GlobalRegistry.
+  return GR->getOrCreateOpTypeByOpcode(OpaqueType, MIRBuilder, Opcode);
+}
+
+SPIRVType *getSamplerType(MachineIRBuilder &MIRBuilder,
+                          SPIRVGlobalRegistry *GR) {
+  // Create or get an existing type from GlobalRegistry.
+  return GR->getOrCreateOpTypeSampler(MIRBuilder);
+}
+
+SPIRVType *getPipeType(const StructType *OpaqueType,
+                       MachineIRBuilder &MIRBuilder, SPIRVGlobalRegistry *GR) {
+  // Lookup pipe type lowering details in TableGen records or parse the
+  // name/literal for details.
+  std::unique_ptr<const SPIRV::PipeType> Record =
+      lookupOrParseBuiltinPipeType(OpaqueType->getName());
+  // Create or get an existing type from GlobalRegistry.
+  return GR->getOrCreateOpTypePipe(MIRBuilder, Record.get()->Qualifier);
+}
+
+SPIRVType *getImageType(const StructType *OpaqueType,
+                        SPIRV::AccessQualifier::AccessQualifier AccessQual,
+                        MachineIRBuilder &MIRBuilder, SPIRVGlobalRegistry *GR) {
+  // Lookup image type lowering details in TableGen records or parse the
+  // name/literal for details.
+  std::unique_ptr<const SPIRV::ImageType> Record =
+      lookupOrParseBuiltinImageType(OpaqueType->getName());
+
+  SPIRVType *SampledType =
+      GR->getOrCreateSPIRVTypeByName(Record.get()->SampledType, MIRBuilder);
+  return GR->getOrCreateOpTypeImage(
+      MIRBuilder, SampledType, Record.get()->Dimensionality,
+      Record.get()->Depth, Record.get()->Arrayed, Record.get()->Multisampled,
+      Record.get()->Sampled, Record.get()->Format,
+      AccessQual == SPIRV::AccessQualifier::WriteOnly
+          ? SPIRV::AccessQualifier::WriteOnly
+          : Record.get()->Qualifier);
+}
+
+SPIRVType *getSampledImageType(const StructType *OpaqueType,
+                               MachineIRBuilder &MIRBuilder,
+                               SPIRVGlobalRegistry *GR) {
+  StringRef TypeParametersString =
+      OpaqueType->getName().substr(strlen("spirv.SampledImage."));
+  LLVMContext &Context = MIRBuilder.getMF().getFunction().getContext();
+  Type *ImageOpaqueType = StructType::getTypeByName(
+      Context, "spirv.Image." + TypeParametersString.str());
+  SPIRVType *TargetImageType =
+      GR->getOrCreateSPIRVType(ImageOpaqueType, MIRBuilder);
+  return GR->getOrCreateOpTypeSampledImage(TargetImageType, MIRBuilder);
+}
+
+SPIRVType *lowerBuiltinType(const StructType *OpaqueType,
+                            SPIRV::AccessQualifier::AccessQualifier AccessQual,
+                            MachineIRBuilder &MIRBuilder,
+                            SPIRVGlobalRegistry *GR) {
+  assert(OpaqueType->hasName() &&
+         "Structs representing builtin types must have a parsable name");
+  unsigned NumStartingVRegs = MIRBuilder.getMRI()->getNumVirtRegs();
+
+  const StringRef Name = OpaqueType->getName();
+  LLVM_DEBUG(dbgs() << "Lowering builtin type: " << Name << "\n");
+
+  // Lookup the demangled builtin type in the TableGen records.
+  const SPIRV::DemangledType *TypeRecord = lookupBuiltinType(Name);
+  if (!TypeRecord)
+    report_fatal_error("Missing TableGen record for builtin type: " + Name);
+
+  // "Lower" the BuiltinType into TargetType. The following get<...>Type methods
+  // use the implementation details from TableGen records to either create a new
+  // OpType<...> machine instruction or get an existing equivalent SPIRVType
+  // from GlobalRegistry.
+  SPIRVType *TargetType;
+  switch (TypeRecord->Opcode) {
+  case SPIRV::OpTypeImage: {
+    TargetType = getImageType(OpaqueType, AccessQual, MIRBuilder, GR);
+  } break;
+  case SPIRV::OpTypePipe: {
+    TargetType = getPipeType(OpaqueType, MIRBuilder, GR);
+  } break;
+  case SPIRV::OpTypeSampler: {
+    TargetType = getSamplerType(MIRBuilder, GR);
+  } break;
+  case SPIRV::OpTypeSampledImage: {
+    TargetType = getSampledImageType(OpaqueType, MIRBuilder, GR);
+  } break;
+  default: {
+    TargetType = getNonParametrizedType(OpaqueType, TypeRecord, MIRBuilder, GR);
+  } break;
+  }
+
+  // Emit OpName instruction if a new OpType<...> instruction was added
+  // (equivalent type was not found in GlobalRegistry).
+  if (NumStartingVRegs < MIRBuilder.getMRI()->getNumVirtRegs())
+    buildOpName(GR->getSPIRVTypeID(TargetType), OpaqueType->getName(),
+                MIRBuilder);
+
+  return TargetType;
+}
 } // namespace llvm

--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.h
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.h
@@ -21,18 +21,31 @@ namespace llvm {
 /// Lowers a builtin funtion call using the provided \p DemangledCall skeleton
 /// and external instruction \p Set.
 ///
-/// \return a pair of boolean values, the first true means the call recognized
+/// \return A pair of boolean values, the first true means the call recognized
 /// as a builtin, the second one indicates the successful lowering.
 ///
 /// \p DemangledCall is the skeleton of the lowered builtin function call.
 /// \p Set is the external instruction set containing the given builtin.
 /// \p OrigRet is the single original virtual return register if defined,
-/// Register(0) otherwise. \p OrigRetTy is the type of the \p OrigRet. \p Args
-/// are the arguments of the lowered builtin call.
+/// Register(0) otherwise. 
+/// \p OrigRetTy is the type of the \p OrigRet. 
+/// \p Args are the arguments of the lowered builtin call.
 std::pair<bool, bool> lowerBuiltin(
     const StringRef DemangledCall, SPIRV::InstructionSet::InstructionSet Set,
     MachineIRBuilder &MIRBuilder, const Register OrigRet, const Type *OrigRetTy,
     const SmallVectorImpl<Register> &Args, SPIRVGlobalRegistry *GR);
 
+/// Handles the translation of the provided special opaque/builtin type \p Type
+/// to SPIR-V type. Generates the corresponding machine instructions for the
+/// target type or gets the already existing OpType<...> register from the
+/// global registry \p GR.
+///
+/// \return A machine instruction representing the OpType<...> SPIR-V type.
+///
+/// \p Type is the special opaque/builtin type to be lowered.
+SPIRVType *lowerBuiltinType(const StructType *Type,
+                            AQ::AccessQualifier AccessQual,
+                            MachineIRBuilder &MIRBuilder,
+                            SPIRVGlobalRegistry *GR);
 } // end namespace llvm
 #endif // LLVM_LIB_TARGET_SPIRV_SPIRVBUILTINS_H

--- a/llvm/lib/Target/SPIRV/SPIRVBuiltins.td
+++ b/llvm/lib/Target/SPIRV/SPIRVBuiltins.td
@@ -1104,22 +1104,37 @@ def DemangledTypes : GenericTable {
 }
 
 // Function to lookup builtin types by their demangled name.
-def lookupType : SearchIndex {
+def lookupBuiltinType : SearchIndex {
   let Table = DemangledTypes;
   let Key = ["Name"];
 }
 
-// OpenCL builtin types:
 def : DemangledType<"opencl.reserve_id_t", OpTypeReserveId>;
 def : DemangledType<"opencl.event_t", OpTypeEvent>;
 def : DemangledType<"opencl.queue_t", OpTypeQueue>;
 def : DemangledType<"opencl.sampler_t", OpTypeSampler>;
 def : DemangledType<"opencl.clk_event_t", OpTypeDeviceEvent>;
-def : DemangledType<"opencl.clk_event_t", OpTypeDeviceEvent>;
+
+def : DemangledType<"spirv.ReserveId", OpTypeReserveId>;
+def : DemangledType<"spirv.PipeStorage", OpTypePipeStorage>;
+def : DemangledType<"spirv.Queue", OpTypeQueue>;
+def : DemangledType<"spirv.Event", OpTypeEvent>;
+def : DemangledType<"spirv.Sampler", OpTypeSampler>;
+def : DemangledType<"spirv.DeviceEvent", OpTypeDeviceEvent>;
+
+// Some SPIR-V builtin types (e.g. spirv.Image) have a complex list of
+// parameters as part of their name. Some of those parameters should be treated
+// as numeric literals and therefore they cannot be represented in TableGen and
+// should be parsed instead.
+def : DemangledType<"spirv.Image", OpTypeImage>;
+def : DemangledType<"spirv.SampledImage", OpTypeSampledImage>;
+def : DemangledType<"spirv.Pipe", OpTypePipe>;
+
 
 // Class definining lowering details for various variants of image type indentifiers.
 class ImageType<string name> {
   string Name = name;
+  string Type = "void";
   AccessQualifier Qualifier = !cond(!not(!eq(!find(name, "_ro_t"), -1)) : ReadOnly,
                                   !not(!eq(!find(name, "_wo_t"), -1)) : WriteOnly,
                                   !not(!eq(!find(name, "_rw_t"), -1)) : ReadWrite,
@@ -1130,14 +1145,19 @@ class ImageType<string name> {
                                   !not(!eq(!find(name, "image3"), -1)) : DIM_3D);
   bit Arrayed = !not(!eq(!find(name, "array"), -1));
   bit Depth = !not(!eq(!find(name, "depth"), -1));
+  bit Multisampled = false;
+  bit Sampled = false;
+  ImageFormat Format = Unknown;
 }
 
 // Table gathering all the image type records.
 def ImageTypes : GenericTable {
   let FilterClass = "ImageType";
-  let Fields = ["Name", "Qualifier", "Dimensionality", "Arrayed", "Depth"];
+  let Fields = ["Name", "Type", "Qualifier", "Dimensionality", "Arrayed",
+                "Depth", "Multisampled", "Sampled", "Format"];
   string TypeOf_Qualifier = "AccessQualifier";
   string TypeOf_Dimensionality = "Dim";
+  string TypeOf_Format = "ImageFormat";
 }
 
 // Function to lookup builtin image types by their demangled name.

--- a/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
+++ b/llvm/lib/Target/SPIRV/SPIRVGlobalRegistry.h
@@ -216,28 +216,9 @@ private:
                                const SmallVectorImpl<SPIRVType *> &ArgTypes,
                                MachineIRBuilder &MIRBuilder);
 
-  SPIRVType *getOpTypeByOpcode(const Type *Ty, MachineIRBuilder &MIRBuilder,
-                               unsigned Opcode);
   SPIRVType *getOrCreateSpecialType(const Type *Ty,
                                     MachineIRBuilder &MIRBuilder,
                                     AQ::AccessQualifier AccQual);
-
-  SPIRVType *handleOpenCLBuiltin(const StructType *Ty,
-                                 MachineIRBuilder &MIRBuilder,
-                                 AQ::AccessQualifier AccQual);
-
-  SPIRVType *
-  getOrCreateOpenCLOpaqueType(const StructType *Ty,
-                              MachineIRBuilder &MIRBuilder,
-                              AQ::AccessQualifier AccQual = AQ::ReadWrite);
-
-  SPIRVType *handleSPIRVBuiltin(const StructType *Ty,
-                                MachineIRBuilder &MIRBuilder,
-                                AQ::AccessQualifier AccQual);
-
-  SPIRVType *
-  getOrCreateSPIRVOpaqueType(const StructType *Ty, MachineIRBuilder &MIRBuilder,
-                             AQ::AccessQualifier AccQual = AQ::ReadWrite);
 
   std::tuple<Register, ConstantInt *, bool> getOrCreateConstIntReg(
       uint64_t Val, SPIRVType *SpvType, MachineIRBuilder *MIRBuilder,
@@ -329,6 +310,10 @@ public:
       const Type *Ty, SPIRVType *RetType,
       const SmallVectorImpl<SPIRVType *> &ArgTypes,
       MachineIRBuilder &MIRBuilder);
+
+  SPIRVType *getOrCreateOpTypeByOpcode(const Type *Ty,
+                                       MachineIRBuilder &MIRBuilder,
+                                       unsigned Opcode);
 };
 } // end namespace llvm
 #endif // LLLVM_LIB_TARGET_SPIRV_SPIRVTYPEMANAGER_H

--- a/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
+++ b/llvm/lib/Target/SPIRV/SPIRVSymbolicOperands.td
@@ -734,7 +734,7 @@ class ImageFormat<string name, bits<32> value> {
 }
 
 multiclass ImageFormatOperand<bits<32> value, list<Capability> reqCapabilities> {
-  def : ImageFormat<NAME, value>;
+  def NAME : ImageFormat<NAME, value>;
   defm : SymbolicOperandWithRequirements<ImageFormatOperand, value, NAME, 0, 0, [], reqCapabilities>;
 }
 


### PR DESCRIPTION
This commit moves TableGen lookup of OpenCL builtin types from SPIRVGlobalRegistry.cpp to SPIRVBuiltins.cpp, implements partial lookup and parsing of SPIR-V builtin types using TableGen, and makes getOrCreateOpTypeByOpcode method public.