### PR TITLE
[SPIR-V] Correct formatting of /function/ tests

### DIFF
--- a/llvm/test/CodeGen/SPIRV/function/alloca-load-store.ll
+++ b/llvm/test/CodeGen/SPIRV/function/alloca-load-store.ll
@@ -1,14 +1,14 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 
-; CHECK-DAG: OpName [[BAR:%.+]] "bar"
-; CHECK-DAG: OpName [[FOO:%.+]] "foo"
-; CHECK-DAG: OpName [[GOO:%.+]] "goo"
+; CHECK-DAG: OpName %[[#BAR:]] "bar"
+; CHECK-DAG: OpName %[[#FOO:]] "foo"
+; CHECK-DAG: OpName %[[#GOO:]] "goo"
 
-; CHECK:     [[INT:%.+]] = OpTypeInt 32
-; CHECK-DAG: [[STACK_PTR:%.+]] = OpTypePointer Function [[INT]]
-; CHECK-DAG: [[GLOBAL_PTR:%.+]] = OpTypePointer CrossWorkgroup [[INT]]
-; CHECK-DAG: [[FN1:%.+]] = OpTypeFunction [[INT]] [[INT]]
-; CHECK-DAG: [[FN2:%.+]] = OpTypeFunction [[INT]] [[INT]] [[GLOBAL_PTR]]
+; CHECK:     %[[#INT:]] = OpTypeInt 32
+; CHECK-DAG: %[[#STACK_PTR:]] = OpTypePointer Function %[[#INT]]
+; CHECK-DAG: %[[#GLOBAL_PTR:]] = OpTypePointer CrossWorkgroup %[[#INT]]
+; CHECK-DAG: %[[#FN1:]] = OpTypeFunction %[[#INT]] %[[#INT]]
+; CHECK-DAG: %[[#FN2:]] = OpTypeFunction %[[#INT]] %[[#INT]] %[[#GLOBAL_PTR]]
 
 define i32 @bar(i32 %a) {
   %p = alloca i32
@@ -17,13 +17,13 @@ define i32 @bar(i32 %a) {
   ret i32 %b
 }
 
-; CHECK: [[BAR]] = OpFunction [[INT]] None [[FN1]]
-; CHECK: [[A:%.+]] = OpFunctionParameter [[INT]]
+; CHECK: %[[#BAR]] = OpFunction %[[#INT]] None %[[#FN1]]
+; CHECK: %[[#A:]] = OpFunctionParameter %[[#INT]]
 ; CHECK: OpLabel
-; CHECK: [[P:%.+]] = OpVariable [[STACK_PTR]] Function
-; CHECK: OpStore [[P]] [[A]]
-; CHECK: [[B:%.+]] = OpLoad [[INT]] [[P]]
-; CHECK: OpReturnValue [[B]]
+; CHECK: %[[#P:]] = OpVariable %[[#STACK_PTR]] Function
+; CHECK: OpStore %[[#P]] %[[#A]]
+; CHECK: %[[#B:]] = OpLoad %[[#INT]] %[[#P]]
+; CHECK: OpReturnValue %[[#B]]
 ; CHECK: OpFunctionEnd
 
 
@@ -34,13 +34,13 @@ define i32 @foo(i32 %a) {
   ret i32 %b
 }
 
-; CHECK: [[FOO]] = OpFunction [[INT]] None [[FN1]]
-; CHECK: [[A:%.+]] = OpFunctionParameter [[INT]]
+; CHECK: %[[#FOO]] = OpFunction %[[#INT]] None %[[#FN1]]
+; CHECK: %[[#A:]] = OpFunctionParameter %[[#INT]]
 ; CHECK: OpLabel
-; CHECK: [[P:%.+]] = OpVariable [[STACK_PTR]] Function
-; CHECK: OpStore [[P]] [[A]] Volatile
-; CHECK: [[B:%.+]] = OpLoad [[INT]] [[P]] Volatile
-; CHECK: OpReturnValue [[B]]
+; CHECK: %[[#P:]] = OpVariable %[[#STACK_PTR]] Function
+; CHECK: OpStore %[[#P]] %[[#A]] Volatile
+; CHECK: %[[#B:]] = OpLoad %[[#INT]] %[[#P]] Volatile
+; CHECK: OpReturnValue %[[#B]]
 ; CHECK: OpFunctionEnd
 
 
@@ -51,11 +51,11 @@ define i32 @goo(i32 %a, i32 addrspace(1)* %p) {
   ret i32 %b
 }
 
-; CHECK: [[GOO]] = OpFunction [[INT]] None [[FN2]]
-; CHECK: [[A:%.+]] = OpFunctionParameter [[INT]]
-; CHECK: [[P:%.+]] = OpFunctionParameter [[GLOBAL_PTR]]
+; CHECK: %[[#GOO]] = OpFunction %[[#INT]] None %[[#FN2]]
+; CHECK: %[[#A:]] = OpFunctionParameter %[[#INT]]
+; CHECK: %[[#P:]] = OpFunctionParameter %[[#GLOBAL_PTR]]
 ; CHECK: OpLabel
-; CHECK: OpStore [[P]] [[A]]
-; CHECK: [[B:%.+]] = OpLoad [[INT]] [[P]]
-; CHECK: OpReturnValue [[B]]
+; CHECK: OpStore %[[#P]] %[[#A]]
+; CHECK: %[[#B:]] = OpLoad %[[#INT]] %[[#P]]
+; CHECK: OpReturnValue %[[#B]]
 ; CHECK: OpFunctionEnd

--- a/llvm/test/CodeGen/SPIRV/function/identity-function.ll
+++ b/llvm/test/CodeGen/SPIRV/function/identity-function.ll
@@ -1,15 +1,15 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 
-; CHECK-DAG:  OpName [[VALUE:%.+]] "value"
-; CHECK-DAG:  OpName [[IDENTITY:%.+]] "identity"
+; CHECK-DAG: OpName %[[#VALUE:]] "value"
+; CHECK-DAG: OpName %[[#IDENTITY:]] "identity"
 
-; CHECK:      [[INT:%.+]] = OpTypeInt 32
-; CHECK:      [[FN:%.+]] = OpTypeFunction [[INT]] [[INT]]
+; CHECK: %[[#INT:]] = OpTypeInt 32
+; CHECK: %[[#FN:]] = OpTypeFunction %[[#INT]] %[[#INT]]
 
-; CHECK:      [[IDENTITY]] = OpFunction [[INT]] None [[FN]]
-; CHECK-NEXT: [[VALUE]] = OpFunctionParameter [[INT]]
+; CHECK: %[[#IDENTITY]] = OpFunction %[[#INT]] None %[[#FN]]
+; CHECK-NEXT: %[[#VALUE]] = OpFunctionParameter %[[#INT]]
 ; CHECK-NEXT: {{%.+}} = OpLabel
-; CHECK-NEXT: OpReturnValue [[VALUE]]
+; CHECK-NEXT: OpReturnValue %[[#VALUE]]
 ; CHECK-NEXT: OpFunctionEnd
 
 define i32 @identity(i32 %value) {

--- a/llvm/test/CodeGen/SPIRV/function/trivial-function-definition.ll
+++ b/llvm/test/CodeGen/SPIRV/function/trivial-function-definition.ll
@@ -1,14 +1,14 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 
 ;; Debug info:
-; CHECK:     OpName [[FOO:%.+]] "foo"
+; CHECK:     OpName %[[#FOO:]] "foo"
 
 ;; Types:
-; CHECK:     [[VOID:%.+]] = OpTypeVoid
-; CHECK:     [[FN:%.+]] = OpTypeFunction [[VOID]]
+; CHECK:     %[[#VOID:]] = OpTypeVoid
+; CHECK:     %[[#FN:]] = OpTypeFunction %[[#VOID]]
 
 ;; Functions:
-; CHECK:     [[FOO]] = OpFunction [[VOID]] None [[FN]]
+; CHECK:     %[[#FOO]] = OpFunction %[[#VOID]] None %[[#FN]]
 ; CHECK-NOT: OpFunctionParameter
 ;; NOTE: In 2.4, it isn't explicitly written that a function always has a least
 ;;       one block. In fact, 2.4.11 seems to imply that there are at least two

--- a/llvm/test/CodeGen/SPIRV/function/trivial-function-with-attributes.ll
+++ b/llvm/test/CodeGen/SPIRV/function/trivial-function-with-attributes.ll
@@ -3,17 +3,17 @@
 ;; FIXME: Are there any attributes that would make the IR invalid for SPIR-V?
 
 ;; Names:
-; CHECK-DAG: OpName [[FN1:%.+]] "fn1"
-; CHECK-DAG: OpName [[FN2:%.+]] "fn2"
-; CHECK-DAG: OpName [[FN3:%.+]] "fn3"
-; CHECK-DAG: OpName [[FN4:%.+]] "fn4"
-; CHECK-DAG: OpName [[FN5:%.+]] "fn5"
-; CHECK-DAG: OpName [[FN6:%.+]] "fn6"
-; CHECK-DAG: OpName [[FN7:%.+]] "fn7"
+; CHECK-DAG: OpName %[[#FN1:]] "fn1"
+; CHECK-DAG: OpName %[[#FN2:]] "fn2"
+; CHECK-DAG: OpName %[[#FN3:]] "fn3"
+; CHECK-DAG: OpName %[[#FN4:]] "fn4"
+; CHECK-DAG: OpName %[[#FN5:]] "fn5"
+; CHECK-DAG: OpName %[[#FN6:]] "fn6"
+; CHECK-DAG: OpName %[[#FN7:]] "fn7"
 
 ;; Types:
-; CHECK:     [[VOID:%.+]] = OpTypeVoid
-; CHECK:     [[FN:%.+]] = OpTypeFunction [[VOID]]
+; CHECK:     %[[#VOID:]] = OpTypeVoid
+; CHECK:     %[[#FN:]] = OpTypeFunction %[[#VOID]]
 
 
 ;; Functions:
@@ -21,7 +21,7 @@
 define void @fn1() noinline {
   ret void
 }
-; CHECK:     [[FN1]] = OpFunction [[VOID]] DontInline [[FN]]
+; CHECK:     %[[#FN1]] = OpFunction %[[#VOID]] DontInline %[[#FN]]
 ; CHECK-NOT: OpFunctionParameter
 ; CHECK:     OpFunctionEnd
 
@@ -30,41 +30,41 @@ attributes #0 = { noinline }
 define void @fn2() #0 {
   ret void
 }
-; CHECK: [[FN2]] = OpFunction [[VOID]] DontInline [[FN]]
+; CHECK: %[[#FN2]] = OpFunction %[[#VOID]] DontInline %[[#FN]]
 ; CHECK: OpFunctionEnd
 
 
 define void @fn3() alwaysinline {
   ret void
 }
-; CHECK: [[FN3]] = OpFunction [[VOID]] Inline [[FN]]
+; CHECK: %[[#FN3]] = OpFunction %[[#VOID]] Inline %[[#FN]]
 ; CHECK: OpFunctionEnd
 
 
-; NOTE: inlinehint is not an actual requirement.
+;; NOTE: inlinehint is not an actual requirement.
 define void @fn4() inlinehint {
   ret void
 }
-; CHECK: [[FN4]] = OpFunction [[VOID]] None [[FN]]
+; CHECK: %[[#FN4]] = OpFunction %[[#VOID]] None %[[#FN]]
 ; CHECK: OpFunctionEnd
 
 
 define void @fn5() readnone {
   ret void
 }
-; CHECK: [[FN5]] = OpFunction [[VOID]] Pure [[FN]]
+; CHECK: %[[#FN5]] = OpFunction %[[#VOID]] Pure %[[#FN]]
 ; CHECK: OpFunctionEnd
 
 
 define void @fn6() readonly {
   ret void
 }
-; CHECK: [[FN6]] = OpFunction [[VOID]] Const [[FN]]
+; CHECK: %[[#FN6]] = OpFunction %[[#VOID]] Const %[[#FN]]
 ; CHECK: OpFunctionEnd
 
 
 define void @fn7() alwaysinline readnone {
   ret void
 }
-; CHECK: [[FN7]] = OpFunction [[VOID]] Inline|Pure [[FN]]
+; CHECK: %[[#FN7]] = OpFunction %[[#VOID]] Inline|Pure %[[#FN]]
 ; CHECK: OpFunctionEnd

--- a/llvm/test/CodeGen/SPIRV/function/trivial-function-with-call.ll
+++ b/llvm/test/CodeGen/SPIRV/function/trivial-function-with-call.ll
@@ -1,24 +1,24 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 
 ;; Debug info:
-; CHECK:      OpName [[FOO:%.+]] "foo"
-; CHECK:      OpName [[BAR:%.+]] "bar"
+; CHECK:      OpName %[[#FOO:]] "foo"
+; CHECK:      OpName %[[#BAR:]] "bar"
 
 ;; Types:
-; CHECK-DAG:  [[I32:%.+]] = OpTypeInt 32
-; CHECK-DAG:  [[VOID:%.+]] = OpTypeVoid
-; CHECK-DAG:  [[FNVOID:%.+]] = OpTypeFunction [[VOID]] [[I32]]
-; CHECK-DAG:  [[FNI32:%.+]] = OpTypeFunction [[I32]] [[I32]]
+; CHECK-DAG:  %[[#I32:]] = OpTypeInt 32
+; CHECK-DAG:  %[[#VOID:]] = OpTypeVoid
+; CHECK-DAG:  %[[#FNVOID:]] = OpTypeFunction %[[#VOID]] %[[#I32]]
+; CHECK-DAG:  %[[#FNI32:]] = OpTypeFunction %[[#I32]] %[[#I32]]
 ;; Function decl:
-; CHECK:      [[BAR]] = OpFunction [[I32]] None [[FNI32]]
-; CHECK-NEXT: OpFunctionParameter [[I32]]
+; CHECK:      %[[#BAR]] = OpFunction %[[#I32]] None %[[#FNI32]]
+; CHECK-NEXT: OpFunctionParameter %[[#I32]]
 ; CHECK-NEXT: OpFunctionEnd
 declare i32 @bar(i32 %x)
 ;; Function def:
-; CHECK:      [[FOO]] = OpFunction [[VOID]] None [[FNVOID]]
+; CHECK:      %[[#FOO]] = OpFunction %[[#VOID]] None %[[#FNVOID]]
 ; CHECK:      OpFunctionParameter
 ; CHECK:      OpLabel
-; CHECK:      OpFunctionCall [[I32]] [[BAR]]
+; CHECK:      OpFunctionCall %[[#I32]] %[[#BAR]]
 ; CHECK:      OpReturn
 ; CHECK-NOT:  OpLabel
 ; CHECK:      OpFunctionEnd


### PR DESCRIPTION
Corrects formatting of /function/ tests to match the formatting of the new internal-anonymous-function.ll test in [pull request 224](https://github.com/KhronosGroup/LLVM-SPIRV-Backend/pull/224).