### PR TITLE
[SPIR-V] Assert int width <= 64 in const selection

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVInstructionSelector.cpp
@@ -1189,6 +1189,7 @@ bool SPIRVInstructionSelector::selectConst(Register ResVReg,
         .addUse(GR.getSPIRVTypeID(ResType))
         .constrainAllUses(TII, TRI, RBI);
   if (TyOpcode == SPIRV::OpTypeInt) {
+    assert(Imm.getBitWidth() <= 64 && "Unsupported integer width!");
     Register Reg = GR.getOrCreateConstInt(Imm.getZExtValue(), I, ResType, TII);
     if (Reg == ResVReg)
       return true;


### PR DESCRIPTION
This change adds an assert for integer bit width. Similarly, the Khronos SPIR-V LLVM Translator [does not support integers larger than i64 natively](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/blob/a9391f71c5a175bd330eff60a058835d07f54741/test/negative/invalid-int-bitwidth.ll).