### PR TITLE
[SPIR-V] Fix translation of undef aggregates

### DIFF
--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -198,6 +198,7 @@ Instruction *SPIRVEmitIntrinsics::visitSwitchInst(SwitchInst &I) {
   for (auto &Op : I.operands())
     if (Op.get()->getType()->isSized())
       Args.push_back(Op);
+  IRB->SetInsertPoint(&I);
   IRB->CreateIntrinsic(Intrinsic::spv_switch, {I.getOperand(0)->getType()},
                        {Args});
   return &I;

--- a/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVEmitIntrinsics.cpp
@@ -176,6 +176,13 @@ void SPIRVEmitIntrinsics::preprocessCompositeConstants() {
       if (auto *AggrC = dyn_cast<ConstantAggregate>(Op)) {
         SmallVector<Value *> Args(AggrC->op_begin(), AggrC->op_end());
         BuildCompositeIntrinsic(AggrC, Args);
+      } else if (isa<UndefValue>(Op) && Op->getType()->isAggregateType()) {
+        auto *AggrC = dyn_cast<Constant>(Op);
+        SmallVector<Value *> Args;
+        unsigned Idx = 0;
+        while (auto Elt = AggrC->getAggregateElement(Idx++))
+          Args.push_back(Elt);
+        BuildCompositeIntrinsic(AggrC, Args);
       } else if (auto *AggrC = dyn_cast<ConstantDataArray>(Op)) {
         SmallVector<Value *> Args;
         for (unsigned i = 0; i < AggrC->getNumElements(); ++i)

--- a/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
+++ b/llvm/lib/Target/SPIRV/SPIRVPreLegalizer.cpp
@@ -389,14 +389,11 @@ static void processInstrsWithTypeFolding(MachineFunction &MF,
 
 static void processSwitches(MachineFunction &MF, SPIRVGlobalRegistry *GR,
                             MachineIRBuilder MIB) {
-  DenseMap<Register, SmallDenseMap<uint64_t, MachineBasicBlock *>>
-      SwitchRegToMBB;
-  DenseMap<Register, MachineBasicBlock *> DefaultMBBs;
-  DenseSet<Register> SwitchRegs;
-  MachineRegisterInfo &MRI = MF.getRegInfo();
-  // Before IRTranslator pass, spv_switch calls are inserted before each
-  // switch instruction. IRTranslator lowers switches to ICMP+CBr+Br triples.
-  // A switch with two cases may be translated to this MIR sequesnce:
+  // Before IRTranslator pass, calls to spv_switch intrinsic are inserted before
+  // each switch instruction. IRTranslator lowers switches to G_ICMP + G_BRCOND
+  // + G_BR triples. A switch with two cases may be transformed to this MIR
+  // sequence:
+  //
   //   intrinsic(@llvm.spv.switch), %CmpReg, %Const0, %Const1
   //   %Dst0 = G_ICMP intpred(eq), %CmpReg, %Const0
   //   G_BRCOND %Dst0, %bb.2
@@ -411,31 +408,48 @@ static void processSwitches(MachineFunction &MF, SPIRVGlobalRegistry *GR,
   //   ...
   // bb.4.sw.epilog:
   //   ...
-  // Walk MIs and collect information about destination MBBs to update
-  // spv_switch call. We assume that all spv_switch precede corresponding ICMPs.
+  //
+  // Sometimes (in case of range-compare switches), additional G_SUBs
+  // instructions are inserted before G_ICMPs. Those need to be additionally
+  // processed and require type assignment.
+  //
+  // This function modifies spv_switch call's operands to include destination
+  // MBBs (default and for each constant value).
+  // Note that this function does not remove G_ICMP + G_BRCOND + G_BR sequences,
+  // but they are marked by ModuleAnalysis as skipped and as a result AsmPrinter
+  // does not output them.
+
+  MachineRegisterInfo &MRI = MF.getRegInfo();
+
+  // Collect all MIs relevant to switches across all MBBs in MF.
+  std::vector<MachineInstr *> RelevantInsts;
+
+  // Temporary set of compare registers. G_SUBs and G_ICMPs relating to
+  // spv_switch use these registers.
+  DenseSet<Register> CompareRegs;
   for (MachineBasicBlock &MBB : MF) {
     for (MachineInstr &MI : MBB) {
+      // Calls to spv_switch intrinsics representing IR switches.
       if (isSpvIntrinsic(MI, Intrinsic::spv_switch)) {
         assert(MI.getOperand(1).isReg());
-        Register Reg = MI.getOperand(1).getReg();
-        SwitchRegs.insert(Reg);
-        // Set the first successor as default MBB to support empty switches.
-        DefaultMBBs[Reg] = *MBB.succ_begin();
+        CompareRegs.insert(MI.getOperand(1).getReg());
+        RelevantInsts.push_back(&MI);
       }
-      // Process G_SUB coming from switch range-compare lowering.
+
+      // G_SUBs coming from range-compare switch lowering. G_SUBs are found
+      // after spv_switch but before G_ICMP.
       if (MI.getOpcode() == TargetOpcode::G_SUB && MI.getOperand(1).isReg() &&
-          SwitchRegs.contains(MI.getOperand(1).getReg())) {
+          CompareRegs.contains(MI.getOperand(1).getReg())) {
         assert(MI.getOperand(0).isReg() && MI.getOperand(1).isReg());
         Register Dst = MI.getOperand(0).getReg();
-        SwitchRegs.insert(Dst);
+        CompareRegs.insert(Dst);
         SPIRVType *Ty = GR->getSPIRVTypeForVReg(MI.getOperand(1).getReg());
         insertAssignInstr(Dst, nullptr, Ty, GR, MIB, MRI);
       }
-      // Process only ICMPs that relate to spv_switches.
+
+      // G_ICMPs relating to switches.
       if (MI.getOpcode() == TargetOpcode::G_ICMP && MI.getOperand(2).isReg() &&
-          SwitchRegs.contains(MI.getOperand(2).getReg())) {
-        assert(MI.getOperand(0).isReg() && MI.getOperand(1).isPredicate() &&
-               MI.getOperand(3).isReg());
+          CompareRegs.contains(MI.getOperand(2).getReg())) {
         Register Dst = MI.getOperand(0).getReg();
         // Set type info for destination register of switch's ICMP instruction.
         if (GR->getSPIRVTypeForVReg(Dst) == nullptr) {
@@ -445,60 +459,85 @@ static void processSwitches(MachineFunction &MF, SPIRVGlobalRegistry *GR,
           MRI.setRegClass(Dst, &SPIRV::IDRegClass);
           GR->assignSPIRVTypeToVReg(SpirvTy, Dst, MIB.getMF());
         }
-        Register CmpReg = MI.getOperand(2).getReg();
-        MachineOperand &PredOp = MI.getOperand(1);
-        const auto CC = static_cast<CmpInst::Predicate>(PredOp.getPredicate());
-        assert((CC == CmpInst::ICMP_EQ || CC == CmpInst::ICMP_ULE) &&
-               MRI.hasOneUse(Dst) && MRI.hasOneDef(CmpReg));
-        uint64_t Val = getIConstVal(MI.getOperand(3).getReg(), &MRI);
-        MachineInstr *CBr = MRI.use_begin(Dst)->getParent();
-        assert(CBr->getOpcode() == SPIRV::G_BRCOND &&
-               CBr->getOperand(1).isMBB());
-        SwitchRegToMBB[CmpReg][Val] = CBr->getOperand(1).getMBB();
-        // The next MI is always BR to either the next case or the default.
-        MachineInstr *NextMI = CBr->getNextNode();
-        assert(NextMI->getOpcode() == SPIRV::G_BR &&
-               NextMI->getOperand(0).isMBB());
-        MachineBasicBlock *NextMBB = NextMI->getOperand(0).getMBB();
-        assert(NextMBB != nullptr);
-        // The default MBB is not started by ICMP with switch's cmp register.
-        if (NextMBB->front().getOpcode() != SPIRV::G_ICMP ||
-            (NextMBB->front().getOperand(2).isReg() &&
-             NextMBB->front().getOperand(2).getReg() != CmpReg))
-          DefaultMBBs[CmpReg] = NextMBB;
+        RelevantInsts.push_back(&MI);
       }
     }
   }
-  // Modify spv_switch's operands by collected values. For the example above,
-  // the result will be like this:
-  //   intrinsic(@llvm.spv.switch), %CmpReg, %bb.4, i32 0, %bb.2, i32 1, %bb.3
-  // Note that ICMP+CBr+Br sequences are not removed, but ModuleAnalysis marks
-  // them as skipped and AsmPrinter does not output them.
-  for (MachineBasicBlock &MBB : MF) {
-    for (MachineInstr &MI : MBB) {
-      if (!isSpvIntrinsic(MI, Intrinsic::spv_switch))
+
+  // Update each spv_switch with destination MBBs.
+  for (auto i = RelevantInsts.begin(); i != RelevantInsts.end(); i++) {
+    if (!isSpvIntrinsic(**i, Intrinsic::spv_switch))
+      continue;
+
+    // Currently considered spv_switch.
+    MachineInstr *Switch = *i;
+    // Set the first successor as default MBB to support empty switches.
+    MachineBasicBlock *DefaultMBB = *Switch->getParent()->succ_begin();
+    // Container for mapping values to MMBs.
+    SmallDenseMap<uint64_t, MachineBasicBlock *> ValuesToMBBs;
+
+    // Walk all G_ICMPs to collect ValuesToMBBs. Start at currently considered
+    // spv_switch (i) and break at any spv_switch with the same compare
+    // register (indicating we are back at the same scope).
+    Register CompareReg = Switch->getOperand(1).getReg();
+    for (auto j = i + 1; j != RelevantInsts.end(); j++) {
+      if (isSpvIntrinsic(**j, Intrinsic::spv_switch) &&
+          (*j)->getOperand(1).getReg() == CompareReg)
+        break;
+
+      if (!((*j)->getOpcode() == TargetOpcode::G_ICMP &&
+            (*j)->getOperand(2).getReg() == CompareReg))
         continue;
-      assert(MI.getOperand(1).isReg());
-      Register Reg = MI.getOperand(1).getReg();
-      unsigned NumOp = MI.getNumExplicitOperands();
-      SmallVector<const ConstantInt *, 3> Vals;
-      SmallVector<MachineBasicBlock *, 3> MBBs;
-      for (unsigned i = 2; i < NumOp; i++) {
-        Register CReg = MI.getOperand(i).getReg();
-        uint64_t Val = getIConstVal(CReg, &MRI);
-        MachineInstr *ConstInstr = getDefInstrMaybeConstant(CReg, &MRI);
-        if (!SwitchRegToMBB[Reg][Val])
-          continue;
-        Vals.push_back(ConstInstr->getOperand(1).getCImm());
-        MBBs.push_back(SwitchRegToMBB[Reg][Val]);
-      }
-      for (unsigned i = MI.getNumExplicitOperands() - 1; i > 1; i--)
-        MI.removeOperand(i);
-      MI.addOperand(MachineOperand::CreateMBB(DefaultMBBs[Reg]));
-      for (unsigned i = 0; i < Vals.size(); i++) {
-        MI.addOperand(MachineOperand::CreateCImm(Vals[i]));
-        MI.addOperand(MachineOperand::CreateMBB(MBBs[i]));
-      }
+
+      MachineInstr *ICMP = *j;
+      Register Dst = ICMP->getOperand(0).getReg();
+      MachineOperand &PredOp = ICMP->getOperand(1);
+      const auto CC = static_cast<CmpInst::Predicate>(PredOp.getPredicate());
+      assert((CC == CmpInst::ICMP_EQ || CC == CmpInst::ICMP_ULE) &&
+             MRI.hasOneUse(Dst) && MRI.hasOneDef(CompareReg));
+      uint64_t Value = getIConstVal(ICMP->getOperand(3).getReg(), &MRI);
+      MachineInstr *CBr = MRI.use_begin(Dst)->getParent();
+      assert(CBr->getOpcode() == SPIRV::G_BRCOND && CBr->getOperand(1).isMBB());
+      MachineBasicBlock *MBB = CBr->getOperand(1).getMBB();
+
+      // Map switch case Value to target MBB.
+      ValuesToMBBs[Value] = MBB;
+
+      // The next MI is always G_BR to either the next case or the default.
+      MachineInstr *NextMI = CBr->getNextNode();
+      assert(NextMI->getOpcode() == SPIRV::G_BR &&
+             NextMI->getOperand(0).isMBB());
+      MachineBasicBlock *NextMBB = NextMI->getOperand(0).getMBB();
+      // Default MBB does not begin with G_ICMP using spv_switch compare
+      // register.
+      if (NextMBB->front().getOpcode() != SPIRV::G_ICMP ||
+          (NextMBB->front().getOperand(2).isReg() &&
+           NextMBB->front().getOperand(2).getReg() != CompareReg))
+        DefaultMBB = NextMBB;
+    }
+
+    // Modify considered spv_switch operands using collected Values and
+    // MBBs.
+    SmallVector<const ConstantInt *, 3> Values;
+    SmallVector<MachineBasicBlock *, 3> MBBs;
+    for (unsigned k = 2; k < Switch->getNumExplicitOperands(); k++) {
+      Register CReg = Switch->getOperand(k).getReg();
+      uint64_t Val = getIConstVal(CReg, &MRI);
+      MachineInstr *ConstInstr = getDefInstrMaybeConstant(CReg, &MRI);
+      if (!ValuesToMBBs[Val])
+        continue;
+
+      Values.push_back(ConstInstr->getOperand(1).getCImm());
+      MBBs.push_back(ValuesToMBBs[Val]);
+    }
+
+    for (unsigned k = Switch->getNumExplicitOperands() - 1; k > 1; k--)
+      Switch->removeOperand(k);
+
+    Switch->addOperand(MachineOperand::CreateMBB(DefaultMBB));
+    for (unsigned k = 0; k < Values.size(); k++) {
+      Switch->addOperand(MachineOperand::CreateCImm(Values[k]));
+      Switch->addOperand(MachineOperand::CreateMBB(MBBs[k]));
     }
   }
 }

--- a/llvm/test/CodeGen/SPIRV/instructions/call-complex-function.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/call-complex-function.ll
@@ -1,28 +1,30 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
 
-; CHECK-DAG: OpName [[FUN:%.+]] "fun"
-; CHECK-DAG: OpName [[FOO:%.+]] "foo"
-; CHECK-DAG: OpName [[GOO:%.+]] "goo"
+; CHECK-DAG: OpName %[[#FUN:]] "fun"
+; CHECK-DAG: OpName %[[#FOO:]] "foo"
+; CHECK-DAG: OpName %[[#GOO:]] "goo"
 
 ; CHECK-NOT: DAG-FENCE
 
-; CHECK-DAG: [[I16:%.+]] = OpTypeInt 16
-; CHECK-DAG: [[I32:%.+]] = OpTypeInt 32
-; CHECK-DAG: [[I64:%.+]] = OpTypeInt 64
-; CHECK-DAG: [[FN3:%.+]] = OpTypeFunction [[I32]] [[I32]] [[I16]] [[I64]]
-; CHECK-DAG: [[PAIR:%.+]] = OpTypeStruct [[I32]] [[I16]]
-; CHECK-DAG: [[FN1:%.+]] = OpTypeFunction [[I32]] [[I32]]
-; CHECK-DAG: [[FN2:%.+]] = OpTypeFunction [[I32]] [[PAIR]] [[I64]]
+; CHECK-DAG: %[[#I16:]] = OpTypeInt 16
+; CHECK-DAG: %[[#I32:]] = OpTypeInt 32
+; CHECK-DAG: %[[#I64:]] = OpTypeInt 64
+; CHECK-DAG: %[[#FN3:]] = OpTypeFunction %[[#I32]] %[[#I32]] %[[#I16]] %[[#I64]]
+; CHECK-DAG: %[[#PAIR:]] = OpTypeStruct %[[#I32]] %[[#I16]]
+; CHECK-DAG: %[[#FN1:]] = OpTypeFunction %[[#I32]] %[[#I32]]
+; CHECK-DAG: %[[#FN2:]] = OpTypeFunction %[[#I32]] %[[#PAIR]] %[[#I64]]
 ;; According to the Specification, the OpUndef can be defined in Function.
 ;; But the Specification also recommends defining it here. So we enforce that.
-; CHECK-DAG: [[UNDEF:%.+]] = OpUndef [[PAIR]]
+; CHECK-DAG: %[[#UNDEF1:]] = OpUndef %[[#I32]]
+; CHECK-DAG: %[[#UNDEF2:]] = OpUndef %[[#I16]]
+; CHECK-DAG: %[[#COMPOSITE:]] = OpConstantComposite %[[#PAIR]] %[[#UNDEF1]] %[[#UNDEF2]]
 
 
 declare i32 @fun(i32 %value)
 
 ;; Check for @fun declaration
-; CHECK:      [[FUN]] = OpFunction [[I32]] None [[FN1]]
-; CHECK-NEXT: OpFunctionParameter [[I32]]
+; CHECK:      %[[#FUN]] = OpFunction %[[#I32]] None %[[#FN1]]
+; CHECK-NEXT: OpFunctionParameter %[[#I32]]
 ; CHECK-NEXT: OpFunctionEnd
 
 
@@ -32,22 +34,22 @@ define i32 @foo({i32, i16} %in, i64 %unused) {
   ret i32 %bar
 }
 
-; CHECK:      [[GOO]] = OpFunction [[I32]] None [[FN3]]
-; CHECK-NEXT: [[A:%.+]] = OpFunctionParameter [[I32]]
-; CHECK-NEXT: [[B:%.+]] = OpFunctionParameter [[I16]]
-; CHECK-NEXT: [[C:%.+]] = OpFunctionParameter [[I64]]
-; CHECK:      [[AGG1:%.+]] = OpCompositeInsert [[PAIR]] [[A]] [[UNDEF]] 0
-; CHECK:      [[AGG2:%.+]] = OpCompositeInsert [[PAIR]] [[B]] [[AGG1]] 1
-; CHECK:      [[RET:%.+]] = OpFunctionCall [[I32]] [[FOO]] [[AGG2]] [[C]]
-; CHECK:      OpReturnValue [[RET]]
+; CHECK:      %[[#GOO]] = OpFunction %[[#I32]] None %[[#FN3]]
+; CHECK-NEXT: %[[#A:]] = OpFunctionParameter %[[#I32]]
+; CHECK-NEXT: %[[#B:]] = OpFunctionParameter %[[#I16]]
+; CHECK-NEXT: %[[#C:]] = OpFunctionParameter %[[#I64]]
+; CHECK:      %[[#AGG1:]] = OpCompositeInsert %[[#PAIR]] %[[#A]] %[[#COMPOSITE]] 0
+; CHECK:      %[[#AGG2:]] = OpCompositeInsert %[[#PAIR]] %[[#B]] %[[#AGG1]] 1
+; CHECK:      %[[#RET:]] = OpFunctionCall %[[#I32]] %[[#FOO]] %[[#AGG2]] %[[#C]]
+; CHECK:      OpReturnValue %[[#RET]]
 ; CHECK:      OpFunctionEnd
 
-; CHECK:      [[FOO]] = OpFunction [[I32]] None [[FN2]]
-; CHECK-NEXT: [[IN:%.+]] = OpFunctionParameter [[PAIR]]
-; CHECK-NEXT: OpFunctionParameter [[I64]]
-; CHECK:      [[FIRST:%.+]] = OpCompositeExtract [[I32]] [[IN]] 0
-; CHECK:      [[BAR:%.+]] = OpFunctionCall [[I32]] [[FUN]] [[FIRST]]
-; CHECK:      OpReturnValue [[BAR]]
+; CHECK:      %[[#FOO]] = OpFunction %[[#I32]] None %[[#FN2]]
+; CHECK-NEXT: %[[#IN:]] = OpFunctionParameter %[[#PAIR]]
+; CHECK-NEXT: OpFunctionParameter %[[#I64]]
+; CHECK:      %[[#FIRST:]] = OpCompositeExtract %[[#I32]] %[[#IN]] 0
+; CHECK:      %[[#BAR:]] = OpFunctionCall %[[#I32]] %[[#FUN]] %[[#FIRST]]
+; CHECK:      OpReturnValue %[[#BAR]]
 ; CHECK:      OpFunctionEnd
 
 define i32 @goo(i32 %a, i16 %b, i64 %c) {

--- a/llvm/test/CodeGen/SPIRV/instructions/undef-composite-store.ll
+++ b/llvm/test/CodeGen/SPIRV/instructions/undef-composite-store.ll
@@ -1,0 +1,20 @@
+; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s
+
+; CHECK-DAG: %[[#I32:]] = OpTypeInt 32
+; CHECK-DAG: %[[#I16:]] = OpTypeInt 16
+; CHECK-DAG: %[[#STRUCT:]] = OpTypeStruct %[[#I32]] %[[#I16]]
+; CHECK-DAG: %[[#UNDEF_I32:]] = OpUndef %[[#I32]]
+; CHECK-DAG: %[[#UNDEF_I16:]] = OpUndef %[[#I16]]
+; CHECK-DAG: %[[#COMPOSITE:]] = OpConstantComposite %[[#STRUCT]] %[[#UNDEF_I32]] %[[#UNDEF_I16]]
+
+; CHECK: %[[#]] = OpFunction %[[#]] None %[[#]]
+; CHECK-NEXT: %[[#PTR:]] = OpFunctionParameter %[[#]]
+; CHECK-NEXT: %[[#]] = OpLabel
+; CHECK-NEXT: OpStore %[[#PTR]] %[[#COMPOSITE]] Aligned 4
+; CHECK-NEXT: OpReturn
+; CHECK-NEXT: OpFunctionEnd
+
+define void @foo(ptr %ptr) {
+  store { i32, i16 } undef, ptr %ptr
+  ret void
+}

--- a/llvm/test/CodeGen/SPIRV/transcoding/Two_OpSwitch_same_register.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/Two_OpSwitch_same_register.ll
@@ -1,0 +1,42 @@
+; RUN: llc -O0 -mtriple=spirv64-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
+
+define spir_kernel void @test_two_switch_same_register(i32 %value) {
+; CHECK-SPIRV:      OpSwitch %[[#REGISTER:]] %[[#DEFAULT1:]] 1 %[[#CASE1:]] 0 %[[#CASE2:]]
+  switch i32 %value, label %default1 [
+    i32 1, label %case1
+    i32 0, label %case2
+  ]
+
+; CHECK-SPIRV:      %[[#CASE1]] = OpLabel
+case1:
+; CHECK-SPIRV-NEXT: OpBranch %[[#DEFAULT1]]
+  br label %default1
+
+; CHECK-SPIRV:      %[[#CASE2]] = OpLabel
+case2:
+; CHECK-SPIRV-NEXT: OpBranch %[[#DEFAULT1]]
+  br label %default1
+
+; CHECK-SPIRV:      %[[#DEFAULT1]] = OpLabel
+default1:
+; CHECK-SPIRV-NEXT:      OpSwitch %[[#REGISTER]] %[[#DEFAULT2:]] 0 %[[#CASE3:]] 1 %[[#CASE4:]]
+  switch i32 %value, label %default2 [
+    i32 0, label %case3
+    i32 1, label %case4
+  ]
+
+; CHECK-SPIRV:      %[[#CASE3]] = OpLabel
+case3:
+; CHECK-SPIRV-NEXT: OpBranch %[[#DEFAULT2]]
+  br label %default2
+
+; CHECK-SPIRV:      %[[#CASE4]] = OpLabel
+case4:
+; CHECK-SPIRV-NEXT: OpBranch %[[#DEFAULT2]]
+  br label %default2
+
+; CHECK-SPIRV:      %[[#DEFAULT2]] = OpLabel
+default2:
+; CHECK-SPIRV-NEXT: OpReturn
+  ret void
+}


### PR DESCRIPTION
The [_spirv_new / op_undef_struct_int_char_simple_ test](https://spirv-testing.khronos.org/cts_result/44963/) contains the following _store_ instruction:
```
%structtype = type { i32, i8 }
...
store %structtype undef, %structtype addrspace(1)* %5, align 1
```

The _store_ instruction is substituted with a call to _spv_store_ intrinsic before the _IRTranslator_. Unfortunately, the current implementation of _IRTranslator_ does not translate intrinsic calls with aggregate operands.

Other (non-undef) aggregate operands (such as _ConstantAggregate_, _ConstantDataArray_...) are substituted with _spv_const_composite_ intrinsic calls before _IRTranslator_.

This change proposes to treat _undef_ in a similar fashion. All _undef_ operands of aggregate type are substituted with _spv_const_composite_:
```
...
%6 = call i32 (...) @llvm.spv.const.composite(i32 undef, i8 undef)
store i32 %6, %structtype addrspace(1)* %5, align 1
```

After this change three additional CTS tests pass: _spirv_new / op_undef_struct_int_float_simple_, _spirv_new / op_undef_struct_int_char_simple_, _spirv_new / op_undef_struct_struct_simple_.

WIP:
This approach produces slightly different (but equivalent) code than SPIR-V Translator. The translator creates one OpUndef instruction with array type as operand:
```
...
%_struct_10 = OpTypeStruct %uint %uchar
%15 = OpUndef %_struct_10
...
OpStore %20 %15
```

Whereas the backend after this change produces:
```
%4 = OpTypeStruct %2 %3
...
%12 = OpUndef %2
%13 = OpUndef %3
%14 = OpConstantComposite %4 %12 %13
...
OpStore %22 %14 Aligned 1

```
This is consistent with the code produced by both the backend (before the change) and translator for aggregates of constant values (non-undef):
```
%structtype = OpTypeStruct %uint %uchar
...
%15 = OpConstantComposite %structtype %uint_2 %uchar_1
...
OpStore %12 %15 Aligned 4
```

Two LIT tests _nested-composites.ll_ and _call-complex-function.ll_ will require adjusting CHECKs. To avoid this I am exploring a different (less elegant) solution which will generate a new intrinsic in such cases. However, I think it would be best to keep consistency with other aggregate-type constants and not introduce additional complexity.