### PR TITLE
[SPIR-V] convert SPIRVLowerConstExpr pass to function-level

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRV.h
+++ b/llvm/lib/Target/SPIRV/SPIRV.h
@@ -22,7 +22,7 @@ class RegisterBankInfo;
 ModulePass *createSPIRVPrepareFunctionsPass();
 FunctionPass *createSPIRVOCLRegularizerPass();
 FunctionPass *createSPIRVBasicBlockDominancePass();
-ModulePass *createSPIRVLowerConstExprLegacyPass();
+FunctionPass *createSPIRVLowerConstExprLegacyPass();
 FunctionPass *createSPIRVPreLegalizerPass();
 FunctionPass *createSPIRVEmitIntrinsicsPass(SPIRVTargetMachine *TM);
 InstructionSelector *

--- a/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVCallLowering.cpp
@@ -308,10 +308,9 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
   // Generate a SPIR-V type for the function.
   auto MRI = MIRBuilder.getMRI();
   Register FuncVReg = MRI->createGenericVirtualRegister(LLT::scalar(32));
+  MRI->setRegClass(FuncVReg, &SPIRV::IDRegClass);
   if (F.isDeclaration())
     GR->add(&F, &MIRBuilder.getMF(), FuncVReg);
-  MRI->setRegClass(FuncVReg, &SPIRV::IDRegClass);
-
   SPIRVType *RetTy = GR->getOrCreateSPIRVType(FTy->getReturnType(), MIRBuilder);
   SPIRVType *FuncTy = GR->getOrCreateOpTypeFunctionWithArgs(
       FTy, RetTy, ArgTypeVRegs, MIRBuilder);
@@ -337,7 +336,6 @@ bool SPIRVCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
       GR->add(&Arg, &MIRBuilder.getMF(), VRegs[i][0]);
     i++;
   }
