### PR TITLE
[SPIR-V] Disable MachineLateInstrsCleanup pass

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVTargetMachine.cpp
@@ -124,6 +124,7 @@ void SPIRVPassConfig::addPostRegAlloc() {
   disablePass(&PatchableFunctionID);
   disablePass(&ShrinkWrapID);
   disablePass(&LiveDebugValuesID);
+  disablePass(&MachineLateInstrsCleanupID);
 
   // Do not work with OpPhi.
   disablePass(&BranchFolderPassID);

--- a/llvm/test/CodeGen/SPIRV/function/trivial-function-with-attributes.ll
+++ b/llvm/test/CodeGen/SPIRV/function/trivial-function-with-attributes.ll
@@ -10,6 +10,8 @@
 ; CHECK-DAG: OpName %[[#FN5:]] "fn5"
 ; CHECK-DAG: OpName %[[#FN6:]] "fn6"
 ; CHECK-DAG: OpName %[[#FN7:]] "fn7"
+; CHECK-DAG: OpName %[[#FN8:]] "fn8"
+; CHECK-DAG: OpName %[[#FN9:]] "fn9"
 
 ;; Types:
 ; CHECK:     %[[#VOID:]] = OpTypeVoid
@@ -56,15 +58,29 @@ define void @fn5() readnone {
 ; CHECK: OpFunctionEnd
 
 
-define void @fn6() readonly {
+define void @fn6() memory(none) {
   ret void
 }
-; CHECK: %[[#FN6]] = OpFunction %[[#VOID]] Const %[[#FN]]
+; CHECK: %[[#FN6]] = OpFunction %[[#VOID]] Pure %[[#FN]]
 ; CHECK: OpFunctionEnd
 
 
-define void @fn7() alwaysinline readnone {
+define void @fn7() readonly {
   ret void
 }
-; CHECK: %[[#FN7]] = OpFunction %[[#VOID]] Inline|Pure %[[#FN]]
+; CHECK: %[[#FN7]] = OpFunction %[[#VOID]] Const %[[#FN]]
+; CHECK: OpFunctionEnd
+
+
+define void @fn8() memory(read) {
+  ret void
+}
+; CHECK: %[[#FN8]] = OpFunction %[[#VOID]] Const %[[#FN]]
+; CHECK: OpFunctionEnd
+
+
+define void @fn9() alwaysinline readnone {
+  ret void
+}
+; CHECK: %[[#FN9]] = OpFunction %[[#VOID]] Inline|Pure %[[#FN]]
 ; CHECK: OpFunctionEnd

--- a/llvm/test/CodeGen/SPIRV/instructions/atomic.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/atomic.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 
 ; CHECK-DAG: OpName [[ADD:%.*]] "test_add"
 ; CHECK-DAG: OpName [[SUB:%.*]] "test_sub"

--- a/llvm/test/CodeGen/SPIRV/instructions/atomic_acqrel.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/atomic_acqrel.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 
 ; CHECK-DAG: OpName [[ADD:%.*]] "test_add"
 ; CHECK-DAG: OpName [[SUB:%.*]] "test_sub"

--- a/llvm/test/CodeGen/SPIRV/instructions/atomic_seq.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/atomic_seq.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 
 ; CHECK-DAG: OpName [[ADD:%.*]] "test_add"
 ; CHECK-DAG: OpName [[SUB:%.*]] "test_sub"

--- a/llvm/test/CodeGen/SPIRV/instructions/fcmp.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/fcmp.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 
 ; CHECK-DAG: OpName [[UEQ:%.*]] "test_ueq"
 ; CHECK-DAG: OpName [[OEQ:%.*]] "test_oeq"

--- a/llvm/test/CodeGen/SPIRV/instructions/float-casts.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/float-casts.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 
 ; CHECK-DAG: OpName [[TRUNC32_16:%.*]] "f32tof16"
 ; CHECK-DAG: OpName [[EXT16_32:%.*]] "f16tof32"

--- a/llvm/test/CodeGen/SPIRV/instructions/icmp.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/icmp.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 
 ; CHECK-DAG: OpName [[EQ:%.*]] "test_eq"
 ; CHECK-DAG: OpName [[NE:%.*]] "test_ne"

--- a/llvm/test/CodeGen/SPIRV/instructions/integer-casts.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/integer-casts.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 
 ; CHECK-DAG: OpName [[TRUNC32_16:%.*]] "i32toi16"
 ; CHECK-DAG: OpName [[TRUNC32_8:%.*]] "i32toi8"

--- a/llvm/test/CodeGen/SPIRV/instructions/intrinsics.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/intrinsics.ll
@@ -1,4 +1,4 @@
-; RUN: llc %s -mtriple=spirv32-unknown-unknown -o - | FileCheck %s
+; RUN: llc -O0 %s -mtriple=spirv32-unknown-unknown -o - | FileCheck %s
 
 declare float @llvm.fabs.f32(float)
 declare float @llvm.rint.f32(float)

--- a/llvm/test/CodeGen/SPIRV/instructions/ptrcmp.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/ptrcmp.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 
 ; CHECK-DAG: OpName [[EQ:%.*]] "test_eq"
 ; CHECK-DAG: OpName [[NE:%.*]] "test_ne"

--- a/llvm/test/CodeGen/SPIRV/instructions/vector-shuffle.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/vector-shuffle.ll
@@ -1,4 +1,4 @@
-; RUN: llc -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 
 ; CHECK-DAG: OpName [[SHFv4:%.+]] "shuffle_v4"
 ; CHECK-DAG: OpName [[INSv4:%.+]] "insert_v4"


### PR DESCRIPTION
This change:

- Disables the recently added MachineLateInstrsCleanup pass since it does not work with virtual registers.
- Makes all LIT tests run with -O0