### PR TITLE
[SPIR-V] Add Machine Value Type for SPIR-V builtins

### DIFF
--- a/llvm/include/llvm/CodeGen/ValueTypes.td
+++ b/llvm/include/llvm/CodeGen/ValueTypes.td
@@ -238,6 +238,7 @@ def x86amx    : ValueType<8192, 194>;  // X86 AMX value
 def i64x8     : ValueType<512,  195>;  // 8 Consecutive GPRs (AArch64)
 def aarch64svcount
               : ValueType<16,   196>;  // AArch64 predicate-as-counter
+def spirvbuiltin : ValueType<0,  197>; // SPIR-V's builtin type
 
 def token      : ValueType<0, 248>;  // TokenTy
 def MetadataVT : ValueType<0, 249>;  // Metadata

--- a/llvm/include/llvm/Support/MachineValueType.h
+++ b/llvm/include/llvm/Support/MachineValueType.h
@@ -292,9 +292,10 @@ namespace llvm {
       x86amx         = 194,    // This is an X86 AMX value
       i64x8          = 195,    // 8 Consecutive GPRs (AArch64)
       aarch64svcount = 196,    // AArch64 predicate-as-counter
+      spirvbuiltin   = 197,    // SPIR-V's builtin type
 
       FIRST_VALUETYPE =  1,    // This is always the beginning of the list.
-      LAST_VALUETYPE = aarch64svcount, // This always remains at the end of the list.
+      LAST_VALUETYPE = spirvbuiltin, // This always remains at the end of the list.
       VALUETYPE_SIZE = LAST_VALUETYPE + 1,
 
       // This is the current maximum for LAST_VALUETYPE.
@@ -1143,7 +1144,9 @@ namespace llvm {
       case v2048i32:
       case v2048f32:  return TypeSize::Fixed(65536);
       case funcref:
-      case externref: return TypeSize::Fixed(0); // opaque type
+      case externref:
+      case spirvbuiltin:
+        return TypeSize::Fixed(0); // opaque type
       }
     }
 

--- a/llvm/lib/CodeGen/ValueTypes.cpp
+++ b/llvm/lib/CodeGen/ValueTypes.cpp
@@ -176,6 +176,8 @@ std::string EVT::getEVTString() const {
   case MVT::externref: return "externref";
   case MVT::aarch64svcount:
     return "aarch64svcount";
+  case MVT::spirvbuiltin:
+    return "spirvbuiltin";
   }
 }
 
@@ -583,12 +585,16 @@ MVT MVT::getVT(Type *Ty, bool HandleUnknown){
   case Type::DoubleTyID:    return MVT(MVT::f64);
   case Type::X86_FP80TyID:  return MVT(MVT::f80);
   case Type::X86_MMXTyID:   return MVT(MVT::x86mmx);
-  case Type::TargetExtTyID:
-    if (cast<TargetExtType>(Ty)->getName() == "aarch64.svcount")
+  case Type::TargetExtTyID: {
+    TargetExtType *TargetExtTy = cast<TargetExtType>(Ty);
+    if (TargetExtTy->getName() == "aarch64.svcount")
       return MVT(MVT::aarch64svcount);
+    else if (TargetExtTy->getName().starts_with("spirv."))
+      return MVT(MVT::spirvbuiltin);
     if (HandleUnknown)
       return MVT(MVT::Other);
     llvm_unreachable("Unknown target ext type!");
+  }
   case Type::X86_AMXTyID:   return MVT(MVT::x86amx);
   case Type::FP128TyID:     return MVT(MVT::f128);
   case Type::PPC_FP128TyID: return MVT(MVT::ppcf128);


### PR DESCRIPTION
Fix required after llvm_unreachable() was added in this patch [D136862 [AArch64][SME2] Add CodeGen support for target("aarch64.svcount")](https://reviews.llvm.org/D136862). This fixes the spirv-types.ll LIT test.