-
   // Name the function.
   if (F.hasName())
     buildOpName(FuncVReg, F.getName(), MIRBuilder);

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.cpp
@@ -20,7 +20,9 @@ using namespace llvm;
 
 unsigned SPIRVTargetLowering::getNumRegistersForCallingConv(
     LLVMContext &Context, CallingConv::ID CC, EVT VT) const {
-  // Avoid fail on v3i1 argument. Maybe we need to return 1 for all types.
+  // This code avoids CallLowering fail inside getVectorTypeBreakdown
+  // on v3i1 arguments. Maybe we need to return 1 for all types.
+  // TODO: remove it once this case is supported by the default implementation.
   if (VT.isVector() && VT.getVectorNumElements() == 3 &&
       (VT.getVectorElementType() == MVT::i1 ||
        VT.getVectorElementType() == MVT::i8))
@@ -31,7 +33,9 @@ unsigned SPIRVTargetLowering::getNumRegistersForCallingConv(
 MVT SPIRVTargetLowering::getRegisterTypeForCallingConv(LLVMContext &Context,
                                                        CallingConv::ID CC,
                                                        EVT VT) const {
-  // Avoid fail on v3i1 argument. Maybe we need to return i32 for all types.
+  // This code avoids CallLowering fail inside getVectorTypeBreakdown
+  // on v3i1 arguments. Maybe we need to return i32 for all types.
+  // TODO: remove it once this case is supported by the default implementation.
   if (VT.isVector() && VT.getVectorNumElements() == 3) {
     if (VT.getVectorElementType() == MVT::i1)
       return MVT::v4i1;

--- a/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
+++ b/llvm/lib/Target/SPIRV/SPIRVISelLowering.h
@@ -25,15 +25,14 @@ public:
                                const SPIRVSubtarget &STI)
       : TargetLowering(TM) {}
 
-  // Stop IRTranslator breaking up FMA instrs to preserve types information
+  // Stop IRTranslator breaking up FMA instrs to preserve types information.
   bool isFMAFasterThanFMulAndFAdd(const MachineFunction &MF,
                                   EVT) const override {
     return true;
   }
 
-  // This is to prevent sexts of non-i64 vector indices
-  // which are generated within general IRTranslator hence
-  // type generation for it is omitted
+  // This is to prevent sexts of non-i64 vector indices which are generated
+  // within general IRTranslator hence type generation for it is omitted.
   MVT getVectorIdxTy(const DataLayout &DL) const override {
     return MVT::getIntegerVT(32);
   }

--- a/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLegalizerInfo.cpp
@@ -283,7 +283,7 @@ SPIRVLegalizerInfo::SPIRVLegalizerInfo(const SPIRVSubtarget &ST) {
   // Pointer-handling.
   getActionDefinitionsBuilder(G_FRAME_INDEX).legalFor({p0});
 
-  // Control-flow. In some cases (e.g. constants) s1 may be promoted to s32
+  // Control-flow. In some cases (e.g. constants) s1 may be promoted to s32.
   getActionDefinitionsBuilder(G_BRCOND).legalFor({s1, s32});
 
   getActionDefinitionsBuilder({G_FPOW,

--- a/llvm/lib/Target/SPIRV/SPIRVLowerConstExpr.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVLowerConstExpr.cpp
@@ -1,46 +1,19 @@
-//===- SPIRVLowerConstExpr.cpp - Regularize LLVM for SPIR-V ------- C++ -*-===//
+//===-- SPIRVLowerConstExpr.cpp - Regularize LLVM IR for SPIR-V --- C++ -*-===//
 //
-//                     The LLVM/SPIRV Translator
-//
-// This file is distributed under the University of Illinois Open Source
-// License. See LICENSE.TXT for details.
-//
-// Copyright (c) 2014 Advanced Micro Devices, Inc. All rights reserved.
-//
-// Permission is hereby granted, free of charge, to any person obtaining a
-// copy of this software and associated documentation files (the "Software"),
-// to deal with the Software without restriction, including without limitation
-// the rights to use, copy, modify, merge, publish, distribute, sublicense,
-// and/or sell copies of the Software, and to permit persons to whom the
-// Software is furnished to do so, subject to the following conditions:
-//
-// Redistributions of source code must retain the above copyright notice,
-// this list of conditions and the following disclaimers.
-// Redistributions in binary form must reproduce the above copyright notice,
-// this list of conditions and the following disclaimers in the documentation
-// and/or other materials provided with the distribution.
-// Neither the names of Advanced Micro Devices, Inc., nor the names of its
-// contributors may be used to endorse or promote products derived from this
-// Software without specific prior written permission.
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH
-// THE SOFTWARE.
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
 //
-// This file implements regularization of LLVM module for SPIR-V.
+// This pass implements regularization of LLVM IR for SPIR-V.
 //
 //===----------------------------------------------------------------------===//
-#define DEBUG_TYPE "spv-lower-const-expr"
 
 #include "SPIRV.h"
 #include "SPIRVTargetMachine.h"
-
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/InstIterator.h"
 #include "llvm/IR/InstVisitor.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/PassManager.h"
@@ -48,181 +21,154 @@
 #include "llvm/Support/CommandLine.h"
 
 #include <list>
-#include <set>
+
+#define DEBUG_TYPE "spv-lower-const-expr"
 
 using namespace llvm;
 
+namespace llvm {
+void initializeSPIRVLowerConstExprLegacyPass(PassRegistry &);
+} // namespace llvm
+
 class SPIRVLowerConstExprBase {
 public:
-  SPIRVLowerConstExprBase() : M(nullptr), Ctx(nullptr) {}
-
-  bool runLowerConstExpr(Module &M);
-  void visit(Module *M);
-
-private:
-  Module *M;
-  LLVMContext *Ctx;
+  SPIRVLowerConstExprBase() {}
+  bool runLowerConstExpr(Function &F);
 };
 
 class SPIRVLowerConstExprPass
     : public llvm::PassInfoMixin<SPIRVLowerConstExprPass>,
       public SPIRVLowerConstExprBase {
 public:
-  llvm::PreservedAnalyses run(llvm::Module &M,
-                              llvm::ModuleAnalysisManager &MAM) {
-    return runLowerConstExpr(M) ? llvm::PreservedAnalyses::none()
+  llvm::PreservedAnalyses run(Function &F) {
+    return runLowerConstExpr(F) ? llvm::PreservedAnalyses::none()
                                 : llvm::PreservedAnalyses::all();
   }
 };
 
-namespace llvm {
-void initializeSPIRVLowerConstExprLegacyPass(PassRegistry &);
-}
-
 namespace {
-
-class SPIRVLowerConstExprLegacy : public ModulePass,
+class SPIRVLowerConstExprLegacy : public FunctionPass,
                                   public SPIRVLowerConstExprBase {
 public:
-  SPIRVLowerConstExprLegacy() : ModulePass(ID) {
+  static char ID;
+  SPIRVLowerConstExprLegacy() : FunctionPass(ID) {
     initializeSPIRVLowerConstExprLegacyPass(*PassRegistry::getPassRegistry());
   }
-
-  bool runOnModule(Module &M) override { return runLowerConstExpr(M); }
-
-  static char ID;
+  bool runOnFunction(Function &F) override { return runLowerConstExpr(F); };
 };
-
 } // namespace
-
-INITIALIZE_PASS(SPIRVLowerConstExprLegacy, DEBUG_TYPE,
-                "Regularize LLVM for SPIR-V", false, false)
 
 char SPIRVLowerConstExprLegacy::ID = 0;
 
-bool SPIRVLowerConstExprBase::runLowerConstExpr(Module &Module) {
-  M = &Module;
-  Ctx = &M->getContext();
-
-  LLVM_DEBUG(dbgs() << "Enter SPIRVLowerConstExpr:\n");
-  visit(M);
-
-  return true;
-}
+INITIALIZE_PASS(SPIRVLowerConstExprLegacy, DEBUG_TYPE,
+                "Regularize LLVM IR for SPIR-V", false, false)
 
 /// Since SPIR-V cannot represent constant expression, constant expressions
-/// in LLVM needs to be lowered to instructions.
-/// For each function, the constant expressions used by instructions of the
-/// function are replaced by instructions placed in the entry block since it
-/// dominates all other BB's. Each constant expression only needs to be lowered
-/// once in each function and all uses of it by instructions in that function
-/// is replaced by one instruction.
-/// ToDo: remove redundant instructions for common subexpression
+/// in LLVM IR need to be lowered to instructions. For each function,
+/// the constant expressions used by instructions of the function are replaced
+/// by instructions placed in the entry block since it dominates all other BBs.
+/// Each constant expression only needs to be lowered once in each function
+/// and all uses of it by instructions in that function are replaced by
+/// one instruction.
+/// TODO: remove redundant instructions for common subexpression.
+bool SPIRVLowerConstExprBase::runLowerConstExpr(Function &F) {
+  LLVMContext &Ctx = F.getContext();
+  std::list<Instruction *> WorkList;
+  for (auto &II : instructions(F))
+    WorkList.push_back(&II);
 
-void SPIRVLowerConstExprBase::visit(Module *M) {
-  for (auto &I : M->functions()) {
-    std::list<Instruction *> WorkList;
-    for (auto &BI : I) {
-      for (auto &II : BI) {
-        WorkList.push_back(&II);
+  auto FBegin = F.begin();
+  while (!WorkList.empty()) {
+    Instruction *II = WorkList.front();
+
+    auto LowerOp = [&II, &FBegin, &F](Value *V) -> Value * {
+      if (isa<Function>(V))
+        return V;
+      auto *CE = cast<ConstantExpr>(V);
+      LLVM_DEBUG(dbgs() << "[lowerConstantExpressions] " << *CE);
+      auto ReplInst = CE->getAsInstruction();
+      auto InsPoint = II->getParent() == &*FBegin ? II : &FBegin->back();
+      ReplInst->insertBefore(InsPoint);
+      LLVM_DEBUG(dbgs() << " -> " << *ReplInst << '\n');
+      std::vector<Instruction *> Users;
+      // Do not replace use during iteration of use. Do it in another loop.
+      for (auto U : CE->users()) {
+        LLVM_DEBUG(dbgs() << "[lowerConstantExpressions] Use: " << *U << '\n');
+        auto InstUser = dyn_cast<Instruction>(U);
+        // Only replace users in scope of current function.
+        if (InstUser && InstUser->getParent()->getParent() == &F)
+          Users.push_back(InstUser);
       }
-    }
-    auto FBegin = I.begin();
-    while (!WorkList.empty()) {
-      auto II = WorkList.front();
+      for (auto &User : Users) {
+        if (ReplInst->getParent() == User->getParent() &&
+            User->comesBefore(ReplInst))
+          ReplInst->moveBefore(User);
+        User->replaceUsesOfWith(CE, ReplInst);
+      }
+      return ReplInst;
+    };
 
-      auto LowerOp = [&II, &FBegin, &I](Value *V) -> Value * {
-        if (isa<Function>(V))
-          return V;
-        auto *CE = cast<ConstantExpr>(V);
-        LLVM_DEBUG(dbgs() << "[lowerConstantExpressions] " << *CE);
-        auto ReplInst = CE->getAsInstruction();
-        auto InsPoint = II->getParent() == &*FBegin ? II : &FBegin->back();
-        ReplInst->insertBefore(InsPoint);
-        LLVM_DEBUG(dbgs() << " -> " << *ReplInst << '\n');
-        std::vector<Instruction *> Users;
-        // Do not replace use during iteration of use. Do it in another loop
-        for (auto U : CE->users()) {
-          LLVM_DEBUG(dbgs()
-                     << "[lowerConstantExpressions] Use: " << *U << '\n');
-          if (auto InstUser = dyn_cast<Instruction>(U)) {
-            // Only replace users in scope of current function
-            if (InstUser->getParent()->getParent() == &I)
-              Users.push_back(InstUser);
-          }
-        }
-        for (auto &User : Users) {
-          if (ReplInst->getParent() == User->getParent())
-            if (User->comesBefore(ReplInst))
-              ReplInst->moveBefore(User);
-          User->replaceUsesOfWith(CE, ReplInst);
-        }
-        return ReplInst;
-      };
-
-      WorkList.pop_front();
-      auto LowerConstantVec = [&II, &LowerOp, &WorkList,
-                               &M](ConstantVector *Vec,
+    WorkList.pop_front();
+    auto LowerConstantVec = [&II, &LowerOp, &WorkList,
+                             &Ctx](ConstantVector *Vec,
                                    unsigned NumOfOp) -> Value * {
-        if (std::all_of(Vec->op_begin(), Vec->op_end(), [](Value *V) {
-              return isa<ConstantExpr>(V) || isa<Function>(V);
-            })) {
-          // Expand a vector of constexprs and construct it back with
-          // series of insertelement instructions
-          std::list<Value *> OpList;
-          std::transform(Vec->op_begin(), Vec->op_end(),
-                         std::back_inserter(OpList),
-                         [LowerOp](Value *V) { return LowerOp(V); });
-          Value *Repl = nullptr;
-          unsigned Idx = 0;
-          auto *PhiII = dyn_cast<PHINode>(II);
-          auto *InsPoint =
-              PhiII ? &PhiII->getIncomingBlock(NumOfOp)->back() : II;
-          std::list<Instruction *> ReplList;
-          for (auto V : OpList) {
-            if (auto *Inst = dyn_cast<Instruction>(V))
-              ReplList.push_back(Inst);
-            Repl = InsertElementInst::Create(
-                (Repl ? Repl : UndefValue::get(Vec->getType())), V,
-                ConstantInt::get(Type::getInt32Ty(M->getContext()), Idx++), "",
-                InsPoint);
-          }
-          WorkList.splice(WorkList.begin(), ReplList);
-          return Repl;
+      if (std::all_of(Vec->op_begin(), Vec->op_end(), [](Value *V) {
+            return isa<ConstantExpr>(V) || isa<Function>(V);
+          })) {
+        // Expand a vector of constexprs and construct it back with
+        // series of insertelement instructions.
+        std::list<Value *> OpList;
+        std::transform(Vec->op_begin(), Vec->op_end(),
+                       std::back_inserter(OpList),
+                       [LowerOp](Value *V) { return LowerOp(V); });
+        Value *Repl = nullptr;
+        unsigned Idx = 0;
+        auto *PhiII = dyn_cast<PHINode>(II);
+        Instruction *InsPoint =
+            PhiII ? &PhiII->getIncomingBlock(NumOfOp)->back() : II;
+        std::list<Instruction *> ReplList;
+        for (auto V : OpList) {
+          if (auto *Inst = dyn_cast<Instruction>(V))
+            ReplList.push_back(Inst);
+          Repl = InsertElementInst::Create(
+              (Repl ? Repl : UndefValue::get(Vec->getType())), V,
+              ConstantInt::get(Type::getInt32Ty(Ctx), Idx++), "", InsPoint);
         }
-        return nullptr;
-      };
-
-      for (unsigned OI = 0, OE = II->getNumOperands(); OI != OE; ++OI) {
-        auto *Op = II->getOperand(OI);
-        if (auto *Vec = dyn_cast<ConstantVector>(Op)) {
-          Value *ReplInst = LowerConstantVec(Vec, OI);
-          if (ReplInst)
-            II->replaceUsesOfWith(Op, ReplInst);
-        } else if (auto CE = dyn_cast<ConstantExpr>(Op)) {
-          WorkList.push_front(cast<Instruction>(LowerOp(CE)));
-        } else if (auto MDAsVal = dyn_cast<MetadataAsValue>(Op)) {
-          Metadata *MD = MDAsVal->getMetadata();
-          if (auto ConstMD = dyn_cast<ConstantAsMetadata>(MD)) {
-            Constant *C = ConstMD->getValue();
-            Value *ReplInst = nullptr;
-            if (auto *Vec = dyn_cast<ConstantVector>(C))
-              ReplInst = LowerConstantVec(Vec, OI);
-            if (auto *CE = dyn_cast<ConstantExpr>(C))
-              ReplInst = LowerOp(CE);
-            if (ReplInst) {
-              Metadata *RepMD = ValueAsMetadata::get(ReplInst);
-              Value *RepMDVal = MetadataAsValue::get(M->getContext(), RepMD);
-              II->setOperand(OI, RepMDVal);
-              WorkList.push_front(cast<Instruction>(ReplInst));
-            }
-          }
-        }
+        WorkList.splice(WorkList.begin(), ReplList);
+        return Repl;
+      }
+      return nullptr;
+    };
+    for (unsigned OI = 0, OE = II->getNumOperands(); OI != OE; ++OI) {
+      auto *Op = II->getOperand(OI);
+      if (auto *Vec = dyn_cast<ConstantVector>(Op)) {
+        Value *ReplInst = LowerConstantVec(Vec, OI);
+        if (ReplInst)
+          II->replaceUsesOfWith(Op, ReplInst);
+      } else if (auto CE = dyn_cast<ConstantExpr>(Op)) {
+        WorkList.push_front(cast<Instruction>(LowerOp(CE)));
+      } else if (auto MDAsVal = dyn_cast<MetadataAsValue>(Op)) {
+        auto ConstMD = dyn_cast<ConstantAsMetadata>(MDAsVal->getMetadata());
+        if (!ConstMD)
+          continue;
+        Constant *C = ConstMD->getValue();
+        Value *ReplInst = nullptr;
+        if (auto *Vec = dyn_cast<ConstantVector>(C))
+          ReplInst = LowerConstantVec(Vec, OI);
+        if (auto *CE = dyn_cast<ConstantExpr>(C))
+          ReplInst = LowerOp(CE);
+        if (!ReplInst)
+          continue;
+        Metadata *RepMD = ValueAsMetadata::get(ReplInst);
+        Value *RepMDVal = MetadataAsValue::get(Ctx, RepMD);
+        II->setOperand(OI, RepMDVal);
+        WorkList.push_front(cast<Instruction>(ReplInst));
       }
     }
   }
+  return true;
 }
 
-ModulePass *llvm::createSPIRVLowerConstExprLegacyPass() {
+FunctionPass *llvm::createSPIRVLowerConstExprLegacyPass() {
   return new SPIRVLowerConstExprLegacy();
 }

--- a/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVModuleAnalysis.cpp
@@ -112,7 +112,6 @@ void SPIRVModuleAnalysis::setBaseInfo(const Module &M) {
                : PtrSize == 64 ? SPIRV::AddressingModel::Physical64
                                : SPIRV::AddressingModel::Logical;
   }
-
   // Get the OpenCL version number from metadata.
   // TODO: support other source languages.
   if (auto VerNode = M.getNamedMetadata("opencl.ocl.version")) {
@@ -230,7 +229,7 @@ void SPIRVModuleAnalysis::processDefInstrs(const Module &M) {
     MachineFunction *MF = MMI->getMachineFunction(*F);
     if (!MF)
       continue;
-    // Iterate through and hoist any instructions we can at this stage.
+    // Iterate through and collect opextension/opcapability instructions.
     for (MachineBasicBlock &MBB : *MF) {
       for (MachineInstr &MI : MBB) {
         if (MI.getOpcode() == SPIRV::OpExtension) {

--- a/llvm/lib/Target/SPIRV/SPIRVRegisterBankInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVRegisterBankInfo.cpp
@@ -22,9 +22,8 @@
 
 using namespace llvm;
 
-// This required for .td selection patterns to work or we'd end up
-// with RegClass checks being redundant as all the classes would be mapped
-// to the same bank
+// This required for .td selection patterns to work or we'd end up with RegClass
+// checks being redundant as all the classes would be mapped to the same bank.
 const RegisterBank &
 SPIRVRegisterBankInfo::getRegBankFromRegClass(const TargetRegisterClass &RC,
                                               LLT Ty) const {

--- a/llvm/lib/Target/SPIRV/SPIRVRegisterInfo.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVRegisterInfo.cpp
@@ -22,8 +22,7 @@ using namespace llvm;
 SPIRVRegisterInfo::SPIRVRegisterInfo() : SPIRVGenRegisterInfo(SPIRV::ID0) {}
 
 BitVector SPIRVRegisterInfo::getReservedRegs(const MachineFunction &MF) const {
-  BitVector Reserved(getNumRegs());
-  return Reserved;
+  return BitVector(getNumRegs());
 }
 
 const MCPhysReg *

--- a/llvm/lib/Target/SPIRV/SPIRVRegisterInfo.td
+++ b/llvm/lib/Target/SPIRV/SPIRVRegisterInfo.td
@@ -5,11 +5,13 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-//  Declarations that describe the SPIR-V register file
+//
+//  Declarations that describe the SPIR-V register file.
+//
 //===----------------------------------------------------------------------===//
 
 let Namespace = "SPIRV" in {
-  def p0 : PtrValueType <i32, 0>;
+  def p0 : PtrValueType<i32, 0>;
   // All registers are for 32-bit identifiers, so have a single dummy register
 
   // Class for registers that are the result of OpTypeXXX instructions


### PR DESCRIPTION
The patch converts SPIRVLowerConstExpr module-level pass to function-level one. Several other small changes are also copied from llvm repository to unify the code. LIT pass rate is expected to be the same.